### PR TITLE
Add minimum and maximum shift scheduling requirements to periods

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -43,6 +43,8 @@ jobs:
           version: 10
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Build Prisma
+        run: pnpm run --filter=@ecehive/prisma generate
       - name: Run type checks
         run: pnpm run tsc
 

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -17,6 +17,7 @@
 		"@radix-ui/react-hover-card": "^1.1.15",
 		"@radix-ui/react-label": "^2.1.7",
 		"@radix-ui/react-popover": "^1.1.15",
+		"@radix-ui/react-progress": "^1.1.8",
 		"@radix-ui/react-select": "^2.2.6",
 		"@radix-ui/react-separator": "^1.1.7",
 		"@radix-ui/react-slider": "^1.3.6",

--- a/apps/client/src/components/shift-schedules/shift-detail-sheet.tsx
+++ b/apps/client/src/components/shift-schedules/shift-detail-sheet.tsx
@@ -32,6 +32,7 @@ interface ShiftSchedule {
 	meetsRoleRequirement: boolean;
 	meetsBalancingRequirement: boolean;
 	hasTimeOverlap: boolean;
+	blockedByMaxRequirement?: boolean;
 	users: { id: number; name: string }[];
 }
 
@@ -251,6 +252,11 @@ export function ShiftDetailSheet({
 											<li>
 												This shift overlaps with another shift you are already
 												registered for
+											</li>
+										)}
+										{schedule.blockedByMaxRequirement && (
+											<li>
+												You have reached the maximum allowed for this period
 											</li>
 										)}
 									</ul>

--- a/apps/client/src/components/ui/progress.tsx
+++ b/apps/client/src/components/ui/progress.tsx
@@ -1,0 +1,29 @@
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Progress({
+	className,
+	value,
+	...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+	return (
+		<ProgressPrimitive.Root
+			data-slot="progress"
+			className={cn(
+				"bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+				className,
+			)}
+			{...props}
+		>
+			<ProgressPrimitive.Indicator
+				data-slot="progress-indicator"
+				className="bg-primary h-full w-full flex-1 transition-all"
+				style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+			/>
+		</ProgressPrimitive.Root>
+	);
+}
+
+export { Progress };

--- a/apps/client/src/env.d.ts
+++ b/apps/client/src/env.d.ts
@@ -1,2 +1,1 @@
 declare const __APP_VERSION__: string;
-declare const __COMMIT_HASH__: string;

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -17,7 +17,7 @@ if ((import.meta.env.VITE_CLIENT_SENTRY_DSN ?? "").trim().length > 0) {
 		dsn: import.meta.env.VITE_CLIENT_SENTRY_DSN,
 		sendDefaultPii: true,
 		enableLogs: true,
-		release: `${__APP_VERSION__}+${__COMMIT_HASH__}`,
+		release: __APP_VERSION__,
 	});
 }
 

--- a/apps/client/src/routes/shifts/period-details.tsx
+++ b/apps/client/src/routes/shifts/period-details.tsx
@@ -84,7 +84,21 @@ function PeriodDetail() {
 		scheduleSignupEnd: period.scheduleSignupEnd?.toISOString() ?? null,
 		scheduleModifyStart: period.scheduleModifyStart?.toISOString() ?? null,
 		scheduleModifyEnd: period.scheduleModifyEnd?.toISOString() ?? null,
+		min: period.min,
+		max: period.max,
+		minMaxUnit: period.minMaxUnit,
 	};
