### PR TITLE
Add user management page for shifts

### DIFF
--- a/apps/client/src/components/shifts-sidebar.tsx
+++ b/apps/client/src/components/shifts-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 	ListIcon,
 	MoonIcon,
 	NotebookTextIcon,
+	ShieldCheckIcon,
 	SunIcon,
 	SunMoonIcon,
 	User2Icon,
@@ -42,6 +43,7 @@ import { useShiftAccess } from "@/hooks/use-shift-access";
 import { checkPermissions } from "@/lib/permissions";
 import { permissions as attendancePagePermissions } from "@/routes/shifts/attendance";
 import { permissions as shiftsIndexPagePermissions } from "@/routes/shifts/index";
+import { permissions as manageUsersPagePermissions } from "@/routes/shifts/manage-users";
 import { permissions as myShiftsPagePermissions } from "@/routes/shifts/my-shifts";
 import { permissions as periodDetailsPagePermissions } from "@/routes/shifts/period-details";
 import { permissions as schedulingPagePermissions } from "@/routes/shifts/scheduling";
@@ -107,6 +109,12 @@ export const items = [
 				url: "/shifts/shift-schedules",
 				icon: ClockIcon,
 				permissions: shiftSchedulesPagePermissions,
+			},
+			{
+				title: "Manage Users",
+				url: "/shifts/manage-users",
+				icon: ShieldCheckIcon,
+				permissions: manageUsersPagePermissions,
 			},
 			{
 				title: "Reports",

--- a/apps/client/src/components/users/period-user-selector.tsx
+++ b/apps/client/src/components/users/period-user-selector.tsx
@@ -1,0 +1,161 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { useDebounce } from "@/lib/debounce";
+
+export type PeriodUserOption = {
+	id: number;
+	name: string | null;
+	username: string;
+	email: string | null;
+};
+
+export type PeriodUserSelectorProps = {
+	periodId: number | null;
+	value: PeriodUserOption | null;
+	onChange: (value: PeriodUserOption | null) => void;
+	placeholder?: string;
+	disabled?: boolean;
+};
+
+function getDisplayLabel(user: PeriodUserOption) {
+	const primary = user.name || user.username;
+	const secondary = user.email ?? user.username;
+	return secondary && secondary !== primary
+		? `${primary} (${secondary})`
+		: primary;
+}
+
+export function PeriodUserSelector({
+	periodId,
+	value,
+	onChange,
+	placeholder = "Select user",
+	disabled = false,
+}: PeriodUserSelectorProps) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const debounced = useDebounce(query, 250).trim();
+	const search = debounced.length > 0 ? debounced : undefined;
+	const isDisabled = disabled || !periodId;
+
+	useEffect(() => {
+		if (!open) {
+			setQuery("");
+		}
+	}, [open]);
+
+	const { data, isFetching } = useQuery({
+		queryKey: ["period-users", periodId, search],
+		queryFn: async () => {
+			if (!periodId) return [] as PeriodUserOption[];
+			const response = await trpc.shiftSchedules.listEligibleUsers.query({
+				periodId,
+				search,
+			});
+			return response.users.map((user) => ({
+				id: user.id,
+				name: user.name,
+				username: user.username,
+				email: user.email,
+			}));
+		},
+		enabled: open && Boolean(periodId),
+		staleTime: 60_000,
+		select: (users) => users ?? [],
+	});
+
+	const users = data ?? [];
+	const showLoading = isFetching && users.length === 0;
+
+	const buttonLabel = useMemo(() => {
+		if (!value) {
+			return <span className="text-muted-foreground">{placeholder}</span>;
+		}
+		return getDisplayLabel(value);
+	}, [value, placeholder]);
+
+	return (
+		<Popover open={open && !isDisabled} onOpenChange={(next) => setOpen(next)}>
+			<PopoverTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					role="combobox"
+					aria-expanded={open}
+					className="w-full justify-between"
+					disabled={isDisabled}
+				>
+					<span className="truncate text-left">{buttonLabel}</span>
+					<ChevronsUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-[320px] p-0">
+				<Command shouldFilter={false}>
+					<CommandInput
+						placeholder="Search users..."
+						value={query}
+						onValueChange={setQuery}
+					/>
+					<CommandList>
+						{showLoading ? (
+							<CommandEmpty>Searching...</CommandEmpty>
+						) : users.length === 0 ? (
+							<CommandEmpty>No users found</CommandEmpty>
+						) : (
+							<CommandGroup>
+								{value ? (
+									<CommandItem
+										value="clear"
+										onSelect={() => {
+											onChange(null);
+											setOpen(false);
+										}}
+										className="text-muted-foreground"
+									>
+										Clear selection
+									</CommandItem>
+								) : null}
+								{users.map((user) => {
+									const isSelected = user.id === value?.id;
+									return (
+										<CommandItem
+											key={user.id}
+											value={getDisplayLabel(user).toLowerCase()}
+											onSelect={() => {
+												onChange(user);
+												setOpen(false);
+											}}
+										>
+											{isSelected ? (
+												<CheckIcon className="mr-2 h-4 w-4" />
+											) : (
+												<span className="mr-2 w-4" />
+											)}
+											<span className="truncate">{getDisplayLabel(user)}</span>
+										</CommandItem>
+									);
+								})}
+							</CommandGroup>
+						)}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as ShiftsShiftSchedulesRouteImport } from './routes/shifts/shift-
 import { Route as ShiftsSchedulingRouteImport } from './routes/shifts/scheduling'
 import { Route as ShiftsPeriodDetailsRouteImport } from './routes/shifts/period-details'
 import { Route as ShiftsMyShiftsRouteImport } from './routes/shifts/my-shifts'
+import { Route as ShiftsManageUsersRouteImport } from './routes/shifts/manage-users'
 import { Route as ShiftsAttendanceRouteImport } from './routes/shifts/attendance'
 import { Route as AppUsersRouteImport } from './routes/app/users'
 import { Route as AppSessionsRouteImport } from './routes/app/sessions'
@@ -84,6 +85,11 @@ const ShiftsPeriodDetailsRoute = ShiftsPeriodDetailsRouteImport.update({
 const ShiftsMyShiftsRoute = ShiftsMyShiftsRouteImport.update({
   id: '/my-shifts',
   path: '/my-shifts',
+  getParentRoute: () => ShiftsRoute,
+} as any)
+const ShiftsManageUsersRoute = ShiftsManageUsersRouteImport.update({
+  id: '/manage-users',
+  path: '/manage-users',
   getParentRoute: () => ShiftsRoute,
 } as any)
 const ShiftsAttendanceRoute = ShiftsAttendanceRouteImport.update({
@@ -152,6 +158,7 @@ export interface FileRoutesByFullPath {
   '/app/sessions': typeof AppSessionsRoute
   '/app/users': typeof AppUsersRoute
   '/shifts/attendance': typeof ShiftsAttendanceRoute
+  '/shifts/manage-users': typeof ShiftsManageUsersRoute
   '/shifts/my-shifts': typeof ShiftsMyShiftsRoute
   '/shifts/period-details': typeof ShiftsPeriodDetailsRoute
   '/shifts/scheduling': typeof ShiftsSchedulingRoute
@@ -173,6 +180,7 @@ export interface FileRoutesByTo {
   '/app/sessions': typeof AppSessionsRoute
   '/app/users': typeof AppUsersRoute
   '/shifts/attendance': typeof ShiftsAttendanceRoute
+  '/shifts/manage-users': typeof ShiftsManageUsersRoute
   '/shifts/my-shifts': typeof ShiftsMyShiftsRoute
   '/shifts/period-details': typeof ShiftsPeriodDetailsRoute
   '/shifts/scheduling': typeof ShiftsSchedulingRoute
@@ -197,6 +205,7 @@ export interface FileRoutesById {
   '/app/sessions': typeof AppSessionsRoute
   '/app/users': typeof AppUsersRoute
   '/shifts/attendance': typeof ShiftsAttendanceRoute
+  '/shifts/manage-users': typeof ShiftsManageUsersRoute
   '/shifts/my-shifts': typeof ShiftsMyShiftsRoute
   '/shifts/period-details': typeof ShiftsPeriodDetailsRoute
   '/shifts/scheduling': typeof ShiftsSchedulingRoute
@@ -222,6 +231,7 @@ export interface FileRouteTypes {
     | '/app/sessions'
     | '/app/users'
     | '/shifts/attendance'
+    | '/shifts/manage-users'
     | '/shifts/my-shifts'
     | '/shifts/period-details'
     | '/shifts/scheduling'
@@ -243,6 +253,7 @@ export interface FileRouteTypes {
     | '/app/sessions'
     | '/app/users'
     | '/shifts/attendance'
+    | '/shifts/manage-users'
     | '/shifts/my-shifts'
     | '/shifts/period-details'
     | '/shifts/scheduling'
@@ -266,6 +277,7 @@ export interface FileRouteTypes {
     | '/app/sessions'
     | '/app/users'
     | '/shifts/attendance'
+    | '/shifts/manage-users'
     | '/shifts/my-shifts'
     | '/shifts/period-details'
     | '/shifts/scheduling'
@@ -359,6 +371,13 @@ declare module '@tanstack/react-router' {
       path: '/my-shifts'
       fullPath: '/shifts/my-shifts'
       preLoaderRoute: typeof ShiftsMyShiftsRouteImport
+      parentRoute: typeof ShiftsRoute
+    }
+    '/shifts/manage-users': {
+      id: '/shifts/manage-users'
+      path: '/manage-users'
+      fullPath: '/shifts/manage-users'
+      preLoaderRoute: typeof ShiftsManageUsersRouteImport
       parentRoute: typeof ShiftsRoute
     }
     '/shifts/attendance': {
@@ -464,6 +483,7 @@ const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
 interface ShiftsRouteChildren {
   ShiftsAttendanceRoute: typeof ShiftsAttendanceRoute
+  ShiftsManageUsersRoute: typeof ShiftsManageUsersRoute
   ShiftsMyShiftsRoute: typeof ShiftsMyShiftsRoute
   ShiftsPeriodDetailsRoute: typeof ShiftsPeriodDetailsRoute
   ShiftsSchedulingRoute: typeof ShiftsSchedulingRoute
@@ -474,6 +494,7 @@ interface ShiftsRouteChildren {
 
 const ShiftsRouteChildren: ShiftsRouteChildren = {
   ShiftsAttendanceRoute: ShiftsAttendanceRoute,
+  ShiftsManageUsersRoute: ShiftsManageUsersRoute,
   ShiftsMyShiftsRoute: ShiftsMyShiftsRoute,
   ShiftsPeriodDetailsRoute: ShiftsPeriodDetailsRoute,
   ShiftsSchedulingRoute: ShiftsSchedulingRoute,

--- a/apps/client/src/routes/shifts/index.tsx
+++ b/apps/client/src/routes/shifts/index.tsx
@@ -1,12 +1,18 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { CalendarCheckIcon, ClockIcon, UserPlusIcon } from "lucide-react";
+import {
+	CalendarCheckIcon,
+	ClockIcon,
+	ShieldCheckIcon,
+	UserPlusIcon,
+} from "lucide-react";
+import { useCurrentUser } from "@/auth/AuthProvider";
 import { PeriodNotSelected } from "@/components/period-not-selected";
 import { usePeriod } from "@/components/period-provider";
 import { RequireShiftAccess } from "@/components/require-shift-access";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useShiftAccess } from "@/hooks/use-shift-access";
-import type { RequiredPermissions } from "@/lib/permissions";
+import { checkPermissions, type RequiredPermissions } from "@/lib/permissions";
 
 export const Route = createFileRoute("/shifts/")({
 	component: () => (
@@ -23,6 +29,10 @@ export const permissions = {
 function ShiftsIndex() {
 	const { period: periodId } = usePeriod();
 	const { canAccessShifts } = useShiftAccess();
+	const currentUser = useCurrentUser();
+	const canManageUsers = checkPermissions(currentUser, [
+		"shift_schedules.manipulate",
+	]);
 
 	if (periodId === null) {
 		return <PeriodNotSelected />;
@@ -61,6 +71,14 @@ function ShiftsIndex() {
 								View Attendance History
 							</Button>
 						</Link>
+						{canManageUsers ? (
+							<Link to="/shifts/manage-users">
+								<Button variant="outline" className="w-full justify-start">
+									<ShieldCheckIcon className="mr-2 h-4 w-4" />
+									Manage User Shifts
+								</Button>
+							</Link>
+						) : null}
 					</CardContent>
 				</Card>
 			)}

--- a/apps/client/src/routes/shifts/manage-users.tsx
+++ b/apps/client/src/routes/shifts/manage-users.tsx
@@ -1,0 +1,1036 @@
+import { trpc } from "@ecehive/trpc/client";
+import {
+	type UseMutationResult,
+	type UseQueryResult,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { ShieldCheckIcon, UsersIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { RequirePermissions, useCurrentUser } from "@/auth/AuthProvider";
+import { MissingPermissions } from "@/components/missing-permissions";
+import { PeriodNotSelected } from "@/components/period-not-selected";
+import { usePeriod } from "@/components/period-provider";
+import { TablePagination } from "@/components/table-pagination";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+	type PeriodUserOption,
+	PeriodUserSelector,
+} from "@/components/users/period-user-selector";
+import { checkPermissions, type RequiredPermissions } from "@/lib/permissions";
+import { formatDateInAppTimezone, formatTimeRange } from "@/lib/timezone";
+
+const DAYS_OF_WEEK = [
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+];
+
+const PAGE_SIZE = 10;
+const ASSIGNED_PAGE_SIZE = 8;
+const UPCOMING_PAGE_SIZE = 6;
+const ATTENDANCE_PAGE_SIZE = 8;
+
+type AttendanceStatsSnapshot = {
+	attended: number;
+	missed: number;
+	dropped: number;
+	droppedWithMakeup: number;
+	totalScheduledHours: number;
+	totalActualHours: number;
+	attendanceCoveragePercent: number;
+};
+
+const EMPTY_ATTENDANCE_STATS: AttendanceStatsSnapshot = {
+	attended: 0,
+	missed: 0,
+	dropped: 0,
+	droppedWithMakeup: 0,
+	totalScheduledHours: 0,
+	totalActualHours: 0,
+	attendanceCoveragePercent: 0,
+};
+
+type ScheduleFilters = {
+	search: string;
+	shiftTypeId: number | "all";
+	dayOfWeek: number | "all";
+};
+
+type ShiftTypeOption = {
+	id: number;
+	name: string;
+};
+
+const SCHEDULES_QUERY_KEY = ["manage-user-schedules"] as const;
+const UPCOMING_QUERY_KEY = ["manage-user-upcoming"] as const;
+const ATTENDANCE_QUERY_KEY = ["manage-user-attendance"] as const;
+
+type ScheduleManagementData = Awaited<
+	ReturnType<typeof trpc.shiftSchedules.listForUserManagement.query>
+>;
+type UpcomingData = Awaited<
+	ReturnType<typeof trpc.shiftOccurrences.listForUser.query>
+>;
+type AttendanceData = Awaited<
+	ReturnType<typeof trpc.shiftAttendances.listForUser.query>
+>;
+
+export const Route = createFileRoute("/shifts/manage-users")({
+	component: () =>
+		RequirePermissions({
+			permissions,
+			children: <ManageUserShiftsPage />,
+			forbiddenFallback: <MissingPermissions />,
+		}),
+});
+
+export const permissions = [
+	"shift_schedules.manipulate",
+] as RequiredPermissions;
+
+function getErrorMessage(error: unknown) {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	return "Something went wrong";
+}
+
+function formatStatusLabel(status: string) {
+	return status
+		.split("_")
+		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+		.join(" ");
+}
+
+function ManageUserShiftsPage() {
+	const { period: selectedPeriodId } = usePeriod();
+	const [selectedUser, setSelectedUser] = useState<PeriodUserOption | null>(
+		null,
+	);
+	const queryClient = useQueryClient();
+	const currentUser = useCurrentUser();
+	const canManageAssignments = checkPermissions(currentUser, permissions);
+	const canViewUpcoming = checkPermissions(currentUser, permissions);
+	const canViewAttendance = checkPermissions(currentUser, permissions);
+
+	useEffect(() => {
+		setSelectedUser(null);
+	}, [selectedPeriodId]);
+
+	const schedulesQuery = useQuery<ScheduleManagementData | null, Error>({
+		queryKey: [...SCHEDULES_QUERY_KEY, selectedPeriodId, selectedUser?.id],
+		queryFn: async () => {
+			if (!selectedPeriodId || !selectedUser) return null;
+			return trpc.shiftSchedules.listForUserManagement.query({
+				periodId: selectedPeriodId,
+				userId: selectedUser.id,
+			});
+		},
+		enabled: Boolean(selectedPeriodId && selectedUser),
+	});
+
+	const upcomingQuery = useQuery<UpcomingData | null, Error>({
+		queryKey: [...UPCOMING_QUERY_KEY, selectedPeriodId, selectedUser?.id],
+		queryFn: async () => {
+			if (!selectedPeriodId || !selectedUser) return null;
+			return trpc.shiftOccurrences.listForUser.query({
+				periodId: selectedPeriodId,
+				userId: selectedUser.id,
+				limit: 50,
+			});
+		},
+		enabled: Boolean(selectedPeriodId && selectedUser),
+	});
+
+	const attendanceQuery = useQuery<AttendanceData | null, Error>({
+		queryKey: [...ATTENDANCE_QUERY_KEY, selectedPeriodId, selectedUser?.id],
+		queryFn: async () => {
+			if (!selectedPeriodId || !selectedUser) return null;
+			return trpc.shiftAttendances.listForUser.query({
+				periodId: selectedPeriodId,
+				userId: selectedUser.id,
+				limit: 25,
+			});
+		},
+		enabled: Boolean(selectedPeriodId && selectedUser),
+	});
+
+	const invalidateManagementData = async () => {
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: SCHEDULES_QUERY_KEY }),
+			queryClient.invalidateQueries({ queryKey: UPCOMING_QUERY_KEY }),
+			queryClient.invalidateQueries({ queryKey: ATTENDANCE_QUERY_KEY }),
+		]);
+	};
+
+	const assignMutation = useMutation<void, Error, number>({
+		mutationFn: async (shiftScheduleId: number) => {
+			if (!selectedUser) {
+				throw new Error("Select a user before assigning shifts");
+			}
+			await trpc.shiftSchedules.forceRegister.mutate({
+				shiftScheduleId,
+				userId: selectedUser.id,
+			});
+		},
+		onSuccess: async () => {
+			await invalidateManagementData();
+			toast.success("User assigned to shift");
+		},
+		onError: (error) => toast.error(getErrorMessage(error)),
+	});
+
+	const unassignMutation = useMutation<void, Error, number>({
+		mutationFn: async (shiftScheduleId: number) => {
+			if (!selectedUser) {
+				throw new Error("Select a user before removing shifts");
+			}
+			await trpc.shiftSchedules.forceUnregister.mutate({
+				shiftScheduleId,
+				userId: selectedUser.id,
+			});
+		},
+		onSuccess: async () => {
+			await invalidateManagementData();
+			toast.success("User removed from shift");
+		},
+		onError: (error) => toast.error(getErrorMessage(error)),
+	});
+
+	const assignedCount = useMemo(() => {
+		return (
+			schedulesQuery.data?.schedules.filter((schedule) => schedule.isRegistered)
+				.length ?? 0
+		);
+	}, [schedulesQuery.data]);
+
+	const upcomingCount = upcomingQuery.data?.total ?? 0;
+	const attendanceCount = attendanceQuery.data?.total ?? 0;
+	const periodLabel =
+		schedulesQuery.data?.period?.name ?? `Period ${selectedPeriodId}`;
+
+	if (selectedPeriodId === null) {
+		return <PeriodNotSelected />;
+	}
+
+	return (
+		<div className="container space-y-4 p-4">
+			<div className="flex flex-wrap items-center justify-between gap-4">
+				<div>
+					<h1 className="text-2xl font-bold flex items-center gap-2">
+						<ShieldCheckIcon className="h-6 w-6" /> Manage User Shifts
+					</h1>
+					<p className="text-muted-foreground text-sm">
+						Assign and review staffing for this period
+					</p>
+				</div>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Select user</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid gap-4 md:grid-cols-2">
+						<div>
+							<p className="text-sm font-medium mb-2">Staffing user</p>
+							<PeriodUserSelector
+								periodId={selectedPeriodId}
+								value={selectedUser}
+								onChange={setSelectedUser}
+								placeholder="Search for a staffing user"
+							/>
+						</div>
+						<div>
+							<p className="text-sm font-medium mb-2">Period</p>
+							<div className="flex h-10 items-center rounded-md border px-3 text-sm">
+								{periodLabel}
+							</div>
+						</div>
+					</div>
+					{selectedUser ? (
+						<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+							<SummaryStat label="Assigned shifts" value={assignedCount} />
+							<SummaryStat label="Upcoming" value={upcomingCount} />
+							<SummaryStat label="Attendance records" value={attendanceCount} />
+						</div>
+					) : (
+						<p className="text-sm text-muted-foreground">
+							Choose a user above to view their staffing details.
+						</p>
+					)}
+				</CardContent>
+			</Card>
+
+			{selectedUser ? (
+				<>
+					{canManageAssignments ? (
+						<Card>
+							<CardHeader>
+								<CardTitle className="flex items-center gap-2">
+									<UsersIcon className="h-5 w-5" /> Shift assignments
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<Tabs defaultValue="assign" className="space-y-4">
+									<TabsList>
+										<TabsTrigger value="assign">Find & assign</TabsTrigger>
+										<TabsTrigger value="current">
+											Current assignments
+										</TabsTrigger>
+									</TabsList>
+									<TabsContent value="assign" className="space-y-4">
+										<SchedulesSection
+											query={schedulesQuery}
+											assignMutation={assignMutation}
+											unassignMutation={unassignMutation}
+											activeUserId={selectedUser.id}
+										/>
+									</TabsContent>
+									<TabsContent value="current" className="space-y-4">
+										<AssignedSchedulesSection
+											query={schedulesQuery}
+											unassignMutation={unassignMutation}
+											activeUserId={selectedUser.id}
+										/>
+									</TabsContent>
+								</Tabs>
+							</CardContent>
+						</Card>
+					) : null}
+
+					<div className="grid gap-4 lg:grid-cols-2">
+						{canViewUpcoming ? (
+							<Card>
+								<CardHeader>
+									<CardTitle>Upcoming shifts</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<UpcomingSection
+										query={upcomingQuery}
+										activeUserId={selectedUser.id}
+									/>
+								</CardContent>
+							</Card>
+						) : null}
+						{canViewAttendance ? (
+							<Card>
+								<CardHeader>
+									<CardTitle>Attendance history</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<AttendanceSection
+										query={attendanceQuery}
+										activeUserId={selectedUser.id}
+									/>
+								</CardContent>
+							</Card>
+						) : null}
+					</div>
+
+					{!canManageAssignments && !canViewUpcoming && !canViewAttendance ? (
+						<div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+							You do not have permission to view staffing data for this user.
+						</div>
+					) : null}
+				</>
+			) : (
+				<div className="flex items-center justify-center rounded-md border border-dashed py-16 text-sm text-muted-foreground">
+					Select a user to load shift data
+				</div>
+			)}
+		</div>
+	);
+}
+
+function SummaryStat({ label, value }: { label: string; value: number }) {
+	return (
+		<div className="rounded-lg border bg-muted/40 p-3">
+			<p className="text-xs font-medium uppercase text-muted-foreground">
+				{label}
+			</p>
+			<p className="text-2xl font-semibold">{value}</p>
+		</div>
+	);
+}
+
+type ScheduleSectionProps = {
+	query: UseQueryResult<ScheduleManagementData | null, Error>;
+	assignMutation: UseMutationResult<void, Error, number, unknown>;
+	unassignMutation: UseMutationResult<void, Error, number, unknown>;
+	activeUserId: number | null;
+};
+
+type UpcomingSectionProps = {
+	query: UseQueryResult<UpcomingData | null, Error>;
+	activeUserId: number | null;
+};
+
+type AttendanceSectionProps = {
+	query: UseQueryResult<AttendanceData | null, Error>;
+	activeUserId: number | null;
+};
+
+type AssignedSchedulesSectionProps = {
+	query: UseQueryResult<ScheduleManagementData | null, Error>;
+	unassignMutation: UseMutationResult<void, Error, number, unknown>;
+	activeUserId: number | null;
+};
+
+function SchedulesSection({
+	query,
+	assignMutation,
+	unassignMutation,
+	activeUserId,
+}: ScheduleSectionProps) {
+	const [filters, setFilters] = useState<ScheduleFilters>(() =>
+		createDefaultFilters(),
+	);
+	const [page, setPage] = useState(1);
+
+	useEffect(() => {
+		setFilters(createDefaultFilters());
+		setPage(1);
+	}, [activeUserId]);
+
+	useEffect(() => {
+		setPage(1);
+	}, [filters.search, filters.shiftTypeId, filters.dayOfWeek]);
+
+	const schedules =
+		query.data?.schedules ?? ([] as ScheduleManagementData["schedules"]);
+
+	const shiftTypeOptions: ShiftTypeOption[] = useMemo(() => {
+		const entries = new Map<number, string>();
+		schedules.forEach((schedule) => {
+			entries.set(schedule.shiftTypeId, schedule.shiftTypeName);
+		});
+		return Array.from(entries.entries())
+			.sort((a, b) => a[1].localeCompare(b[1]))
+			.map(([id, name]) => ({ id, name }));
+	}, [schedules]);
+
+	const filteredSchedules = useMemo(() => {
+		const search = filters.search.trim().toLowerCase();
+		return schedules.filter((schedule) => {
+			if (
+				filters.shiftTypeId !== "all" &&
+				schedule.shiftTypeId !== filters.shiftTypeId
+			) {
+				return false;
+			}
+			if (
+				filters.dayOfWeek !== "all" &&
+				schedule.dayOfWeek !== filters.dayOfWeek
+			) {
+				return false;
+			}
+			if (search) {
+				const haystack =
+					`${schedule.shiftTypeName} ${schedule.shiftTypeLocation ?? ""} ${DAYS_OF_WEEK[schedule.dayOfWeek]} ${schedule.startTime} ${schedule.endTime}`.toLowerCase();
+				return haystack.includes(search);
+			}
+			return true;
+		});
+	}, [filters, schedules]);
+
+	const totalItems = filteredSchedules.length;
+	const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
+	const displayPage = Math.min(page, totalPages);
+	const pageStartIndex = totalItems === 0 ? 0 : (displayPage - 1) * PAGE_SIZE;
+	const pageEndIndex =
+		totalItems === 0 ? 0 : Math.min(pageStartIndex + PAGE_SIZE, totalItems);
+	const visibleSchedules = filteredSchedules.slice(
+		pageStartIndex,
+		pageEndIndex,
+	);
+	const hasActiveFilters =
+		filters.search.trim().length > 0 ||
+		filters.shiftTypeId !== "all" ||
+		filters.dayOfWeek !== "all";
+	const showingSubset = filteredSchedules.length !== schedules.length;
+	const summaryText =
+		filteredSchedules.length === 0
+			? "No shifts match the current filters."
+			: `Showing ${pageStartIndex + 1}-${pageEndIndex} of ${filteredSchedules.length} shift${
+					filteredSchedules.length === 1 ? "" : "s"
+				}${showingSubset ? ` (filtered from ${schedules.length})` : ""}`;
+
+	if (query.isLoading) {
+		return (
+			<div className="flex justify-center py-10">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if (query.error) {
+		return (
+			<Alert variant="destructive">
+				<AlertTitle>Unable to load schedules</AlertTitle>
+				<AlertDescription>
+					{getErrorMessage(query.error as Error)}
+				</AlertDescription>
+			</Alert>
+		);
+	}
+
+	if (schedules.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground">
+				No shift schedules found for this period.
+			</p>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<div className="space-y-3 rounded-lg border bg-muted/20 p-3">
+				<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+					<div className="space-y-1">
+						<p className="text-sm font-medium">Search</p>
+						<Input
+							value={filters.search}
+							onChange={(event) =>
+								setFilters((prev) => ({
+									...prev,
+									search: event.target.value,
+								}))
+							}
+							placeholder="Search by name, location, or time"
+						/>
+					</div>
+					<div className="space-y-1">
+						<p className="text-sm font-medium">Shift type</p>
+						<Select
+							value={
+								filters.shiftTypeId === "all"
+									? "all"
+									: String(filters.shiftTypeId)
+							}
+							onValueChange={(value) =>
+								setFilters((prev) => ({
+									...prev,
+									shiftTypeId: value === "all" ? "all" : Number(value),
+								}))
+							}
+						>
+							<SelectTrigger className="w-full justify-between">
+								<SelectValue placeholder="All shift types" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All shift types</SelectItem>
+								{shiftTypeOptions.map((option) => (
+									<SelectItem key={option.id} value={String(option.id)}>
+										{option.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="space-y-1">
+						<p className="text-sm font-medium">Day of week</p>
+						<Select
+							value={
+								filters.dayOfWeek === "all" ? "all" : String(filters.dayOfWeek)
+							}
+							onValueChange={(value) =>
+								setFilters((prev) => ({
+									...prev,
+									dayOfWeek: value === "all" ? "all" : Number(value),
+								}))
+							}
+						>
+							<SelectTrigger className="w-full justify-between">
+								<SelectValue placeholder="All days" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All days</SelectItem>
+								{DAYS_OF_WEEK.map((label, index) => (
+									<SelectItem key={label} value={String(index)}>
+										{label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+				<div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+					<span>{summaryText}</span>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => {
+							setFilters(createDefaultFilters());
+							setPage(1);
+						}}
+						disabled={!hasActiveFilters}
+					>
+						Reset filters
+					</Button>
+				</div>
+			</div>
+
+			{filteredSchedules.length === 0 ? (
+				<div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+					Adjust or clear filters to see matching shifts.
+				</div>
+			) : (
+				<>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Shift</TableHead>
+								<TableHead>Day / Time</TableHead>
+								<TableHead>Slots</TableHead>
+								<TableHead className="text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{visibleSchedules.map((schedule) => {
+								const shiftLabel = (
+									<div>
+										<p className="font-medium">{schedule.shiftTypeName}</p>
+										<p className="text-xs text-muted-foreground">
+											{schedule.shiftTypeLocation ?? ""}
+										</p>
+									</div>
+								);
+								const timeLabel = `${DAYS_OF_WEEK[schedule.dayOfWeek]} · ${schedule.startTime} - ${schedule.endTime}`;
+								const isFull = schedule.availableSlots <= 0;
+								const assigning =
+									assignMutation.isPending &&
+									assignMutation.variables === schedule.id;
+								const unassigning =
+									unassignMutation.isPending &&
+									unassignMutation.variables === schedule.id;
+								return (
+									<TableRow key={schedule.id}>
+										<TableCell>{shiftLabel}</TableCell>
+										<TableCell>
+											<div className="flex flex-col gap-1">
+												<span>{timeLabel}</span>
+												<Badge
+													variant={
+														schedule.isRegistered ? "default" : "secondary"
+													}
+												>
+													{schedule.isRegistered ? "Assigned" : "Available"}
+												</Badge>
+											</div>
+										</TableCell>
+										<TableCell>
+											{schedule.assignedUserCount} / {schedule.slots}
+											{isFull && !schedule.isRegistered ? (
+												<p className="text-xs text-muted-foreground">
+													No open slots
+												</p>
+											) : null}
+										</TableCell>
+										<TableCell className="text-right">
+											{schedule.isRegistered ? (
+												<Button
+													variant="ghost"
+													size="sm"
+													disabled={unassigning}
+													onClick={() => unassignMutation.mutate(schedule.id)}
+												>
+													{unassigning ? "Removing..." : "Remove"}
+												</Button>
+											) : (
+												<Button
+													size="sm"
+													disabled={isFull || assigning}
+													onClick={() => assignMutation.mutate(schedule.id)}
+												>
+													{assigning ? "Assigning..." : "Assign"}
+												</Button>
+											)}
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
+
+					{totalPages > 1 ? (
+						<div className="flex justify-end pt-2">
+							<TablePagination
+								page={displayPage}
+								totalPages={totalPages}
+								onPageChange={setPage}
+							/>
+						</div>
+					) : null}
+				</>
+			)}
+		</div>
+	);
+}
+
+function AssignedSchedulesSection({
+	query,
+	unassignMutation,
+	activeUserId,
+}: AssignedSchedulesSectionProps) {
+	const [page, setPage] = useState(1);
+
+	useEffect(() => {
+		setPage(1);
+	}, [activeUserId]);
+
+	if (query.isLoading) {
+		return (
+			<div className="flex justify-center py-6">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if (query.error) {
+		return (
+			<Alert variant="destructive">
+				<AlertTitle>Unable to load assignments</AlertTitle>
+				<AlertDescription>
+					{getErrorMessage(query.error as Error)}
+				</AlertDescription>
+			</Alert>
+		);
+	}
+
+	const schedules = query.data?.schedules ?? [];
+	const assignedSchedules = schedules.filter(
+		(schedule) => schedule.isRegistered,
+	);
+
+	if (assignedSchedules.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground">
+				No shifts are currently assigned to this user.
+			</p>
+		);
+	}
+
+	const totalPages = Math.max(
+		1,
+		Math.ceil(assignedSchedules.length / ASSIGNED_PAGE_SIZE),
+	);
+	const displayPage = Math.min(page, totalPages);
+	const startIndex =
+		assignedSchedules.length === 0 ? 0 : (displayPage - 1) * ASSIGNED_PAGE_SIZE;
+	const visibleSchedules = assignedSchedules.slice(
+		startIndex,
+		startIndex + ASSIGNED_PAGE_SIZE,
+	);
+
+	return (
+		<div className="space-y-3">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Shift</TableHead>
+						<TableHead>Day / Time</TableHead>
+						<TableHead>Slots</TableHead>
+						<TableHead className="text-right">Actions</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{visibleSchedules.map((schedule) => {
+						const timeLabel = `${DAYS_OF_WEEK[schedule.dayOfWeek]} · ${schedule.startTime} - ${schedule.endTime}`;
+						const removing =
+							unassignMutation.isPending &&
+							unassignMutation.variables === schedule.id;
+						return (
+							<TableRow key={schedule.id}>
+								<TableCell>
+									<p className="font-medium">{schedule.shiftTypeName}</p>
+									<p className="text-xs text-muted-foreground">
+										{schedule.shiftTypeLocation ?? ""}
+									</p>
+								</TableCell>
+								<TableCell>{timeLabel}</TableCell>
+								<TableCell>
+									{schedule.assignedUserCount} / {schedule.slots}
+								</TableCell>
+								<TableCell className="text-right">
+									<Button
+										variant="ghost"
+										size="sm"
+										disabled={removing}
+										onClick={() => unassignMutation.mutate(schedule.id)}
+									>
+										{removing ? "Removing..." : "Remove"}
+									</Button>
+								</TableCell>
+							</TableRow>
+						);
+					})}
+				</TableBody>
+			</Table>
+			<div className="flex items-center justify-between text-sm text-muted-foreground">
+				<span>
+					Showing {startIndex + 1}-
+					{Math.min(startIndex + ASSIGNED_PAGE_SIZE, assignedSchedules.length)}{" "}
+					of {assignedSchedules.length}
+				</span>
+				{totalPages > 1 ? (
+					<TablePagination
+						page={displayPage}
+						totalPages={totalPages}
+						onPageChange={setPage}
+					/>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function UpcomingSection({ query, activeUserId }: UpcomingSectionProps) {
+	const [page, setPage] = useState(1);
+
+	useEffect(() => {
+		setPage(1);
+	}, [activeUserId]);
+
+	if (query.isLoading) {
+		return (
+			<div className="flex justify-center py-6">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if (query.error) {
+		return (
+			<Alert variant="destructive">
+				<AlertTitle>Unable to load upcoming shifts</AlertTitle>
+				<AlertDescription>
+					{getErrorMessage(query.error as Error)}
+				</AlertDescription>
+			</Alert>
+		);
+	}
+
+	const occurrences =
+		query.data?.occurrences ?? ([] as UpcomingData["occurrences"]);
+
+	if (occurrences.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground">
+				No upcoming shifts for this user.
+			</p>
+		);
+	}
+
+	const totalPages = Math.max(
+		1,
+		Math.ceil(occurrences.length / UPCOMING_PAGE_SIZE),
+	);
+	const displayPage = Math.min(page, totalPages);
+	const startIndex = (displayPage - 1) * UPCOMING_PAGE_SIZE;
+	const visibleOccurrences = occurrences.slice(
+		startIndex,
+		startIndex + UPCOMING_PAGE_SIZE,
+	);
+
+	return (
+		<div className="space-y-4">
+			{visibleOccurrences.map((occurrence) => {
+				const dateLabel = formatDateInAppTimezone(occurrence.timestamp, {
+					formatString: "ddd, MMM D",
+				});
+				const timeLabel = formatTimeRange(
+					occurrence.startTime,
+					occurrence.endTime,
+					{ referenceDate: occurrence.timestamp },
+				);
+				return (
+					<div
+						key={occurrence.id}
+						className="rounded-md border bg-muted/30 p-3"
+					>
+						<p className="font-medium">{occurrence.shiftTypeName}</p>
+						<p className="text-sm text-muted-foreground">
+							{dateLabel} · {timeLabel}
+						</p>
+					</div>
+				);
+			})}
+			{totalPages > 1 ? (
+				<div className="flex justify-end">
+					<TablePagination
+						page={displayPage}
+						totalPages={totalPages}
+						onPageChange={setPage}
+					/>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function AttendanceSection({ query, activeUserId }: AttendanceSectionProps) {
+	const [page, setPage] = useState(1);
+
+	useEffect(() => {
+		setPage(1);
+	}, [activeUserId]);
+
+	const stats = query.data?.stats ?? EMPTY_ATTENDANCE_STATS;
+	const records =
+		query.data?.attendances ?? ([] as AttendanceData["attendances"]);
+	const hasRecords = records.length > 0;
+	const totalPages = hasRecords
+		? Math.max(1, Math.ceil(records.length / ATTENDANCE_PAGE_SIZE))
+		: 1;
+	const displayPage = Math.min(page, totalPages);
+	const startIndex = hasRecords ? (displayPage - 1) * ATTENDANCE_PAGE_SIZE : 0;
+	const visibleRecords = hasRecords
+		? records.slice(startIndex, startIndex + ATTENDANCE_PAGE_SIZE)
+		: [];
+
+	if (query.isLoading) {
+		return (
+			<div className="flex justify-center py-6">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if (query.error) {
+		return (
+			<Alert variant="destructive">
+				<AlertTitle>Unable to load attendance</AlertTitle>
+				<AlertDescription>
+					{getErrorMessage(query.error as Error)}
+				</AlertDescription>
+			</Alert>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<AttendanceStatsSummary stats={stats} />
+			{!hasRecords ? (
+				<p className="text-sm text-muted-foreground">
+					No attendance records for this period.
+				</p>
+			) : (
+				<>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Date</TableHead>
+								<TableHead>Shift</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead>Hours</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{visibleRecords.map((record) => {
+								const date = formatDateInAppTimezone(
+									record.shiftOccurrence.timestamp,
+									{ formatString: "MMM D, YYYY" },
+								);
+								const statusLabel = formatStatusLabel(record.status);
+								const scheduledDisplay =
+									typeof record.scheduledHours === "number"
+										? `${record.scheduledHours.toFixed(1)}h`
+										: "–";
+								const actualDisplay =
+									typeof record.actualHours === "number"
+										? `${record.actualHours.toFixed(1)}h`
+										: "–";
+								return (
+									<TableRow key={record.id}>
+										<TableCell>{date}</TableCell>
+										<TableCell>
+											{record.shiftOccurrence.shiftSchedule.shiftType.name}
+										</TableCell>
+										<TableCell>
+											<Badge variant="outline">{statusLabel}</Badge>
+										</TableCell>
+										<TableCell>
+											{actualDisplay} / {scheduledDisplay}
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
+					{totalPages > 1 ? (
+						<div className="flex justify-end">
+							<TablePagination
+								page={displayPage}
+								totalPages={totalPages}
+								onPageChange={setPage}
+							/>
+						</div>
+					) : null}
+				</>
+			)}
+		</div>
+	);
+}
+
+function AttendanceStatsSummary({ stats }: { stats: AttendanceStatsSnapshot }) {
+	const coveragePercent = stats.attendanceCoveragePercent;
+	const scheduledHoursLabel = `${stats.totalScheduledHours.toFixed(1)}h`;
+	const actualHoursLabel = `${stats.totalActualHours.toFixed(1)}h`;
+
+	return (
+		<div className="space-y-3">
+			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				<SummaryStat label="Attended" value={stats.attended} />
+				<SummaryStat label="Missed" value={stats.missed} />
+				<SummaryStat label="Dropped" value={stats.dropped} />
+				<SummaryStat label="Dropped + Makeup" value={stats.droppedWithMakeup} />
+			</div>
+			<div className="rounded-md border bg-muted/30 p-3">
+				<p className="text-xs font-medium uppercase text-muted-foreground">
+					Attendance coverage
+				</p>
+				<p className="text-lg font-semibold">
+					{coveragePercent.toFixed(1)}% ({actualHoursLabel} /{" "}
+					{scheduledHoursLabel})
+				</p>
+			</div>
+		</div>
+	);
+}
+
+function createDefaultFilters(): ScheduleFilters {
+	return {
+		search: "",
+		shiftTypeId: "all",
+		dayOfWeek: "all",
+	};
+}

--- a/packages/prisma/migrations/20251119120000_shift_schedule_manipulate/migration.sql
+++ b/packages/prisma/migrations/20251119120000_shift_schedule_manipulate/migration.sql
@@ -1,0 +1,4 @@
+-- Add shift_schedules.manipulate permission
+INSERT INTO "Permission" ("name")
+VALUES ('shift_schedules.manipulate')
+ON CONFLICT ("name") DO NOTHING;

--- a/packages/trpc/server/routers/shiftAttendances/_route.ts
+++ b/packages/trpc/server/routers/shiftAttendances/_route.ts
@@ -1,8 +1,16 @@
-import { protectedProcedure, router } from "../../trpc";
+import {
+	permissionProtectedProcedure,
+	protectedProcedure,
+	router,
+} from "../../trpc";
+import { listForUserHandler, ZListForUserSchema } from "./listForUser.route";
 import { listMyHandler, ZListMySchema } from "./listMy.route";
 import { myStatsHandler, ZMyStatsSchema } from "./myStats.route";
 
 export const shiftAttendancesRouter = router({
 	listMy: protectedProcedure.input(ZListMySchema).query(listMyHandler),
+	listForUser: permissionProtectedProcedure("shift_schedules.manipulate")
+		.input(ZListForUserSchema)
+		.query(listForUserHandler),
 	myStats: protectedProcedure.input(ZMyStatsSchema).query(myStatsHandler),
 });

--- a/packages/trpc/server/routers/shiftAttendances/listForUser.route.ts
+++ b/packages/trpc/server/routers/shiftAttendances/listForUser.route.ts
@@ -1,0 +1,343 @@
+import { assertCanAccessPeriod, getUserWithRoles } from "@ecehive/features";
+import type { Prisma } from "@ecehive/prisma";
+import { prisma, type ShiftAttendanceStatus } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZListForUserSchema = z.object({
+	periodId: z.number().min(1),
+	userId: z.number().min(1),
+	limit: z.number().min(1).max(100).optional(),
+	offset: z.number().min(0).optional(),
+});
+
+export type TListForUserSchema = z.infer<typeof ZListForUserSchema>;
+
+export type TListForUserOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TListForUserSchema;
+};
+
+export async function listForUserHandler(options: TListForUserOptions) {
+	const { periodId, userId, limit = 50, offset = 0 } = options.input;
+
+	const actor = await getUserWithRoles(prisma, options.ctx.user.id);
+
+	if (!actor) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "User not found",
+		});
+	}
+
+	const actorRoleIds = new Set(actor.roles.map((role) => role.id));
+
+	const period = await prisma.period.findUnique({
+		where: { id: periodId },
+		include: {
+			roles: { select: { id: true } },
+		},
+	});
+
+	if (!period) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Period not found",
+		});
+	}
+
+	assertCanAccessPeriod(period, actorRoleIds, {
+		isSystemUser: options.ctx.user.isSystemUser,
+	});
+
+	const targetUser = await prisma.user.findUnique({
+		where: { id: userId },
+		include: {
+			roles: { select: { id: true } },
+		},
+	});
+
+	if (!targetUser) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Target user not found",
+		});
+	}
+
+	const requiredRoleIds = period.roles.map((role) => role.id);
+
+	if (
+		requiredRoleIds.length > 0 &&
+		!targetUser.roles.some((role) => requiredRoleIds.includes(role.id))
+	) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "User is not eligible for this period",
+		});
+	}
+
+	const where: Prisma.ShiftAttendanceWhereInput = {
+		userId,
+		shiftOccurrence: {
+			shiftSchedule: {
+				shiftType: {
+					periodId,
+				},
+			},
+		},
+	};
+
+	const [attendances, total, stats] = await Promise.all([
+		prisma.shiftAttendance.findMany({
+			where,
+			orderBy: {
+				shiftOccurrence: {
+					timestamp: "desc",
+				},
+			},
+			skip: offset,
+			take: limit,
+			select: {
+				id: true,
+				status: true,
+				droppedNotes: true,
+				timeIn: true,
+				timeOut: true,
+				didArriveLate: true,
+				didLeaveEarly: true,
+				isMakeup: true,
+				createdAt: true,
+				shiftOccurrence: {
+					select: {
+						id: true,
+						timestamp: true,
+						shiftSchedule: {
+							select: {
+								id: true,
+								dayOfWeek: true,
+								startTime: true,
+								endTime: true,
+								shiftType: {
+									select: {
+										id: true,
+										name: true,
+										location: true,
+										color: true,
+										icon: true,
+										period: {
+											select: {
+												id: true,
+												name: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+		prisma.shiftAttendance.count({ where }),
+		computeAttendanceSummary(where),
+	]);
+
+	const droppedStatuses = new Set<ShiftAttendanceStatus>([
+		"dropped" as ShiftAttendanceStatus,
+		"dropped_makeup" as ShiftAttendanceStatus,
+	]);
+
+	const attendancesWithStats = attendances.map((attendanceRecord) => {
+		let timeOnShiftPercentage: number | null = null;
+		let scheduledHours: number | null = null;
+		let actualHours: number | null = null;
+		const isDroppedStatus = droppedStatuses.has(
+			attendanceRecord.status as ShiftAttendanceStatus,
+		);
+		const isUpcomingStatus = attendanceRecord.status === "upcoming";
+
+		if (isDroppedStatus || isUpcomingStatus) {
+			return {
+				...attendanceRecord,
+				scheduledHours,
+				actualHours,
+				timeOnShiftPercentage,
+			};
+		}
+
+		const [startHour, startMinute] =
+			attendanceRecord.shiftOccurrence.shiftSchedule.startTime
+				.split(":")
+				.map(Number);
+		const [endHour, endMinute] =
+			attendanceRecord.shiftOccurrence.shiftSchedule.endTime
+				.split(":")
+				.map(Number);
+		const shiftStart = new Date(attendanceRecord.shiftOccurrence.timestamp);
+		shiftStart.setHours(startHour, startMinute, 0, 0);
+		const shiftEnd = new Date(attendanceRecord.shiftOccurrence.timestamp);
+		shiftEnd.setHours(endHour, endMinute, 0, 0);
+
+		if (shiftEnd < shiftStart) {
+			shiftEnd.setDate(shiftEnd.getDate() + 1);
+		}
+
+		const scheduledDurationMs = shiftEnd.getTime() - shiftStart.getTime();
+		scheduledHours = scheduledDurationMs / (1000 * 60 * 60);
+
+		if (attendanceRecord.timeIn && attendanceRecord.timeOut) {
+			const actualDurationMs =
+				attendanceRecord.timeOut.getTime() - attendanceRecord.timeIn.getTime();
+			actualHours = actualDurationMs / (1000 * 60 * 60);
+
+			if (scheduledHours > 0) {
+				timeOnShiftPercentage =
+					Math.round((actualHours / scheduledHours) * 100 * 100) / 100;
+			}
+		}
+
+		return {
+			...attendanceRecord,
+			scheduledHours: Math.round(scheduledHours * 100) / 100,
+			actualHours: actualHours ? Math.round(actualHours * 100) / 100 : null,
+			timeOnShiftPercentage,
+		};
+	});
+
+	return {
+		attendances: attendancesWithStats,
+		total,
+		stats,
+	};
+}
+
+type AttendanceSummaryRecord = {
+	status: ShiftAttendanceStatus;
+	timeIn: Date | null;
+	timeOut: Date | null;
+	shiftOccurrence: {
+		timestamp: Date;
+		shiftSchedule: {
+			startTime: string;
+			endTime: string;
+		};
+	};
+};
+
+type AttendanceSummaryStats = {
+	attended: number;
+	missed: number;
+	dropped: number;
+	droppedWithMakeup: number;
+	totalScheduledHours: number;
+	totalActualHours: number;
+	attendanceCoveragePercent: number;
+};
+
+async function computeAttendanceSummary(
+	where: Prisma.ShiftAttendanceWhereInput,
+): Promise<AttendanceSummaryStats> {
+	const records: AttendanceSummaryRecord[] =
+		await prisma.shiftAttendance.findMany({
+			where,
+			select: {
+				status: true,
+				timeIn: true,
+				timeOut: true,
+				shiftOccurrence: {
+					select: {
+						timestamp: true,
+						shiftSchedule: {
+							select: {
+								startTime: true,
+								endTime: true,
+							},
+						},
+					},
+				},
+			},
+		});
+
+	return summarizeAttendanceRecords(records);
+}
+
+function summarizeAttendanceRecords(
+	records: AttendanceSummaryRecord[],
+): AttendanceSummaryStats {
+	let attended = 0;
+	let missed = 0;
+	let dropped = 0;
+	let droppedWithMakeup = 0;
+	let totalScheduledHours = 0;
+	let totalActualHours = 0;
+
+	for (const record of records) {
+		switch (record.status) {
+			case "present":
+				attended += 1;
+				break;
+			case "absent":
+				missed += 1;
+				break;
+			case "dropped":
+				dropped += 1;
+				break;
+			case "dropped_makeup":
+				droppedWithMakeup += 1;
+				break;
+			default:
+				break;
+		}
+
+		const shouldCountHours =
+			record.status === "present" || record.status === "absent";
+		if (!shouldCountHours) {
+			continue;
+		}
+
+		const scheduledHours = calculateScheduledHours(record);
+		totalScheduledHours += scheduledHours;
+
+		if (record.timeIn && record.timeOut) {
+			const actualHours =
+				(record.timeOut.getTime() - record.timeIn.getTime()) / (1000 * 60 * 60);
+			totalActualHours += actualHours;
+		}
+	}
+
+	const roundedScheduledHours = Math.round(totalScheduledHours * 100) / 100;
+	const roundedActualHours = Math.round(totalActualHours * 100) / 100;
+	const attendanceCoveragePercent =
+		roundedScheduledHours > 0
+			? Math.round((roundedActualHours / roundedScheduledHours) * 1000) / 10
+			: 0;
+
+	return {
+		attended,
+		missed,
+		dropped,
+		droppedWithMakeup,
+		totalScheduledHours: roundedScheduledHours,
+		totalActualHours: roundedActualHours,
+		attendanceCoveragePercent,
+	};
+}
+
+function calculateScheduledHours(record: AttendanceSummaryRecord) {
+	const [startHour, startMinute] =
+		record.shiftOccurrence.shiftSchedule.startTime.split(":").map(Number);
+	const [endHour, endMinute] = record.shiftOccurrence.shiftSchedule.endTime
+		.split(":")
+		.map(Number);
+	const shiftStart = new Date(record.shiftOccurrence.timestamp);
+	shiftStart.setHours(startHour, startMinute, 0, 0);
+	const shiftEnd = new Date(record.shiftOccurrence.timestamp);
+	shiftEnd.setHours(endHour, endMinute, 0, 0);
+
+	if (shiftEnd < shiftStart) {
+		shiftEnd.setDate(shiftEnd.getDate() + 1);
+	}
+
+	return (shiftEnd.getTime() - shiftStart.getTime()) / (1000 * 60 * 60);
+}

--- a/packages/trpc/server/routers/shiftOccurrences/_route.ts
+++ b/packages/trpc/server/routers/shiftOccurrences/_route.ts
@@ -7,6 +7,7 @@ import { dropHandler, ZDropSchema } from "./drop.route";
 import { dropMakeupHandler, ZDropMakeupSchema } from "./dropMakeup.route";
 import { getHandler, ZGetSchema } from "./get.route";
 import { listHandler, ZListSchema } from "./list.route";
+import { listForUserHandler, ZListForUserSchema } from "./listForUser.route";
 import {
 	listMakeupOptionsHandler,
 	ZListMakeupOptionsSchema,
@@ -19,6 +20,9 @@ export const shiftOccurrencesRouter = router({
 	list: permissionProtectedProcedure("shift_occurrences.list")
 		.input(ZListSchema)
 		.query(listHandler),
+	listForUser: permissionProtectedProcedure("shift_schedules.manipulate")
+		.input(ZListForUserSchema)
+		.query(listForUserHandler),
 	listMy: protectedProcedure.input(ZListMySchema).query(listMyHandler),
 	listMyPast: protectedProcedure
 		.input(ZListMyPastSchema)

--- a/packages/trpc/server/routers/shiftOccurrences/listForUser.route.ts
+++ b/packages/trpc/server/routers/shiftOccurrences/listForUser.route.ts
@@ -1,0 +1,165 @@
+import {
+	assertCanAccessPeriod,
+	computeOccurrenceEnd,
+	getUserWithRoles,
+} from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZListForUserSchema = z.object({
+	periodId: z.number().min(1),
+	userId: z.number().min(1),
+	limit: z.number().min(1).max(100).optional(),
+	offset: z.number().min(0).optional(),
+});
+
+export type TListForUserSchema = z.infer<typeof ZListForUserSchema>;
+
+export type TListForUserOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TListForUserSchema;
+};
+
+export async function listForUserHandler(options: TListForUserOptions) {
+	const { periodId, userId, limit = 50, offset = 0 } = options.input;
+	const now = new Date();
+
+	const actor = await getUserWithRoles(prisma, options.ctx.user.id);
+
+	if (!actor) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "User not found",
+		});
+	}
+
+	const actorRoleIds = new Set(actor.roles.map((role) => role.id));
+
+	const period = await prisma.period.findUnique({
+		where: { id: periodId },
+		include: {
+			roles: { select: { id: true } },
+		},
+	});
+
+	if (!period) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Period not found",
+		});
+	}
+
+	assertCanAccessPeriod(period, actorRoleIds, {
+		isSystemUser: options.ctx.user.isSystemUser,
+	});
+
+	const targetUser = await prisma.user.findUnique({
+		where: { id: userId },
+		include: {
+			roles: { select: { id: true, name: true } },
+		},
+	});
+
+	if (!targetUser) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Target user not found",
+		});
+	}
+
+	const requiredRoleIds = period.roles.map((role) => role.id);
+
+	if (
+		requiredRoleIds.length > 0 &&
+		!targetUser.roles.some((role) => requiredRoleIds.includes(role.id))
+	) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "User is not eligible for this period",
+		});
+	}
+
+	const occurrences = await prisma.shiftOccurrence.findMany({
+		where: {
+			users: {
+				some: { id: userId },
+			},
+			shiftSchedule: {
+				shiftType: {
+					periodId,
+				},
+			},
+			timestamp: {
+				gte: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+			},
+		},
+		include: {
+			shiftSchedule: {
+				include: {
+					shiftType: {
+						include: {
+							period: true,
+						},
+					},
+				},
+			},
+			users: {
+				select: {
+					id: true,
+					name: true,
+				},
+			},
+			attendances: {
+				where: { userId },
+				select: {
+					id: true,
+					status: true,
+					timeIn: true,
+					timeOut: true,
+					didArriveLate: true,
+					didLeaveEarly: true,
+					isMakeup: true,
+					droppedNotes: true,
+				},
+			},
+		},
+		orderBy: { timestamp: "asc" },
+	});
+
+	const mapped = occurrences
+		.map((occurrence) => {
+			const occStart = new Date(occurrence.timestamp);
+			const occEnd = computeOccurrenceEnd(
+				occStart,
+				occurrence.shiftSchedule.startTime,
+				occurrence.shiftSchedule.endTime,
+			);
+
+			return {
+				id: occurrence.id,
+				timestamp: occurrence.timestamp,
+				shiftScheduleId: occurrence.shiftScheduleId,
+				shiftTypeId: occurrence.shiftSchedule.shiftType.id,
+				shiftTypeName: occurrence.shiftSchedule.shiftType.name,
+				shiftTypeLocation: occurrence.shiftSchedule.shiftType.location,
+				shiftTypeColor: occurrence.shiftSchedule.shiftType.color,
+				startTime: occurrence.shiftSchedule.startTime,
+				endTime: occurrence.shiftSchedule.endTime,
+				dayOfWeek: occurrence.shiftSchedule.dayOfWeek,
+				users: occurrence.users,
+				attendance: occurrence.attendances[0] ?? null,
+				occEnd,
+			};
+		})
+		.filter((occurrence) => occurrence.occEnd > now);
+
+	const total = mapped.length;
+	const paginated = mapped.slice(offset, offset + limit);
+
+	return {
+		occurrences: paginated,
+		total,
+	};
+}

--- a/packages/trpc/server/routers/shiftSchedules/_route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/_route.ts
@@ -7,12 +7,28 @@ import { bulkCreateHandler, ZBulkCreateSchema } from "./bulkCreate.route";
 import { bulkDeleteHandler, ZBulkDeleteSchema } from "./bulkDelete.route";
 import { createHandler, ZCreateSchema } from "./create.route";
 import { deleteHandler, ZDeleteSchema } from "./delete.route";
+import {
+	forceRegisterHandler,
+	ZForceRegisterSchema,
+} from "./forceRegister.route";
+import {
+	forceUnregisterHandler,
+	ZForceUnregisterSchema,
+} from "./forceUnregister.route";
 import { getHandler, ZGetSchema } from "./get.route";
 import { listHandler, ZListSchema } from "./list.route";
+import {
+	listEligibleUsersHandler,
+	ZListEligibleUsersSchema,
+} from "./listEligibleUsers.route";
 import {
 	listForRegistrationHandler,
 	ZListForRegistrationSchema,
 } from "./listForRegistration.route";
+import {
+	listForUserManagementHandler,
+	ZListForUserManagementSchema,
+} from "./listForUserManagement.route";
 import {
 	onScheduleUpdateHandler,
 	ZOnScheduleUpdateSchema,
@@ -25,9 +41,17 @@ export const shiftSchedulesRouter = router({
 	list: permissionProtectedProcedure("shift_schedules.list")
 		.input(ZListSchema)
 		.query(listHandler),
+	listEligibleUsers: permissionProtectedProcedure("shift_schedules.manipulate")
+		.input(ZListEligibleUsersSchema)
+		.query(listEligibleUsersHandler),
 	listForRegistration: protectedProcedure
 		.input(ZListForRegistrationSchema)
 		.query(listForRegistrationHandler),
+	listForUserManagement: permissionProtectedProcedure(
+		"shift_schedules.manipulate",
+	)
+		.input(ZListForUserManagementSchema)
+		.query(listForUserManagementHandler),
 	get: permissionProtectedProcedure("shift_schedules.get")
 		.input(ZGetSchema)
 		.query(getHandler),
@@ -46,6 +70,12 @@ export const shiftSchedulesRouter = router({
 	delete: permissionProtectedProcedure("shift_schedules.delete")
 		.input(ZDeleteSchema)
 		.mutation(deleteHandler),
+	forceRegister: permissionProtectedProcedure("shift_schedules.manipulate")
+		.input(ZForceRegisterSchema)
+		.mutation(forceRegisterHandler),
+	forceUnregister: permissionProtectedProcedure("shift_schedules.manipulate")
+		.input(ZForceUnregisterSchema)
+		.mutation(forceUnregisterHandler),
 	register: protectedProcedure.input(ZRegisterSchema).mutation(registerHandler),
 	unregister: protectedProcedure
 		.input(ZUnregisterSchema)

--- a/packages/trpc/server/routers/shiftSchedules/forceRegister.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/forceRegister.route.ts
@@ -1,0 +1,141 @@
+import {
+	assertCanAccessPeriod,
+	assignUserToScheduleOccurrences,
+	getShiftScheduleForRegistration,
+	getUserWithRoles,
+	lockShiftSchedule,
+	shiftScheduleEvents,
+} from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZForceRegisterSchema = z.object({
+	shiftScheduleId: z.number().min(1),
+	userId: z.number().min(1),
+});
+
+export type TForceRegisterSchema = z.infer<typeof ZForceRegisterSchema>;
+
+export type TForceRegisterOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TForceRegisterSchema;
+};
+
+export async function forceRegisterHandler(options: TForceRegisterOptions) {
+	const { shiftScheduleId, userId } = options.input;
+
+	const actor = await getUserWithRoles(prisma, options.ctx.user.id);
+
+	if (!actor) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "User not found",
+		});
+	}
+
+	const actorRoleIds = new Set(actor.roles.map((role) => role.id));
+	let emittedPeriodId = 0;
+
+	await prisma.$transaction(async (tx) => {
+		const isLocked = await lockShiftSchedule(tx, shiftScheduleId);
+
+		if (!isLocked) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Shift schedule not found",
+			});
+		}
+
+		const schedule = await getShiftScheduleForRegistration(tx, shiftScheduleId);
+
+		if (!schedule) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Shift schedule not found",
+			});
+		}
+
+		emittedPeriodId = schedule.shiftType.periodId;
+
+		const period = await tx.period.findUnique({
+			where: { id: schedule.shiftType.periodId },
+			include: {
+				roles: { select: { id: true } },
+			},
+		});
+
+		if (!period) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Period not found",
+			});
+		}
+
+		assertCanAccessPeriod(period, actorRoleIds, {
+			isSystemUser: options.ctx.user.isSystemUser,
+		});
+
+		const targetUser = await tx.user.findUnique({
+			where: { id: userId },
+			include: {
+				roles: { select: { id: true } },
+			},
+		});
+
+		if (!targetUser) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Target user not found",
+			});
+		}
+
+		const requiredRoleIds = period.roles.map((role) => role.id);
+
+		if (
+			requiredRoleIds.length > 0 &&
+			!targetUser.roles.some((role) => requiredRoleIds.includes(role.id))
+		) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "User is not eligible for this period",
+			});
+		}
+
+		if (schedule.users.some((user) => user.id === userId)) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "User is already registered for this shift",
+			});
+		}
+
+		if (schedule.users.length >= schedule.slots) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "All slots for this shift schedule are filled",
+			});
+		}
+
+		await tx.shiftSchedule.update({
+			where: { id: shiftScheduleId },
+			data: {
+				users: {
+					connect: { id: userId },
+				},
+			},
+		});
+
+		await assignUserToScheduleOccurrences(tx, shiftScheduleId, userId);
+	});
+
+	shiftScheduleEvents.emitUpdate({
+		type: "register",
+		shiftScheduleId,
+		userId,
+		periodId: emittedPeriodId,
+		timestamp: new Date(),
+	});
+
+	return { success: true };
+}

--- a/packages/trpc/server/routers/shiftSchedules/forceUnregister.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/forceUnregister.route.ts
@@ -1,0 +1,119 @@
+import {
+	assertCanAccessPeriod,
+	getShiftScheduleForRegistration,
+	getUserWithRoles,
+	lockShiftSchedule,
+	shiftScheduleEvents,
+	unassignUserFromScheduleOccurrences,
+} from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZForceUnregisterSchema = z.object({
+	shiftScheduleId: z.number().min(1),
+	userId: z.number().min(1),
+});
+
+export type TForceUnregisterSchema = z.infer<typeof ZForceUnregisterSchema>;
+
+export type TForceUnregisterOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TForceUnregisterSchema;
+};
+
+export async function forceUnregisterHandler(options: TForceUnregisterOptions) {
+	const { shiftScheduleId, userId } = options.input;
+
+	const actor = await getUserWithRoles(prisma, options.ctx.user.id);
+
+	if (!actor) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "User not found",
+		});
+	}
+
+	const actorRoleIds = new Set(actor.roles.map((role) => role.id));
+	let emittedPeriodId = 0;
+
+	await prisma.$transaction(async (tx) => {
+		const isLocked = await lockShiftSchedule(tx, shiftScheduleId);
+
+		if (!isLocked) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Shift schedule not found",
+			});
+		}
+
+		const schedule = await getShiftScheduleForRegistration(tx, shiftScheduleId);
+
+		if (!schedule) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Shift schedule not found",
+			});
+		}
+
+		emittedPeriodId = schedule.shiftType.periodId;
+
+		const period = await tx.period.findUnique({
+			where: { id: schedule.shiftType.periodId },
+			include: {
+				roles: { select: { id: true } },
+			},
+		});
+
+		if (!period) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Period not found",
+			});
+		}
+
+		assertCanAccessPeriod(period, actorRoleIds, {
+			isSystemUser: options.ctx.user.isSystemUser,
+		});
+
+		const targetUser = await tx.user.findUnique({
+			where: { id: userId },
+		});
+
+		if (!targetUser) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Target user not found",
+			});
+		}
+
+		if (!schedule.users.some((user) => user.id === userId)) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "User is not registered for this shift",
+			});
+		}
+
+		await unassignUserFromScheduleOccurrences(tx, shiftScheduleId, userId);
+
+		await tx.shiftSchedule.update({
+			where: { id: shiftScheduleId },
+			data: {
+				users: {
+					disconnect: { id: userId },
+				},
+			},
+		});
+	});
+
+	shiftScheduleEvents.emitUpdate({
+		type: "unregister",
+		shiftScheduleId,
+		userId,
+		periodId: emittedPeriodId,
+		timestamp: new Date(),
+	});
+
+	return { success: true };
+}

