### PR TITLE
Require AUTH_SECRET to be defined

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,6 +26,9 @@ DB_PASSWORD=changeme
 # Authentication
 # =============================================================================
 
+# Auth secret (should be a long random string)
+AUTH_SECRET=longrandomsecretstring
+
 # Comma-separated list of system administrator usernames
 SYSTEM_USERS=admin,user1,user2
 

--- a/apps/server/.env.sample
+++ b/apps/server/.env.sample
@@ -25,6 +25,9 @@ DB_PASSWORD=changeme
 # Authentication
 # =============================================================================
 
+# Auth secret (should be a long random string)
+AUTH_SECRET=your_long_random_secret_string_here
+
 # Comma-separated list of system administrator usernames
 SYSTEM_USERS=admin,user1,user2
 

--- a/packages/env/src/schema.ts
+++ b/packages/env/src/schema.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import z from "zod";
 
 const BaseEnvSchema = z.object({
@@ -7,12 +6,10 @@ const BaseEnvSchema = z.object({
 		.default("development"),
 	PORT: z.coerce.number().default(44830),
 	DATABASE_URL: z.url(),
-	AUTH_SECRET: z
-		.string()
-		.transform((val) => {
-			const buffer = Buffer.from(val);
-			return new Uint8Array(buffer);
-		}),
+	AUTH_SECRET: z.string().transform((val) => {
+		const buffer = Buffer.from(val);
+		return new Uint8Array(buffer);
+	}),
 	AUTH_PROVIDER: z.enum(["CAS", "CAS_PROXIED"]).default("CAS_PROXIED"),
 	AUTH_CAS_SERVER: z.url(),
 	AUTH_CAS_LOGIN_URL: z.string().url().optional(),

--- a/packages/env/src/schema.ts
+++ b/packages/env/src/schema.ts
@@ -9,7 +9,6 @@ const BaseEnvSchema = z.object({
 	DATABASE_URL: z.url(),
 	AUTH_SECRET: z
 		.string()
-		.default(crypto.randomBytes(64).toString("utf8"))
 		.transform((val) => {
 			const buffer = Buffer.from(val);
 			return new Uint8Array(buffer);


### PR DESCRIPTION
The default AUTH_SECRET is currently `crypto.randomBytes(64).toString("utf8")`. Random bytes rarely map cleanly to UTF-8, so we lose entropy via replacement characters, and the secret is regenerated on every process start if unset. That means tokens become invalid after a restart and multi-instance setups (if we choose to do this in the future) can’t validate each other. Requiring an AUTH_SECRET to be defined mitigates these problems.