+
+	const unitLabels = {
+		count: "shifts",
+		hours: "hours",
+		minutes: "minutes",
+	} as const;
+
+	const hasRequirements = period.min !== null || period.max !== null;
+	const unitLabel = period.minMaxUnit
+		? unitLabels[period.minMaxUnit as keyof typeof unitLabels]
+		: null;
 
 	return (
 		<div className="container p-4 space-y-4">
@@ -236,6 +250,38 @@ function PeriodDetail() {
 						) : (
 							<div className="text-sm text-muted-foreground">
 								No modification window configured
+							</div>
+						)}
+					</div>
+
+					<div>
+						<div className="text-sm font-semibold mb-3">Shift Requirements</div>
+						{hasRequirements && unitLabel ? (
+							<div className="grid gap-4 sm:grid-cols-2">
+								<div>
+									<div className="text-sm font-medium text-muted-foreground">
+										Minimum
+									</div>
+									<div>
+										{period.min !== null
+											? `${period.min} ${unitLabel}`
+											: "Not set"}
+									</div>
+								</div>
+								<div>
+									<div className="text-sm font-medium text-muted-foreground">
+										Maximum
+									</div>
+									<div>
+										{period.max !== null
+											? `${period.max} ${unitLabel}`
+											: "Not set"}
+									</div>
+								</div>
+							</div>
+						) : (
+							<div className="text-sm text-muted-foreground">
+								No shift requirements configured
 							</div>
 						)}
 					</div>

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -1,4 +1,3 @@
-import * as child from "node:child_process";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import { devtools } from "@tanstack/devtools-vite";
@@ -12,14 +11,11 @@ import packageConfig from "./package.json";
 export default defineConfig(({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), ["VITE_"]);
 
-	const commitHash = child.execSync("git rev-parse --short HEAD").toString();
-
 	return {
 		publicDir: "public",
 		base: "/",
 		define: {
-			__APP_VERSION__: JSON.stringify(packageConfig.version) ?? "dev",
-			__COMMIT_HASH__: JSON.stringify(commitHash) ?? "unknown",
+			__APP_VERSION__: JSON.stringify(packageConfig.version ?? "dev"),
 		},
 		server: {
 			port: env.VITE_DEV_PORT ? parseInt(env.VITE_DEV_PORT, 10) : 44831,

--- a/apps/kiosk/src/env.d.ts
+++ b/apps/kiosk/src/env.d.ts
@@ -1,2 +1,1 @@
 declare const __APP_VERSION__: string;
-declare const __COMMIT_HASH__: string;

--- a/apps/kiosk/src/main.tsx
+++ b/apps/kiosk/src/main.tsx
@@ -13,7 +13,7 @@ if ((import.meta.env.VITE_KIOSK_SENTRY_DSN ?? "").trim().length > 0) {
 		dsn: import.meta.env.VITE_KIOSK_SENTRY_DSN,
 		sendDefaultPii: true,
 		enableLogs: true,
-		release: `${__APP_VERSION__}+${__COMMIT_HASH__}`,
+		release: __APP_VERSION__,
 	});
 }
 

--- a/apps/kiosk/vite.config.ts
+++ b/apps/kiosk/vite.config.ts
@@ -1,4 +1,3 @@
-import * as child from "node:child_process";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import { devtools } from "@tanstack/devtools-vite";
@@ -11,14 +10,11 @@ import packageConfig from "./package.json";
 export default defineConfig(({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), ["VITE_"]);
 
-	const commitHash = child.execSync("git rev-parse --short HEAD").toString();
-
 	return {
 		publicDir: "public",
 		base: "/kiosk/",
 		define: {
-			__APP_VERSION__: JSON.stringify(packageConfig.version) ?? "dev",
-			__COMMIT_HASH__: JSON.stringify(commitHash) ?? "unknown",
+			__APP_VERSION__: JSON.stringify(packageConfig.version ?? "dev"),
 		},
 		server: {
 			port: env.VITE_DEV_PORT ? parseInt(env.VITE_DEV_PORT, 10) : 44832,

--- a/packages/features/src/shift-schedules/queries.ts
+++ b/packages/features/src/shift-schedules/queries.ts
@@ -41,6 +41,9 @@ export async function getUserRegisteredSchedules(
 			dayOfWeek: true,
 			startTime: true,
 			endTime: true,
+			shiftType: {
+				select: { periodId: true },
+			},
 		},
 	});
 }

--- a/packages/prisma/migrations/20251114150910_period_min_max/migration.sql
+++ b/packages/prisma/migrations/20251114150910_period_min_max/migration.sql
@@ -1,0 +1,7 @@
+-- CreateEnum
+CREATE TYPE "MinMaxUnit" AS ENUM ('count', 'minutes', 'hours');
+
+-- AlterTable
+ALTER TABLE "Period" ADD COLUMN     "max" INTEGER,
+ADD COLUMN     "min" INTEGER,
+ADD COLUMN     "minMaxUnit" "MinMaxUnit";

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -8,8 +8,7 @@
 		"migrate": "prisma migrate deploy",
 		"migrate:dev": "prisma migrate dev",
 		"reset": "prisma migrate reset",
-		"tsc": "tsc --noEmit",
-		"postinstall": "pnpm run generate"
+		"tsc": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@ecehive/env": "workspace:*",

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -32,6 +32,12 @@ enum SessionType {
   staffing
 }
 
+enum MinMaxUnit {
+  count
+  minutes
+  hours
+}
+
 //
 // Models
 //
@@ -102,6 +108,10 @@ model Period {
   name  String
   start DateTime
   end   DateTime
+
+  min       Int?
+  max       Int?
+  minMaxUnit MinMaxUnit?
 
   visibleStart DateTime?
   visibleEnd   DateTime?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1044,6 +1047,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
@@ -1229,6 +1241,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3679,6 +3704,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3884,6 +3915,16 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:


### PR DESCRIPTION
This pull requests adds support for `min` and `max` shift scheduling requirements to periods. These values are optional, and the units can be changed to set a requirement for `hours`, `minutes`, or a `count`. Some misc. build issues are also addressed.