### PR TITLE
Switch to docker-managed volume for postgres database

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -19,4 +19,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: hive
     volumes:
-      - ./data/postgres:/var/lib/postgresql/data
+      - hive-scheduler-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  hive-scheduler-postgres-data:
+    name: hive-scheduler-postgres-data


### PR DESCRIPTION
Previously, the database volume was mounted on the host machine. This poses an issue on Windows, where Unix permission commands do not work (`chown`, `chmod`) and docker is unable to obtain necessary access. 

This PR moves the volume from the host computer to a docker-managed volume. To ensure that the same database is always used (VS Code Dev Containers seems to be inconsistent), the name `hive-scheduler-postgres-data` is explicitly set.

This moves the database outside of the codebase. It is viewable in the volumes tab of docker desktop, or through the docker cli. Steps for pushing the schema are unchanged.