### PR TITLE
Fix sorting of shift schedules

### DIFF
--- a/apps/client/src/components/shift-schedules/scheduling-timeline.tsx
+++ b/apps/client/src/components/shift-schedules/scheduling-timeline.tsx
@@ -239,11 +239,33 @@ function groupSchedulesByDayAndTimeBlock(
 	return blocks;
 }
 
+function compareShiftSchedules(a: ShiftSchedule, b: ShiftSchedule) {
+	const nameCompare = a.shiftTypeName.localeCompare(b.shiftTypeName);
+	if (nameCompare !== 0) return nameCompare;
+
+	const locationCompare = (a.shiftTypeLocation ?? "").localeCompare(
+		b.shiftTypeLocation ?? "",
+	);
+	if (locationCompare !== 0) return locationCompare;
+
+	const dayCompare = a.dayOfWeek - b.dayOfWeek;
+	if (dayCompare !== 0) return dayCompare;
+
+	const timeCompare = a.startTime.localeCompare(b.startTime);
+	if (timeCompare !== 0) return timeCompare;
+
+	return a.id - b.id;
+}
+
 export function SchedulingTimeline({
 	schedules,
 	isLoading,
 	onBlockClick,
 }: SchedulingTimelineProps) {
+	const sortedSchedules = React.useMemo(
+		() => [...schedules].sort(compareShiftSchedules),
+		[schedules],
+	);
 	if (isLoading) {
 		return (
 			<div className="flex items-center justify-center py-12">
@@ -257,14 +279,14 @@ export function SchedulingTimeline({
 	}
 
 	// Calculate optimal block size
-	const blockSize = calculateBlockSize(schedules);
+	const blockSize = calculateBlockSize(sortedSchedules);
 
 	// Group schedules by day and time block
-	const blocks = groupSchedulesByDayAndTimeBlock(schedules, blockSize);
+	const blocks = groupSchedulesByDayAndTimeBlock(sortedSchedules, blockSize);
 
 	// Determine which days actually have shift schedules
 	const daysWithSchedules = new Set(
-		schedules.map((schedule) => schedule.dayOfWeek),
+		sortedSchedules.map((schedule) => schedule.dayOfWeek),
 	);
 	const visibleDays = DAYS_OF_WEEK.filter((day) =>
 		daysWithSchedules.has(day.value),

--- a/apps/client/src/components/shift-schedules/shift-detail-sheet.tsx
+++ b/apps/client/src/components/shift-schedules/shift-detail-sheet.tsx
@@ -1,6 +1,7 @@
 import { trpc } from "@ecehive/trpc/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ClockIcon, MapPinIcon } from "lucide-react";
+import { useMemo } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -57,6 +58,24 @@ const DAYS_OF_WEEK = [
 	"Saturday",
 ];
 
+function compareShiftSchedules(a: ShiftSchedule, b: ShiftSchedule) {
+	const nameCompare = a.shiftTypeName.localeCompare(b.shiftTypeName);
+	if (nameCompare !== 0) return nameCompare;
+
+	const locationCompare = (a.shiftTypeLocation ?? "").localeCompare(
+		b.shiftTypeLocation ?? "",
+	);
+	if (locationCompare !== 0) return locationCompare;
+
+	const dayCompare = a.dayOfWeek - b.dayOfWeek;
+	if (dayCompare !== 0) return dayCompare;
+
+	const timeCompare = a.startTime.localeCompare(b.startTime);
+	if (timeCompare !== 0) return timeCompare;
+
+	return a.id - b.id;
+}
+
 export function ShiftDetailSheet({
 	open,
 	onOpenChange,
@@ -67,6 +86,10 @@ export function ShiftDetailSheet({
 	isWithinSignupWindow = true,
 }: ShiftDetailSheetProps) {
 	const queryClient = useQueryClient();
+	const sortedSchedules = useMemo(
+		() => [...schedules].sort(compareShiftSchedules),
+		[schedules],
+	);
 
 	const registerMutation = useMutation({
 		mutationFn: async (shiftScheduleId: number) => {
@@ -117,169 +140,160 @@ export function ShiftDetailSheet({
 				</SheetHeader>
 
 				<div className="space-y-6 p-4">
-					{schedules
-						.sort((a, b) => a.shiftTypeName.localeCompare(b.shiftTypeName))
-						.map((schedule) => (
-							<div
-								key={schedule.id}
-								className="border rounded-lg p-4 space-y-3"
-							>
-								<div className="flex items-start justify-between gap-4">
-									<div className="flex-1 space-y-2">
-										<div className="flex items-center gap-2">
-											<h3 className="font-semibold text-lg">
-												{schedule.shiftTypeName}
-											</h3>
-											{schedule.shiftTypeColor && (
-												<div
-													className="w-4 h-4 rounded-full border"
-													style={{ backgroundColor: schedule.shiftTypeColor }}
-												/>
-											)}
-										</div>
-
-										<div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
-											<div className="flex items-center gap-1">
-												<ClockIcon className="w-4 h-4" />
-												<span>
-													{formatTimeRange(
-														schedule.startTime,
-														schedule.endTime,
-													)}
-												</span>
-											</div>
-											<div className="flex items-center gap-1">
-												<MapPinIcon className="w-4 h-4" />
-												<span>{schedule.shiftTypeLocation}</span>
-											</div>
-										</div>
+					{sortedSchedules.map((schedule) => (
+						<div key={schedule.id} className="border rounded-lg p-4 space-y-3">
+							<div className="flex items-start justify-between gap-4">
+								<div className="flex-1 space-y-2">
+									<div className="flex items-center gap-2">
+										<h3 className="font-semibold text-lg">
+											{schedule.shiftTypeName}
+										</h3>
+										{schedule.shiftTypeColor && (
+											<div
+												className="w-4 h-4 rounded-full border"
+												style={{ backgroundColor: schedule.shiftTypeColor }}
+											/>
+										)}
 									</div>
 
-									<div className="flex flex-col items-end gap-2">
-										{schedule.isRegistered ? (
-											<Button
-												size="sm"
-												variant="destructive"
-												onClick={() => unregisterMutation.mutate(schedule.id)}
-												disabled={
-													unregisterMutation.isPending ||
-													!schedule.canUnregister
-												}
-											>
-												{unregisterMutation.isPending ? (
-													<Spinner className="w-4 h-4" />
-												) : (
-													"Unregister"
-												)}
-											</Button>
-										) : schedule.canRegister ? (
-											<Button
-												size="sm"
-												onClick={() => registerMutation.mutate(schedule.id)}
-												disabled={registerMutation.isPending}
-											>
-												{registerMutation.isPending ? (
-													<Spinner className="w-4 h-4" />
-												) : (
-													"Register"
-												)}
-											</Button>
-										) : (
-											<Button size="sm" variant="secondary" disabled>
-												Unavailable
-											</Button>
-										)}
+									<div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+										<div className="flex items-center gap-1">
+											<ClockIcon className="w-4 h-4" />
+											<span>
+												{formatTimeRange(schedule.startTime, schedule.endTime)}
+											</span>
+										</div>
+										<div className="flex items-center gap-1">
+											<MapPinIcon className="w-4 h-4" />
+											<span>{schedule.shiftTypeLocation}</span>
+										</div>
 									</div>
 								</div>
 
-								<div className="pt-3 border-t">
-									<div className="text-sm font-medium mb-2">
-										Slots ({schedule.slots - schedule.availableSlots} /{" "}
-										{schedule.slots} filled)
-									</div>
-									<div className="flex flex-col gap-2">
-										{Array.from({ length: schedule.slots }, (_, i) => {
-											const isFilled =
-												i < schedule.slots - schedule.availableSlots;
-											return (
-												<div
-													key={i}
-													className={cn(
-														"px-3 py-2 rounded-md text-sm flex flex-row items-center justify-between",
-														isFilled
-															? "bg-muted text-muted-foreground"
-															: "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300",
-													)}
-												>
-													{isFilled ? (
-														<span>{schedule.users[i]?.name}</span>
-													) : (
-														<span>Available Slot</span>
-													)}
-												</div>
-											);
-										})}
-									</div>
+								<div className="flex flex-col items-end gap-2">
+									{schedule.isRegistered ? (
+										<Button
+											size="sm"
+											variant="destructive"
+											onClick={() => unregisterMutation.mutate(schedule.id)}
+											disabled={
+												unregisterMutation.isPending || !schedule.canUnregister
+											}
+										>
+											{unregisterMutation.isPending ? (
+												<Spinner className="w-4 h-4" />
+											) : (
+												"Unregister"
+											)}
+										</Button>
+									) : schedule.canRegister ? (
+										<Button
+											size="sm"
+											onClick={() => registerMutation.mutate(schedule.id)}
+											disabled={registerMutation.isPending}
+										>
+											{registerMutation.isPending ? (
+												<Spinner className="w-4 h-4" />
+											) : (
+												"Register"
+											)}
+										</Button>
+									) : (
+										<Button size="sm" variant="secondary" disabled>
+											Unavailable
+										</Button>
+									)}
 								</div>
-
-								{!schedule.canRegister && !schedule.isRegistered && (
-									<div className="pt-3 border-t space-y-1">
-										<div className="text-sm font-medium text-muted-foreground">
-											Why can't I register?
-										</div>
-										<ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
-											{!isWithinSignupWindow && (
-												<li>Registration is outside the signup window</li>
-											)}
-											{!schedule.canSelfAssign && (
-												<li>
-													Self-assignment is not allowed for this shift type
-												</li>
-											)}
-											{!schedule.meetsRoleRequirement && (
-												<li>You don't have the required role(s)</li>
-											)}
-											{!schedule.meetsBalancingRequirement && (
-												<li>
-													Registration is limited due to balancing restrictions
-												</li>
-											)}
-											{schedule.availableSlots === 0 && (
-												<li>All slots are filled</li>
-											)}
-											{schedule.hasTimeOverlap && (
-												<li>
-													This shift overlaps with another shift you are already
-													registered for
-												</li>
-											)}
-											{schedule.blockedByMaxRequirement && (
-												<li>
-													You have reached the maximum allowed for this period
-												</li>
-											)}
-										</ul>
-									</div>
-								)}
-
-								{schedule.isRegistered && (
-									<>
-										<Badge variant="default" className="w-fit">
-											You are registered for this shift
-										</Badge>
-										{!schedule.canUnregister && (
-											<div className="text-sm text-muted-foreground">
-												{!schedule.canSelfAssign
-													? "Note: An administrator must unassign you from this shift."
-													: !isWithinSignupWindow
-														? "Note: Unregistration is outside the signup window."
-														: "Note: You cannot unregister from this shift at this time."}
-											</div>
-										)}
-									</>
-								)}
 							</div>
-						))}
+
+							<div className="pt-3 border-t">
+								<div className="text-sm font-medium mb-2">
+									Slots ({schedule.slots - schedule.availableSlots} /{" "}
+									{schedule.slots} filled)
+								</div>
+								<div className="flex flex-col gap-2">
+									{Array.from({ length: schedule.slots }, (_, i) => {
+										const isFilled =
+											i < schedule.slots - schedule.availableSlots;
+										return (
+											<div
+												key={i}
+												className={cn(
+													"px-3 py-2 rounded-md text-sm flex flex-row items-center justify-between",
+													isFilled
+														? "bg-muted text-muted-foreground"
+														: "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300",
+												)}
+											>
+												{isFilled ? (
+													<span>{schedule.users[i]?.name}</span>
+												) : (
+													<span>Available Slot</span>
+												)}
+											</div>
+										);
+									})}
+								</div>
+							</div>
+
+							{!schedule.canRegister && !schedule.isRegistered && (
+								<div className="pt-3 border-t space-y-1">
+									<div className="text-sm font-medium text-muted-foreground">
+										Why can't I register?
+									</div>
+									<ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
+										{!isWithinSignupWindow && (
+											<li>Registration is outside the signup window</li>
+										)}
+										{!schedule.canSelfAssign && (
+											<li>
+												Self-assignment is not allowed for this shift type
+											</li>
+										)}
+										{!schedule.meetsRoleRequirement && (
+											<li>You don't have the required role(s)</li>
+										)}
+										{!schedule.meetsBalancingRequirement && (
+											<li>
+												Registration is limited due to balancing restrictions
+											</li>
+										)}
+										{schedule.availableSlots === 0 && (
+											<li>All slots are filled</li>
+										)}
+										{schedule.hasTimeOverlap && (
+											<li>
+												This shift overlaps with another shift you are already
+												registered for
+											</li>
+										)}
+										{schedule.blockedByMaxRequirement && (
+											<li>
+												You have reached the maximum allowed for this period
+											</li>
+										)}
+									</ul>
+								</div>
+							)}
+
+							{schedule.isRegistered && (
+								<>
+									<Badge variant="default" className="w-fit">
+										You are registered for this shift
+									</Badge>
+									{!schedule.canUnregister && (
+										<div className="text-sm text-muted-foreground">
+											{!schedule.canSelfAssign
+												? "Note: An administrator must unassign you from this shift."
+												: !isWithinSignupWindow
+													? "Note: Unregistration is outside the signup window."
+													: "Note: You cannot unregister from this shift at this time."}
+										</div>
+									)}
+								</>
+							)}
+						</div>
+					))}
 				</div>
 			</SheetContent>
 		</Sheet>

--- a/apps/client/src/components/shift-schedules/shift-schedule-timeline-view.tsx
+++ b/apps/client/src/components/shift-schedules/shift-schedule-timeline-view.tsx
@@ -41,6 +41,7 @@ interface ShiftTypeInfo {
 	id: number;
 	name: string;
 	color: string | null;
+	location: string | null;
 }
 
 interface TimelineItem {
@@ -145,9 +146,25 @@ function sortSchedulesWithTypes(
 		shiftType: ShiftTypeInfo;
 	}>;
 
-	return withTypes.sort((a, b) =>
-		a.shiftType.name.localeCompare(b.shiftType.name),
-	);
+	return withTypes.sort((a, b) => {
+		const nameCompare = a.shiftType.name.localeCompare(b.shiftType.name);
+		if (nameCompare !== 0) return nameCompare;
+
+		const locationA = a.shiftType.location ?? "";
+		const locationB = b.shiftType.location ?? "";
+		const locationCompare = locationA.localeCompare(locationB);
+		if (locationCompare !== 0) return locationCompare;
+
+		const dayCompare = a.schedule.dayOfWeek - b.schedule.dayOfWeek;
+		if (dayCompare !== 0) return dayCompare;
+
+		const timeCompare = a.schedule.startTime.localeCompare(
+			b.schedule.startTime,
+		);
+		if (timeCompare !== 0) return timeCompare;
+
+		return a.schedule.id - b.schedule.id;
+	});
 }
 
 /**
@@ -240,7 +257,7 @@ export function ShiftScheduleTimelineView({
 	const shiftTypesMap = new Map<number, ShiftTypeInfo>(
 		shiftTypes.map((st) => [
 			st.id,
-			{ id: st.id, name: st.name, color: st.color },
+			{ id: st.id, name: st.name, color: st.color, location: st.location },
 		]),
 	);
 

--- a/packages/features/src/shift-schedules/queries.ts
+++ b/packages/features/src/shift-schedules/queries.ts
@@ -100,7 +100,12 @@ export async function getShiftSchedulesForListing(
 				select: { id: true, name: true },
 			},
 		},
-		orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }],
+		orderBy: [
+			{ shiftType: { name: "asc" } },
+			{ shiftType: { location: "asc" } },
+			{ dayOfWeek: "asc" },
+			{ startTime: "asc" },
+		],
 	});
 }
 

--- a/packages/trpc/server/routers/shiftSchedules/list.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/list.route.ts
@@ -48,7 +48,12 @@ export async function listHandler(options: TListOptions) {
 					select: { users: true },
 				},
 			},
-			orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }],
+			orderBy: [
+				{ shiftType: { name: "asc" } },
+				{ shiftType: { location: "asc" } },
+				{ dayOfWeek: "asc" },
+				{ startTime: "asc" },
+			],
 			skip: offset,
 			take: limit,
 		}),


### PR DESCRIPTION
Fix sorting of shift schedules on the shift schedule creation page and shift scheduling page.

It will now always sort by (in order):
1. Name
2. Location
3. Day
4. Time