### PR TITLE
Implement Vite proxy to bypass CORS restrictions in dev

### DIFF
--- a/apps/client/.env.sample
+++ b/apps/client/.env.sample
@@ -1,1 +1,1 @@
-VITE_PUBLIC_API_URL=http://localhost:8080/trpc
+VITE_PUBLIC_API_URL=http://localhost:8080

--- a/apps/client/.env.sample
+++ b/apps/client/.env.sample
@@ -1,1 +1,2 @@
-VITE_PUBLIC_API_URL=http://localhost:8080
+VITE_PUBLIC_API_URL=<production_url>
+VITE_PRIVATE_API_URL=http://localhost:8080

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -3,28 +3,37 @@ import tailwindcss from "@tailwindcss/vite";
 import router from "@tanstack/router-plugin/vite";
 import basicSSL from "@vitejs/plugin-basic-ssl";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import tsConfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
-	server: {
-		port: 4483,
-		host: "0.0.0.0",
-		https: {},
-	},
-	plugins: [
-		tsConfigPaths(),
-		router({
-			target: "react",
-			autoCodeSplitting: true,
-		}),
-		react(),
-		tailwindcss(),
-		basicSSL(),
-	],
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, process.cwd(), "");
+	return {
+		server: {
+			port: 4483,
+			host: "0.0.0.0",
+			https: {},
+			proxy: {
+				"/trpc": {
+					target: env.VITE_PUBLIC_API_URL,
+					changeOrigin: true,
+				},
+			},
 		},
-	},
+		plugins: [
+			tsConfigPaths(),
+			router({
+				target: "react",
+				autoCodeSplitting: true,
+			}),
+			react(),
+			tailwindcss(),
+			basicSSL(),
+		],
+		resolve: {
+			alias: {
+				"@": path.resolve(__dirname, "./src"),
+			},
+		},
+	};
 });

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => {
 			https: {},
 			proxy: {
 				"/trpc": {
-					target: env.VITE_PUBLIC_API_URL,
+					target: env.VITE_PRIVATE_API_URL,
 					changeOrigin: true,
 				},
 			},

--- a/packages/trpc/client/trpc.ts
+++ b/packages/trpc/client/trpc.ts
@@ -13,7 +13,7 @@ const getBaseUrl = () => {
 
 	// Use public API URL if specified in production, else fallback to relative
 	return import.meta.env.VITE_PUBLIC_API_URL ?? "";
-}
+};
 
 export const trpc = createTRPCClient<AppRouter>({
 	links: [

--- a/packages/trpc/client/trpc.ts
+++ b/packages/trpc/client/trpc.ts
@@ -4,10 +4,21 @@ import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
 import type { AppRouter } from "../server/router";
 
+// Determine base URL for tRPC requests
+const getBaseUrl = () => {
+	// Always use relative "/trpc" in dev, no extra base URL
+	if (import.meta.env.DEV) {
+		return "";
+	}
+
+	// Use public API URL if specified in production, else fallback to relative
+	return import.meta.env.VITE_PUBLIC_API_URL ?? "";
+}
+
 export const trpc = createTRPCClient<AppRouter>({
 	links: [
 		httpBatchLink({
-			url: "/trpc",
+			url: `${getBaseUrl()}/trpc`,
 			transformer: superjson,
 			headers() {
 				if (typeof window === "undefined") return {};

--- a/packages/trpc/client/trpc.ts
+++ b/packages/trpc/client/trpc.ts
@@ -7,8 +7,7 @@ import type { AppRouter } from "../server/router";
 export const trpc = createTRPCClient<AppRouter>({
 	links: [
 		httpBatchLink({
-			// Don't use the env package here, as this is in the client bundle
-			url: import.meta.env.VITE_PUBLIC_API_URL ?? "/trpc",
+			url: "/trpc",
 			transformer: superjson,
 			headers() {
 				if (typeof window === "undefined") return {};


### PR DESCRIPTION
See title. 

**`.env` updates made, do not forget to update yours!**

`vite.config.ts`
- Proxy implemented, target is based on `VITE_PUBLIC_API_URL` environment variable
- `loadEnv` added to dependencies

`trpc.ts`
- Always uses relative "/trpc" to avoid bypassing the Vite proxy

`.env.sample`
- `VITE_PUBLIC_API_URL` updated to not contain "/trpc", it is appended in the proxy from the relative route in `trpc.ts`