### PR TITLE
Add user permissions checks

### DIFF
--- a/apps/client/src/auth/AuthProvider.tsx
+++ b/apps/client/src/auth/AuthProvider.tsx
@@ -17,6 +17,7 @@ export type AuthUser = {
 	name: string | null;
 	email: string | null;
 	permissions: string[];
+	isSystemUser: boolean;
 	// allow other fields if needed
 	[key: string]: unknown;
 };

--- a/apps/client/src/components/app-sidebar.tsx
+++ b/apps/client/src/components/app-sidebar.tsx
@@ -22,28 +22,31 @@ import {
 	SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { checkPermissions } from "@/lib/permissions";
+import { permissions as adminPagePermissions } from "@/routes/app/admin";
+import { permissions as appIndexPagePermissions } from "@/routes/app/index";
+import { permissions as schedulingPagePermissions } from "@/routes/app/scheduling";
 
 // Removed ModeToggle button in favor of options inside the user dropdown
 
 // Menu items.
-const items = [
+export const items = [
 	{
 		title: "Home",
 		url: "/app",
 		icon: Home,
-		permissions: [],
+		permissions: appIndexPagePermissions,
 	},
 	{
 		title: "Scheduling",
 		url: "/app/scheduling",
 		icon: Calendar,
-		permissions: [],
+		permissions: schedulingPagePermissions,
 	},
 	{
 		title: "Admin",
 		url: "/app/admin",
 		icon: ShieldUser,
-		permissions: ["admin"], // Example, will be changed based on real permissions
+		permissions: adminPagePermissions, // Example, will be changed based on real permissions
 	},
 ];
 

--- a/apps/client/src/components/app-sidebar.tsx
+++ b/apps/client/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Calendar, ChevronUp, Home, User2 } from "lucide-react";
+import { Calendar, ChevronUp, Home, ShieldUser, User2 } from "lucide-react";
 import { useAuth, useCurrentUser } from "@/auth/AuthProvider";
 import { useTheme } from "@/components/theme-provider"; // Import useTheme from theme-provider
 import {
@@ -21,6 +21,7 @@ import {
 	SidebarMenuButton,
 	SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { checkPermissions } from "@/lib/permissions";
 
 // Removed ModeToggle button in favor of options inside the user dropdown
 
@@ -30,11 +31,19 @@ const items = [
 		title: "Home",
 		url: "/app",
 		icon: Home,
+		permissions: [],
 	},
 	{
 		title: "Scheduling",
 		url: "/app/scheduling",
 		icon: Calendar,
+		permissions: [],
+	},
+	{
+		title: "Admin",
+		url: "/app/admin",
+		icon: ShieldUser,
+		permissions: ["admin"], // Example, will be changed based on real permissions
 	},
 ];
 
@@ -49,16 +58,18 @@ export function AppSidebar() {
 					<SidebarGroupLabel>Hive Shift Scheduler</SidebarGroupLabel>
 					<SidebarGroupContent>
 						<SidebarMenu>
-							{items.map((item) => (
-								<SidebarMenuItem key={item.title}>
-									<SidebarMenuButton asChild>
-										<Link to={item.url}>
-											<item.icon />
-											<span>{item.title}</span>
-										</Link>
-									</SidebarMenuButton>
-								</SidebarMenuItem>
-							))}
+							{items
+								.filter((item) => checkPermissions(user, item.permissions))
+								.map((item) => (
+									<SidebarMenuItem key={item.title}>
+										<SidebarMenuButton asChild>
+											<Link to={item.url}>
+												<item.icon />
+												<span>{item.title}</span>
+											</Link>
+										</SidebarMenuButton>
+									</SidebarMenuItem>
+								))}
 						</SidebarMenu>
 					</SidebarGroupContent>
 				</SidebarGroup>

--- a/apps/client/src/lib/permissions.ts
+++ b/apps/client/src/lib/permissions.ts
@@ -1,9 +1,29 @@
+import { useRouter } from "@tanstack/react-router";
+import type { JSX } from "react";
 import type { AuthUser } from "@/auth";
+import { useCurrentUser } from "@/auth/AuthProvider";
 
+// Check if a given user possesses all given permissions
 export function checkPermissions(
 	user: AuthUser | null,
 	requiredPermissions: string[],
 ): boolean {
 	if (user?.isSystemUser) return true;
 	return requiredPermissions.every((perm) => user?.permissions.includes(perm));
+}
+
+// Navigate to /app if the user does not have the required permissions to view the element
+export function ExitWithoutPermissions(
+	requiredPermissions: string[],
+	element: JSX.Element,
+) {
+	const user = useCurrentUser();
+	const router = useRouter();
+
+	if (!checkPermissions(user, requiredPermissions)) {
+		void router.navigate({ to: "/app" });
+		return null;
+	}
+
+	return element;
 }

--- a/apps/client/src/lib/permissions.ts
+++ b/apps/client/src/lib/permissions.ts
@@ -1,0 +1,9 @@
+import type { AuthUser } from "@/auth";
+
+export function checkPermissions(
+	user: AuthUser | null,
+	requiredPermissions: string[],
+): boolean {
+	if (user?.isSystemUser) return true;
+	return requiredPermissions.every((perm) => user?.permissions.includes(perm));
+}

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AppRouteImport } from './routes/app'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AppIndexRouteImport } from './routes/app/index'
 import { Route as AppSchedulingRouteImport } from './routes/app/scheduling'
+import { Route as AppAdminRouteImport } from './routes/app/admin'
 
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
@@ -40,17 +41,24 @@ const AppSchedulingRoute = AppSchedulingRouteImport.update({
   path: '/scheduling',
   getParentRoute: () => AppRoute,
 } as any)
+const AppAdminRoute = AppAdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => AppRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/app': typeof AppRouteWithChildren
   '/login': typeof LoginRoute
+  '/app/admin': typeof AppAdminRoute
   '/app/scheduling': typeof AppSchedulingRoute
   '/app/': typeof AppIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/app/admin': typeof AppAdminRoute
   '/app/scheduling': typeof AppSchedulingRoute
   '/app': typeof AppIndexRoute
 }
