### PR TITLE
Improve permissions editing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 			"label": "Install Dependencies",
 			"type": "shell",
 			"command": "pnpm install",
-            "problemMatcher": []
+			"problemMatcher": []
 		},
 		{
 			"label": "Check",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -8,6 +8,7 @@
 	},
 	"dependencies": {
 		"@ecehive/trpc": "workspace:*",
+		"@radix-ui/react-accordion": "^1.2.12",
 		"@radix-ui/react-checkbox": "^1.3.3",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/apps/client/src/components/roles/columns.tsx
+++ b/apps/client/src/components/roles/columns.tsx
@@ -2,7 +2,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { AuthUser } from "@/auth";
 import { checkPermissions } from "@/lib/permissions";
 import { DeleteDialog } from "./delete-dialog";
-import { PermissionsDialog } from "./permissions-dialog";
+import { EditPermissionsSheet } from "./edit-permissions-sheet";
 import { RenameDialog } from "./rename-dialog";
 
 type Role = {
@@ -39,7 +39,9 @@ export function generateColumns(user: AuthUser | null): ColumnDef<Role>[] {
 			header: "Permissions",
 			cell: ({ row }) => {
 				return (
-					(canEditPermissions && <PermissionsDialog role={row.original} />) || (
+					(canEditPermissions && (
+						<EditPermissionsSheet role={row.original} />
+					)) || (
 						<span style={{ fontStyle: "italic", color: "#888" }}>
 							No actions available
 						</span>

--- a/apps/client/src/components/roles/edit-permissions-sheet.tsx
+++ b/apps/client/src/components/roles/edit-permissions-sheet.tsx
@@ -3,19 +3,25 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { JSX } from "react/jsx-runtime";
 import { useAuth } from "@/auth/AuthProvider";
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-	Dialog,
-	DialogClose,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import {
+	Sheet,
+	SheetClose,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
 import {
 	checkPermissions,
 	formatPermissionName,
@@ -23,7 +29,7 @@ import {
 	getAllPermissions,
 } from "@/lib/permissions";
 
-type PermissionsDialogProps = {
+type EditPermissionsSheetProps = {
 	role: {
 		id: number;
 		name: string;
@@ -31,9 +37,9 @@ type PermissionsDialogProps = {
 	};
 };
 
-export function PermissionsDialog({
+export function EditPermissionsSheet({
 	role,
-}: PermissionsDialogProps): JSX.Element {
+}: EditPermissionsSheetProps): JSX.Element {
 	const queryClient = useQueryClient();
 
 	const currentUser = useAuth().user;
@@ -148,13 +154,13 @@ export function PermissionsDialog({
 	);
 
 	return (
-		<Dialog
+		<Sheet
 			onOpenChange={(open) => {
 				if (!open) queryClient.invalidateQueries({ queryKey: ["roles"] });
 			}}
 		>
 			<form>
-				<DialogTrigger asChild>
+				<SheetTrigger asChild>
 					<Button
 						variant="outline"
 						size="sm"
@@ -163,72 +169,98 @@ export function PermissionsDialog({
 						Edit {role.permissions.length} permission
 						{role.permissions.length !== 1 ? "s" : ""}
 					</Button>
-				</DialogTrigger>
-				<DialogContent className="sm:max-w-[425px] overflow-y-auto max-h-full">
-					<DialogHeader>
-						<DialogTitle>Permissions for {role.name}</DialogTitle>
-						<DialogDescription>Changes saved automatically.</DialogDescription>
-					</DialogHeader>
-					<div className="flex flex-wrap gap-1">
+				</SheetTrigger>
+				<SheetContent
+					side="right"
+					className="w-full sm:max-w-[540px] overflow-y-auto max-h-full"
+				>
+					<SheetHeader>
+						<SheetTitle>Permissions for {role.name}</SheetTitle>
+						<SheetDescription>Changes saved automatically.</SheetDescription>
+					</SheetHeader>
+					<Accordion type="multiple" className="space-y-2 px-4 sm:px-6">
 						{Array.from(rolePermissions.entries()).map(([type, perms]) => (
-							<div key={type} className="w-full">
-								<div className="flex items-center justify-between mt-4 mb-2">
-									<h3 className="font-medium">{formatPermissionType(type)}</h3>
-									<Button
-										variant="ghost"
-										size="sm"
-										onClick={async () => {
-											if (!canEditRolePermissions) return;
-											await toggleAllInSection(perms);
-										}}
-										disabled={
-											updateRolePermissionMutation.isPending ||
-											!canEditRolePermissions
-										}
+							<AccordionItem key={type} value={type}>
+								<AccordionTrigger>
+									<div
+										style={{ paddingBottom: "1.25%" }}
+										className="flex items-center gap-3 flex-1"
 									>
-										{areAllSelected(perms) ? "Deselect all" : "Select all"}
-									</Button>
-								</div>
-								<div className="grid grid-cols-2 gap-2">
-									{perms.map((perm) => (
-										<Label
-											key={perm.id}
-											className="flex items-center space-x-2"
-										>
-											<Checkbox
-												onCheckedChange={(checked) => {
+										<div className="flex gap-3 flex-1">
+											<h3 className="font-medium leading-none">
+												{formatPermissionType(type)}
+											</h3>
+											<span className="text-sm text-muted-foreground leading-none">
+												{
+													perms.filter((p) => assignedById[p.id] ?? p.assigned)
+														.length
+												}
+												/{perms.length}
+											</span>
+										</div>
+										<div className="flex items-center">
+											<Button
+												variant="ghost"
+												size="sm"
+												className="py-0 leading-none"
+												onClick={async (e) => {
+													// Prevent trigger toggle when clicking the select all button
+													e.stopPropagation();
 													if (!canEditRolePermissions) return;
-													// Optimistic local update
-													setAssignedById((prev) => ({
-														...prev,
-														[perm.id]: checked === true,
-													}));
-													updateRolePermissionMutation.mutate({
-														roleId: role.id,
-														permissionId: perm.id,
-														assigned: checked === true,
-													});
+													await toggleAllInSection(perms);
 												}}
 												disabled={
 													updateRolePermissionMutation.isPending ||
 													!canEditRolePermissions
 												}
-												checked={assignedById[perm.id] ?? perm.assigned}
-											/>
-											<span>{formatPermissionName(perm.name)}</span>
-										</Label>
-									))}
-								</div>
-							</div>
+											>
+												{areAllSelected(perms) ? "Deselect all" : "Select all"}
+											</Button>
+										</div>
+									</div>
+								</AccordionTrigger>
+								<AccordionContent>
+									<div className="grid grid-cols-2 gap-2">
+										{perms.map((perm) => (
+											<Label
+												key={perm.id}
+												className="flex items-center space-x-2"
+											>
+												<Checkbox
+													onCheckedChange={(checked) => {
+														if (!canEditRolePermissions) return;
+														// Optimistic local update
+														setAssignedById((prev) => ({
+															...prev,
+															[perm.id]: checked === true,
+														}));
+														updateRolePermissionMutation.mutate({
+															roleId: role.id,
+															permissionId: perm.id,
+															assigned: checked === true,
+														});
+													}}
+													disabled={
+														updateRolePermissionMutation.isPending ||
+														!canEditRolePermissions
+													}
+													checked={assignedById[perm.id] ?? perm.assigned}
+												/>
+												<span>{formatPermissionName(perm.name)}</span>
+											</Label>
+										))}
+									</div>
+								</AccordionContent>
+							</AccordionItem>
 						))}
-					</div>
-					<DialogFooter>
-						<DialogClose asChild>
+					</Accordion>
+					<SheetFooter>
+						<SheetClose asChild>
 							<Button variant="outline">Close</Button>
-						</DialogClose>
-					</DialogFooter>
-				</DialogContent>
+						</SheetClose>
+					</SheetFooter>
+				</SheetContent>
 			</form>
-		</Dialog>
+		</Sheet>
 	);
 }

--- a/apps/client/src/components/roles/edit-permissions-sheet.tsx
+++ b/apps/client/src/components/roles/edit-permissions-sheet.tsx
@@ -181,11 +181,8 @@ export function EditPermissionsSheet({
 					<Accordion type="multiple" className="space-y-2 px-4 sm:px-6">
 						{Array.from(rolePermissions.entries()).map(([type, perms]) => (
 							<AccordionItem key={type} value={type}>
-								<AccordionTrigger>
-									<div
-										style={{ paddingBottom: "1.25%" }}
-										className="flex items-center gap-3 flex-1"
-									>
+								<AccordionTrigger className="items-center">
+									<div className="flex items-center gap-3 flex-1">
 										<div className="flex gap-3 flex-1">
 											<h3 className="font-medium leading-none">
 												{formatPermissionType(type)}
@@ -202,7 +199,7 @@ export function EditPermissionsSheet({
 											<Button
 												variant="ghost"
 												size="sm"
-												className="py-0 leading-none"
+												className="py-1 leading-none"
 												onClick={async (e) => {
 													// Prevent trigger toggle when clicking the select all button
 													e.stopPropagation();

--- a/apps/client/src/components/ui/accordion.tsx
+++ b/apps/client/src/components/ui/accordion.tsx
@@ -1,0 +1,64 @@
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDownIcon } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Accordion({
+	...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+	return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+	className,
+	...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+	return (
+		<AccordionPrimitive.Item
+			data-slot="accordion-item"
+			className={cn("border-b last:border-b-0", className)}
+			{...props}
+		/>
+	);
+}
+
+function AccordionTrigger({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+	return (
+		<AccordionPrimitive.Header className="flex">
+			<AccordionPrimitive.Trigger
+				data-slot="accordion-trigger"
+				className={cn(
+					"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				<ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+	);
+}
+
+function AccordionContent({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+	return (
+		<AccordionPrimitive.Content
+			data-slot="accordion-content"
+			className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+			{...props}
+		>
+			<div className={cn("pt-0 pb-4", className)}>{children}</div>
+		</AccordionPrimitive.Content>
+	);
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@ecehive/trpc':
         specifier: workspace:*
         version: link:../../packages/trpc
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -901,6 +904,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -916,6 +932,19 @@ packages:
 
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3464,6 +3493,23 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -3483,6 +3529,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.13)(react@19.1.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:


### PR DESCRIPTION
This pull request refactors the role permissions editing UI to use a sheet with an accordion layout, improving usability and organization. It introduces a new shadcn accordion component and replaces the previous dialog-based approach. The changes also update dependencies and lockfiles to support the new UI components.

**UI Refactor and Component Updates:**

* Replaced the old `PermissionsDialog` with a new `EditPermissionsSheet` component, which uses a sheet (slide-over panel) and organizes permissions by type in an accordion layout for better clarity and navigation. (`apps/client/src/components/roles/edit-permissions-sheet.tsx`, `apps/client/src/components/roles/columns.tsx`) [[1]](diffhunk://#diff-fbfc274acc401088f652e567bd506b9c7e89cf08e0c48abc8200daa653b816bcL5-R5) [[2]](diffhunk://#diff-fbfc274acc401088f652e567bd506b9c7e89cf08e0c48abc8200daa653b816bcL42-R44) [[3]](diffhunk://#diff-37729b7087aaab8042108eba4da48a1e33132f9ede8a24381010c7102eb27544R6-R42) [[4]](diffhunk://#diff-37729b7087aaab8042108eba4da48a1e33132f9ede8a24381010c7102eb27544L151-R163) [[5]](diffhunk://#diff-37729b7087aaab8042108eba4da48a1e33132f9ede8a24381010c7102eb27544L166-R208) [[6]](diffhunk://#diff-37729b7087aaab8042108eba4da48a1e33132f9ede8a24381010c7102eb27544R220-R222) [[7]](diffhunk://#diff-37729b7087aaab8042108eba4da48a1e33132f9ede8a24381010c7102eb27544L222-R264)
* Added a new shadcn UI component `accordion.tsx` that wraps Radix UI's accordion primitives, providing a consistent accordion interface for the app. (`apps/client/src/components/ui/accordion.tsx`)

**Dependency and Lockfile Updates:**

* Added `@radix-ui/react-accordion` to project dependencies and updated `pnpm-lock.yaml` to include the new package and its related dependencies. (`apps/client/package.json`, `pnpm-lock.yaml`) [[1]](diffhunk://#diff-813b5be743f8e37cd04896bbc79fd264aeb9432a87c2662a07df58d3af96b56fR11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23-R25) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR907-R919) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR946-R958) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3496-R3512) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3538-R3553)