### PR TITLE
Fix shift schedule timeline limit

### DIFF
--- a/apps/client/src/components/shift-schedules/shift-schedule-timeline-view.tsx
+++ b/apps/client/src/components/shift-schedules/shift-schedule-timeline-view.tsx
@@ -216,7 +216,7 @@ export function ShiftScheduleTimelineView({
 			return trpc.shiftSchedules.list.query({
 				periodId,
 				dayOfWeek: selectedDay,
-				limit: 100,
+				limit: 1000,
 			});
 		},
 	});

--- a/packages/trpc/server/routers/shiftSchedules/get.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/get.route.ts
@@ -14,8 +14,6 @@ export type TGetOptions = {
 export async function getHandler(options: TGetOptions) {
 	const { id } = options.input;
 
-	console.log("Fetching shift schedule with ID:", id);
-
 	const shiftSchedule = await prisma.shiftSchedule.findUnique({
 		where: { id },
 		include: {

--- a/packages/trpc/server/routers/shiftSchedules/get.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/get.route.ts
@@ -14,6 +14,8 @@ export type TGetOptions = {
 export async function getHandler(options: TGetOptions) {
 	const { id } = options.input;
 
+	console.log("Fetching shift schedule with ID:", id);
+
 	const shiftSchedule = await prisma.shiftSchedule.findUnique({
 		where: { id },
 		include: {

--- a/packages/trpc/server/routers/shiftSchedules/list.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/list.route.ts
@@ -3,7 +3,7 @@ import z from "zod";
 import type { TPermissionProtectedProcedureContext } from "../../trpc";
 
 export const ZListSchema = z.object({
-	limit: z.number().min(1).max(100).optional(),
+	limit: z.number().min(1).max(1000).optional(),
 	offset: z.number().min(0).optional(),
 	shiftTypeId: z.number().min(1).optional(),
 	periodId: z.number().min(1).optional(),


### PR DESCRIPTION
Addresses #73 by increasing the query limit to 1000. Pagination was not removed entirely because the data table view in shift schedules still requires it. 1000 shifts should be well over the number any individual day would contain.