@@ -59,15 +67,29 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/app': typeof AppRouteWithChildren
   '/login': typeof LoginRoute
+  '/app/admin': typeof AppAdminRoute
   '/app/scheduling': typeof AppSchedulingRoute
   '/app/': typeof AppIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/app' | '/login' | '/app/scheduling' | '/app/'
+  fullPaths:
+    | '/'
+    | '/app'
+    | '/login'
+    | '/app/admin'
+    | '/app/scheduling'
+    | '/app/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/app/scheduling' | '/app'
-  id: '__root__' | '/' | '/app' | '/login' | '/app/scheduling' | '/app/'
+  to: '/' | '/login' | '/app/admin' | '/app/scheduling' | '/app'
+  id:
+    | '__root__'
+    | '/'
+    | '/app'
+    | '/login'
+    | '/app/admin'
+    | '/app/scheduling'
+    | '/app/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -113,15 +135,24 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSchedulingRouteImport
       parentRoute: typeof AppRoute
     }
+    '/app/admin': {
+      id: '/app/admin'
+      path: '/admin'
+      fullPath: '/app/admin'
+      preLoaderRoute: typeof AppAdminRouteImport
+      parentRoute: typeof AppRoute
+    }
   }
 }
 
 interface AppRouteChildren {
+  AppAdminRoute: typeof AppAdminRoute
   AppSchedulingRoute: typeof AppSchedulingRoute
   AppIndexRoute: typeof AppIndexRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppAdminRoute: AppAdminRoute,
   AppSchedulingRoute: AppSchedulingRoute,
   AppIndexRoute: AppIndexRoute,
 }

--- a/apps/client/src/routes/app/admin.tsx
+++ b/apps/client/src/routes/app/admin.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { ExitWithoutPermissions } from "@/lib/permissions";
 
 export const Route = createFileRoute("/app/admin")({

--- a/apps/client/src/routes/app/admin.tsx
+++ b/apps/client/src/routes/app/admin.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/app/admin")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	return <div>live laugh hive</div>;
+}

--- a/apps/client/src/routes/app/admin.tsx
+++ b/apps/client/src/routes/app/admin.tsx
@@ -1,9 +1,16 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { ExitWithoutPermissions } from "@/lib/permissions";
 
 export const Route = createFileRoute("/app/admin")({
-	component: RouteComponent,
+	component: () => ExitWithoutPermissions(permissions, <Admin />),
 });
 
-function RouteComponent() {
-	return <div>live laugh hive</div>;
+export const permissions = ["admin"];
+
+function Admin() {
+	return (
+		<div className="flex flex-col p-4">
+			<p>live laugh hive</p>
+		</div>
+	);
 }

--- a/apps/client/src/routes/app/index.tsx
+++ b/apps/client/src/routes/app/index.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { ExitWithoutPermissions } from "@/lib/permissions";
 
 export const Route = createFileRoute("/app/")({
-	component: AppIndexLayout,
+	component: () => ExitWithoutPermissions(permissions, <AppIndexLayout />),
 });
+
+export const permissions = [];
 
 function AppIndexLayout() {
 	return (

--- a/apps/client/src/routes/app/scheduling.tsx
+++ b/apps/client/src/routes/app/scheduling.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { ExitWithoutPermissions } from "@/lib/permissions";
 
 export const Route = createFileRoute("/app/scheduling")({
-	component: Scheduling,
+	component: () => ExitWithoutPermissions(permissions, <Scheduling />),
 });
+
+export const permissions = [];
 
 function Scheduling() {
 	return (


### PR DESCRIPTION
This PR implements a permissions system that restricts the pages a user can visit or see in the sidebar.

`permissions.ts`
- `checkPermissions`: checks a user's permissions against a provided list of permissions, and returns a boolean, with system users bypassing checks
- `ExitWithoutPermissions`: wrapper function for page rendering functions that navigates the user back to `/app` before loading the restricted page if they are missing permissions

`AuthProvider.tsx`
- Add `isSystemUser` boolean to `AuthUser` type

`app-sidebar.tsx`
- Add `permissions` `string[]` field to page dictionaries in `items` array
- Import permissions from each page's `.tsx` file to populate above

`admin.tsx`, `index.tsx`, `scheduling.tsx`
- Add `permissions` export with required permissions for page access
- Implement `ExitWithoutPermissions` wrapper function to restrict page access

These changes have been tested with and without the system user bypass, as well as with sufficient/insufficient permissions granted through roles assigned to the user.