--- a/packages/trpc/server/routers/shiftSchedules/listEligibleUsers.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/listEligibleUsers.route.ts
@@ -1,0 +1,101 @@
+import { assertCanAccessPeriod, getUserWithRoles } from "@ecehive/features";
+import { type Prisma, prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZListEligibleUsersSchema = z.object({
+	periodId: z.number().min(1),
+	search: z.string().min(1).max(100).optional(),
+	limit: z.number().min(1).max(100).optional(),
+});
+
+export type TListEligibleUsersSchema = z.infer<typeof ZListEligibleUsersSchema>;
+
+export type TListEligibleUsersOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TListEligibleUsersSchema;
+};
+
+export async function listEligibleUsersHandler(
+	options: TListEligibleUsersOptions,
+) {
+	const { periodId, search, limit = 25 } = options.input;
+
+	const actor = await getUserWithRoles(prisma, options.ctx.user.id);
+
+	if (!actor) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "User not found",
+		});
+	}
+
+	const actorRoleIds = new Set(actor.roles.map((role) => role.id));
+
+	const period = await prisma.period.findUnique({
+		where: { id: periodId },
+		include: {
+			roles: {
+				select: { id: true },
+			},
+		},
+	});
+
+	if (!period) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Period not found",
+		});
+	}
+
+	assertCanAccessPeriod(period, actorRoleIds, {
+		isSystemUser: options.ctx.user.isSystemUser,
+	});
+
+	const periodRoleIds = period.roles.map((role) => role.id);
+
+	const where: Prisma.UserWhereInput = {};
+	const andFilters: Prisma.UserWhereInput[] = [];
+
+	if (periodRoleIds.length > 0) {
+		andFilters.push({
+			roles: {
+				some: {
+					id: { in: periodRoleIds },
+				},
+			},
+		});
+	}
+
+	if (search) {
+		andFilters.push({
+			OR: [
+				{ name: { contains: search, mode: "insensitive" } },
+				{ username: { contains: search, mode: "insensitive" } },
+				{ email: { contains: search, mode: "insensitive" } },
+			],
+		});
+	}
+
+	if (andFilters.length > 0) {
+		where.AND = andFilters;
+	}
+
+	const users = await prisma.user.findMany({
+		where,
+		orderBy: [{ name: "asc" }],
+		take: limit,
+		include: {
+			roles: {
+				select: { id: true, name: true },
+			},
+		},
+	});
+
+	return {
+		users,
+		periodRoleIds,
+		isRoleRestricted: periodRoleIds.length > 0,
+	};
+}

--- a/packages/trpc/server/routers/shiftSchedules/listForUserManagement.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/listForUserManagement.route.ts
@@ -1,0 +1,126 @@
+import {
+	assertCanAccessPeriod,
+	getShiftSchedulesForListing,
+	getUserWithRoles,
+} from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZListForUserManagementSchema = z.object({
+	periodId: z.number().min(1),
+	userId: z.number().min(1),
+	dayOfWeek: z.number().min(0).max(6).optional(),
+});
+
+export type TListForUserManagementSchema = z.infer<
+	typeof ZListForUserManagementSchema
+>;
+
+export type TListForUserManagementOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TListForUserManagementSchema;
+};
+
+export async function listForUserManagementHandler(
+	options: TListForUserManagementOptions,
+) {
+	const { periodId, userId, dayOfWeek } = options.input;
+
+	const actor = await getUserWithRoles(prisma, options.ctx.user.id);
+
+	if (!actor) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "User not found",
+		});
+	}
+
+	const actorRoleIds = new Set(actor.roles.map((role) => role.id));
+
+	const period = await prisma.period.findUnique({
+		where: { id: periodId },
+		include: {
+			roles: { select: { id: true } },
+		},
+	});
+
+	if (!period) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Period not found",
+		});
+	}
+
+	assertCanAccessPeriod(period, actorRoleIds, {
+		isSystemUser: options.ctx.user.isSystemUser,
+	});
+
+	const targetUser = await prisma.user.findUnique({
+		where: { id: userId },
+		include: {
+			roles: {
+				select: { id: true, name: true },
+			},
+		},
+	});
+
+	if (!targetUser) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Target user not found",
+		});
+	}
+
+	const requiredRoleIds = period.roles.map((role) => role.id);
+
+	if (
+		requiredRoleIds.length > 0 &&
+		!targetUser.roles.some((role) => requiredRoleIds.includes(role.id))
+	) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "User is not eligible for this period",
+		});
+	}
+
+	const schedules = await getShiftSchedulesForListing(prisma, {
+		shiftType: { periodId },
+		...(dayOfWeek !== undefined ? { dayOfWeek } : {}),
+	});
+
+	const scheduleSummaries = schedules.map((schedule) => {
+		const assignedUsers = schedule.users.length;
+		const isRegistered = schedule.users.some((user) => user.id === userId);
+		const availableSlots = schedule.slots - assignedUsers;
+
+		return {
+			id: schedule.id,
+			shiftTypeId: schedule.shiftTypeId,
+			shiftTypeName: schedule.shiftType.name,
+			shiftTypeColor: schedule.shiftType.color,
+			shiftTypeLocation: schedule.shiftType.location,
+			dayOfWeek: schedule.dayOfWeek,
+			startTime: schedule.startTime,
+			endTime: schedule.endTime,
+			slots: schedule.slots,
+			assignedUserCount: assignedUsers,
+			availableSlots,
+			isRegistered,
+		};
+	});
+
+	return {
+		period: {
+			id: period.id,
+			name: period.name,
+		},
+		user: {
+			id: targetUser.id,
+			name: targetUser.name ?? targetUser.username,
+			roles: targetUser.roles,
+		},
+		schedules: scheduleSummaries,
+	};
+}


### PR DESCRIPTION
This pull request introduces a new "Manage Users" feature to shift scheduling, allowing admins with the appropriate permissions to view and manage user shifts. It adds the necessary UI components, updates routing and permissions logic, and ensures that only authorized users can access the new functionality.