### PR TITLE
Add configuration management

### DIFF
--- a/apps/client/src/components/config/config-field.tsx
+++ b/apps/client/src/components/config/config-field.tsx
@@ -1,0 +1,221 @@
+import { RotateCcwIcon } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+interface ConfigFieldDef {
+	key: string;
+	label: string;
+	description?: string;
+	type: string;
+	defaultValue: unknown;
+	options?: { value: string; label: string }[];
+	placeholder?: string;
+	min?: number;
+	max?: number;
+	step?: number;
+	required?: boolean;
+}
+
+interface ConfigFieldProps {
+	field: ConfigFieldDef;
+	value: unknown;
+	canWrite: boolean;
+	isSaving: boolean;
+	onChange: (value: unknown) => void;
+	onReset: () => void;
+}
+
+export function ConfigField({
+	field,
+	value,
+	canWrite,
+	isSaving,
+	onChange,
+	onReset,
+}: ConfigFieldProps) {
+	// For number fields, track the string representation to allow empty inputs
+	const [inputValue, setInputValue] = useState(() =>
+		field.type === "number" ? String(value) : value,
+	);
+
+	// Update when the value prop changes from external sources (save/reset)
+	useEffect(() => {
+		if (field.type === "number") {
+			setInputValue(String(value));
+		} else {
+			setInputValue(value);
+		}
+	}, [value, field.type]);
+
+	// Get the actual value to compare and save
+	const getCurrentValue = useCallback(() => {
+		if (field.type === "number") {
+			const num = Number(inputValue);
+			return Number.isNaN(num) ? value : num;
+		}
+		return inputValue;
+	}, [field.type, inputValue, value]);
+
+	// Check if current value differs from default
+	const currentValue = getCurrentValue();
+	const isDifferentFromDefault = currentValue !== field.defaultValue;
+
+	const handleChange = useCallback(
+		(newValue: unknown) => {
+			setInputValue(newValue);
+			// Notify parent of value change
+			if (field.type === "number") {
+				const num = Number(newValue);
+				if (!Number.isNaN(num)) {
+					onChange(num);
+				}
+			} else {
+				onChange(newValue);
+			}
+		},
+		[field.type, onChange],
+	);
+
+	const handleReset = useCallback(() => {
+		onReset();
+	}, [onReset]);
+
+	const renderInput = () => {
+		switch (field.type) {
+			case "boolean":
+				return (
+					<div className="flex items-center gap-2">
+						<Checkbox
+							id={field.key}
+							checked={inputValue as boolean}
+							onCheckedChange={handleChange}
+							disabled={!canWrite || isSaving}
+						/>
+						<label
+							htmlFor={field.key}
+							className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+						>
+							{field.label}
+						</label>
+					</div>
+				);
+
+			case "number":
+				return (
+					<Input
+						type="number"
+						value={inputValue as string}
+						onChange={(e) => handleChange(e.target.value)}
+						placeholder={field.placeholder}
+						min={field.min}
+						max={field.max}
+						step={field.step}
+						disabled={!canWrite || isSaving}
+					/>
+				);
+
+			case "select":
+				return (
+					<Select
+						value={String(inputValue)}
+						onValueChange={handleChange}
+						disabled={!canWrite || isSaving}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder={field.placeholder || "Select..."} />
+						</SelectTrigger>
+						<SelectContent>
+							{field.options?.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				);
+
+			case "textarea":
+				return (
+					<Textarea
+						value={inputValue as string}
+						onChange={(e) => handleChange(e.target.value)}
+						placeholder={field.placeholder}
+						disabled={!canWrite || isSaving}
+						rows={4}
+					/>
+				);
+
+			default:
+				return (
+					<Input
+						type="text"
+						value={inputValue as string}
+						onChange={(e) => handleChange(e.target.value)}
+						placeholder={field.placeholder}
+						disabled={!canWrite || isSaving}
+					/>
+				);
+		}
+	};
+
+	// For boolean fields, we render differently
+	if (field.type === "boolean") {
+		return (
+			<div className="flex items-center justify-between gap-4">
+				<div className="flex-1">
+					{renderInput()}
+					{field.description && (
+						<FieldDescription className="mt-1.5">
+							{field.description}
+						</FieldDescription>
+					)}
+				</div>
+				{canWrite && isDifferentFromDefault && (
+					<Button
+						size="sm"
+						variant="ghost"
+						onClick={handleReset}
+						disabled={isSaving}
+						title="Reset to default"
+					>
+						<RotateCcwIcon className="h-4 w-4" />
+					</Button>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<Field>
+			<FieldLabel>{field.label}</FieldLabel>
+			{field.description && (
+				<FieldDescription>{field.description}</FieldDescription>
+			)}
+			<div className="flex items-center gap-2 mt-2">
+				<div className="flex-1">{renderInput()}</div>
+				{canWrite && isDifferentFromDefault && (
+					<Button
+						size="sm"
+						variant="ghost"
+						onClick={handleReset}
+						disabled={isSaving}
+						title="Reset to default"
+					>
+						<RotateCcwIcon className="h-4 w-4" />
+					</Button>
+				)}
+			</div>
+		</Field>
+	);
+}

--- a/apps/client/src/components/config/config-group.tsx
+++ b/apps/client/src/components/config/config-group.tsx
@@ -1,0 +1,91 @@
+import { Clock as ClockIcon, Settings as SettingsIcon } from "lucide-react";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { ConfigField } from "./config-field";
+
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+	Clock: ClockIcon,
+	Settings: SettingsIcon,
+};
+
+interface ConfigFieldDef {
+	key: string;
+	label: string;
+	description?: string;
+	type: string;
+	defaultValue: unknown;
+	options?: { value: string; label: string }[];
+	placeholder?: string;
+	min?: number;
+	max?: number;
+	step?: number;
+	required?: boolean;
+}
+
+interface ConfigGroupDef {
+	id: string;
+	label: string;
+	description?: string;
+	icon?: string;
+	fields: ConfigFieldDef[];
+}
+
+interface ConfigGroupProps {
+	group: ConfigGroupDef;
+	values: Record<string, unknown>;
+	canWrite: boolean;
+	savingKeys: Set<string>;
+	shouldShowField: (field: ConfigFieldDef) => boolean;
+	onChange: (key: string, value: unknown) => void;
+	onReset: (key: string) => void;
+}
+
+export function ConfigGroup({
+	group,
+	values,
+	canWrite,
+	savingKeys,
+	shouldShowField,
+	onChange,
+	onReset,
+}: ConfigGroupProps) {
+	// Get icon component if specified
+	const IconComponent = group.icon ? iconMap[group.icon] : null;
+
+	// Filter fields based on conditional logic
+	const visibleFields = group.fields.filter(shouldShowField);
+
+	if (visibleFields.length === 0) return null;
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2">
+					{IconComponent && <IconComponent className="h-5 w-5" />}
+					{group.label}
+				</CardTitle>
+				{group.description && (
+					<CardDescription>{group.description}</CardDescription>
+				)}
+			</CardHeader>
+			<CardContent className="space-y-6">
+				{visibleFields.map((field) => (
+					<ConfigField
+						key={field.key}
+						field={field}
+						value={values[field.key] ?? field.defaultValue}
+						canWrite={canWrite}
+						isSaving={savingKeys.has(field.key)}
+						onChange={(value) => onChange(field.key, value)}
+						onReset={() => onReset(field.key)}
+					/>
+				))}
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/client/src/components/config/configuration-panel.tsx
+++ b/apps/client/src/components/config/configuration-panel.tsx
@@ -1,0 +1,252 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { SearchIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { useAuth } from "@/auth/AuthProvider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { checkPermissions } from "@/lib/permissions";
+import { ConfigGroup } from "./config-group";
+
+interface ConfigField {
+	key: string;
+	label: string;
+	description?: string;
+	type: string;
+	defaultValue: unknown;
+	options?: { value: string; label: string }[];
+	placeholder?: string;
+	min?: number;
+	max?: number;
+	step?: number;
+	required?: boolean;
+}
+
+interface ConfigGroupDef {
+	id: string;
+	label: string;
+	description?: string;
+	icon?: string;
+	fields: ConfigField[];
+}
+
+interface ConfigDefinition {
+	namespace: string;
+	groups: ConfigGroupDef[];
+}
+
+interface ConfigurationPanelProps {
+	definitions: ConfigDefinition[];
+	initialValues: Record<string, unknown>;
+}
+
+export function ConfigurationPanel({
+	definitions,
+	initialValues,
+}: ConfigurationPanelProps) {
+	const { user } = useAuth();
+	const canWrite = user ? checkPermissions(user, ["config.write"]) : false;
+	const queryClient = useQueryClient();
+	const [values, setValues] = useState<Record<string, unknown>>(initialValues);
+	const [savedValues, setSavedValues] =
+		useState<Record<string, unknown>>(initialValues);
+	const [search, setSearch] = useState("");
+	const [savingKeys, setSavingKeys] = useState<Set<string>>(new Set());
+	const [isSaving, setIsSaving] = useState(false);
+
+	// Update saved values when initial values change (after fetch/reset)
+	useEffect(() => {
+		setSavedValues(initialValues);
+		setValues(initialValues);
+	}, [initialValues]);
+
+	// Create a map of default values from definitions
+	const defaultValues = useMemo(() => {
+		const defaults: Record<string, unknown> = {};
+		for (const def of definitions) {
+			for (const group of def.groups) {
+				for (const field of group.fields) {
+					defaults[field.key] = field.defaultValue;
+				}
+			}
+		}
+		return defaults;
+	}, [definitions]);
+
+	// Calculate which values have changed
+	const changedKeys = useMemo(() => {
+		const keys: string[] = [];
+		for (const key in values) {
+			if (values[key] !== savedValues[key]) {
+				keys.push(key);
+			}
+		}
+		return keys;
+	}, [values, savedValues]);
+
+	const hasChanges = changedKeys.length > 0;
+
+	const setManyMutation = useMutation({
+		mutationFn: (valuesToSave: Record<string, unknown>) =>
+			trpc.config.setMany.mutate({ values: valuesToSave }),
+		onMutate: () => {
+			setIsSaving(true);
+		},
+		onSuccess: (_, valuesToSave) => {
+			// Update saved state to match current values
+			setSavedValues((prev) => ({ ...prev, ...valuesToSave }));
+			queryClient.invalidateQueries({ queryKey: ["config", "all"] });
+			const count = Object.keys(valuesToSave).length;
+			toast.success(`Updated ${count} configuration${count > 1 ? "s" : ""}`);
+			setIsSaving(false);
+		},
+		onError: (error) => {
+			toast.error("Failed to update configuration", {
+				description: error.message,
+			});
+			setIsSaving(false);
+		},
+	});
+
+	const resetValueMutation = useMutation({
+		mutationFn: ({ key }: { key: string; defaultValue: unknown }) =>
+			trpc.config.resetValue.mutate({ key }),
+		onMutate: ({ key }) => {
+			setSavingKeys((prev) => new Set(prev).add(key));
+		},
+		onSuccess: (_, { key, defaultValue }) => {
+			// Reset both local and saved state to default value
+			setValues((prev) => ({ ...prev, [key]: defaultValue }));
+			setSavedValues((prev) => ({ ...prev, [key]: defaultValue }));
+			queryClient.invalidateQueries({ queryKey: ["config", "all"] });
+			toast.success("Configuration reset to default");
+			setSavingKeys((prev) => {
+				const next = new Set(prev);
+				next.delete(key);
+				return next;
+			});
+		},
+		onError: (error, { key }) => {
+			toast.error("Failed to reset configuration", {
+				description: error.message,
+			});
+			setSavingKeys((prev) => {
+				const next = new Set(prev);
+				next.delete(key);
+				return next;
+			});
+		},
+	});
+
+	const handleValueChange = useCallback((key: string, value: unknown) => {
+		setValues((prev) => ({ ...prev, [key]: value }));
+	}, []);
+
+	const handleSaveAll = useCallback(() => {
+		if (!canWrite || !hasChanges) return;
+
+		// Build object of changed values
+		const valuesToSave: Record<string, unknown> = {};
+		for (const key of changedKeys) {
+			valuesToSave[key] = values[key];
+		}
+
+		setManyMutation.mutate(valuesToSave);
+	}, [canWrite, hasChanges, changedKeys, values, setManyMutation]);
+
+	const handleReset = useCallback(
+		(key: string) => {
+			if (!canWrite) return;
+			const defaultValue = defaultValues[key];
+			resetValueMutation.mutate({ key, defaultValue });
+		},
+		[canWrite, defaultValues, resetValueMutation],
+	);
+
+	// Filter groups based on search
+	const filteredDefinitions = useMemo(() => {
+		if (!search.trim()) return definitions;
+
+		const lowerSearch = search.toLowerCase();
+		return definitions
+			.map((def) => ({
+				...def,
+				groups: def.groups
+					.map((group) => ({
+						...group,
+						fields: group.fields.filter(
+							(field) =>
+								field.label.toLowerCase().includes(lowerSearch) ||
+								field.description?.toLowerCase().includes(lowerSearch) ||
+								field.key.toLowerCase().includes(lowerSearch),
+						),
+					}))
+					.filter((group) => group.fields.length > 0),
+			}))
+			.filter((def) => def.groups.length > 0);
+	}, [definitions, search]);
+
+	// Check if field should be shown based on conditional logic using current values
+	const shouldShowField = useCallback(
+		(field: ConfigField) => {
+			// Since we can't serialize functions, we'll handle common patterns here
+			// For the session timeout example:
+			if (field.key.endsWith(".hours")) {
+				const enabledKey = field.key.replace(".hours", ".enabled");
+				// Use current values (not saved values) for conditional display
+				return values[enabledKey] === true;
+			}
+			return true;
+		},
+		[values],
+	);
+
+	return (
+		<div className="space-y-6">
+			{/* Search and Save Button */}
+			<div className="flex items-center gap-4">
+				<div className="relative flex-1">
+					<SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						placeholder="Search configuration options..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="pl-9"
+					/>
+				</div>
+				{canWrite && (
+					<Button onClick={handleSaveAll} disabled={!hasChanges || isSaving}>
+						{isSaving
+							? "Saving..."
+							: `Save Changes${hasChanges ? ` (${changedKeys.length})` : ""}`}
+					</Button>
+				)}
+			</div>
+
+			{/* Configuration Groups */}
+			{filteredDefinitions.length === 0 ? (
+				<div className="text-center py-12 text-muted-foreground">
+					No configuration options found
+				</div>
+			) : (
+				<div className="space-y-6">
+					{filteredDefinitions.map((definition) =>
+						definition.groups.map((group) => (
+							<ConfigGroup
+								key={group.id}
+								group={group}
+								values={values}
+								canWrite={canWrite}
+								savingKeys={savingKeys}
+								shouldShowField={shouldShowField}
+								onChange={handleValueChange}
+								onReset={handleReset}
+							/>
+						)),
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/client/src/components/navigation/app-sidebar.tsx
+++ b/apps/client/src/components/navigation/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
 	LaptopMinimalCheckIcon,
 	MoonIcon,
 	ScrollTextIcon,
+	SettingsIcon,
 	ShieldIcon,
 	SunIcon,
 	SunMoonIcon,
@@ -48,6 +49,7 @@ import { checkPermissions } from "@/lib/permissions";
 import { permissions as agreementsPagePermissions } from "@/routes/app/agreements";
 import { permissions as apiTokensPagePermissions } from "@/routes/app/api-tokens";
 import { permissions as auditLogsPagePermissions } from "@/routes/app/audit-logs";
+import { permissions as configurationPagePermissions } from "@/routes/app/configuration";
 import { permissions as appIndexPagePermissions } from "@/routes/app/index";
 import { permissions as kiosksPagePermissions } from "@/routes/app/kiosks";
 import { permissions as rolesPagePermissions } from "@/routes/app/roles";
@@ -138,6 +140,12 @@ export const items: AppSidebarGroup[] = [
 				url: "/app/sessions",
 				icon: FileClockIcon,
 				permissions: sessionsPagePermissions,
+			},
+			{
+				title: "Configuration",
+				url: "/app/configuration",
+				icon: SettingsIcon,
+				permissions: configurationPagePermissions,
 			},
 		],
 	},

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as AppRolesRouteImport } from './routes/app/roles'
 import { Route as AppMySessionsRouteImport } from './routes/app/my-sessions'
 import { Route as AppMyAgreementsRouteImport } from './routes/app/my-agreements'
 import { Route as AppKiosksRouteImport } from './routes/app/kiosks'
+import { Route as AppConfigurationRouteImport } from './routes/app/configuration'
 import { Route as AppAuditLogsRouteImport } from './routes/app/audit-logs'
 import { Route as AppApiTokensRouteImport } from './routes/app/api-tokens'
 import { Route as AppAgreementsRouteImport } from './routes/app/agreements'
@@ -145,6 +146,11 @@ const AppKiosksRoute = AppKiosksRouteImport.update({
   path: '/kiosks',
   getParentRoute: () => AppRoute,
 } as any)
+const AppConfigurationRoute = AppConfigurationRouteImport.update({
+  id: '/configuration',
+  path: '/configuration',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppAuditLogsRoute = AppAuditLogsRouteImport.update({
   id: '/audit-logs',
   path: '/audit-logs',
@@ -170,6 +176,7 @@ export interface FileRoutesByFullPath {
   '/app/agreements': typeof AppAgreementsRoute
   '/app/api-tokens': typeof AppApiTokensRoute
   '/app/audit-logs': typeof AppAuditLogsRoute
+  '/app/configuration': typeof AppConfigurationRoute
   '/app/kiosks': typeof AppKiosksRoute
   '/app/my-agreements': typeof AppMyAgreementsRoute
   '/app/my-sessions': typeof AppMySessionsRoute
@@ -195,6 +202,7 @@ export interface FileRoutesByTo {
   '/app/agreements': typeof AppAgreementsRoute
   '/app/api-tokens': typeof AppApiTokensRoute
   '/app/audit-logs': typeof AppAuditLogsRoute
+  '/app/configuration': typeof AppConfigurationRoute
   '/app/kiosks': typeof AppKiosksRoute
   '/app/my-agreements': typeof AppMyAgreementsRoute
   '/app/my-sessions': typeof AppMySessionsRoute
@@ -223,6 +231,7 @@ export interface FileRoutesById {
   '/app/agreements': typeof AppAgreementsRoute
   '/app/api-tokens': typeof AppApiTokensRoute
   '/app/audit-logs': typeof AppAuditLogsRoute
+  '/app/configuration': typeof AppConfigurationRoute
   '/app/kiosks': typeof AppKiosksRoute
   '/app/my-agreements': typeof AppMyAgreementsRoute
   '/app/my-sessions': typeof AppMySessionsRoute
@@ -252,6 +261,7 @@ export interface FileRouteTypes {
     | '/app/agreements'
     | '/app/api-tokens'
     | '/app/audit-logs'
+    | '/app/configuration'
     | '/app/kiosks'
     | '/app/my-agreements'
     | '/app/my-sessions'
@@ -277,6 +287,7 @@ export interface FileRouteTypes {
     | '/app/agreements'
     | '/app/api-tokens'
     | '/app/audit-logs'
+    | '/app/configuration'
     | '/app/kiosks'
     | '/app/my-agreements'
     | '/app/my-sessions'
@@ -304,6 +315,7 @@ export interface FileRouteTypes {
     | '/app/agreements'
     | '/app/api-tokens'
     | '/app/audit-logs'
+    | '/app/configuration'
     | '/app/kiosks'
     | '/app/my-agreements'
     | '/app/my-sessions'
@@ -487,6 +499,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppKiosksRouteImport
       parentRoute: typeof AppRoute
     }
+    '/app/configuration': {
+      id: '/app/configuration'
+      path: '/configuration'
+      fullPath: '/app/configuration'
+      preLoaderRoute: typeof AppConfigurationRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/app/audit-logs': {
       id: '/app/audit-logs'
       path: '/audit-logs'
@@ -515,6 +534,7 @@ interface AppRouteChildren {
   AppAgreementsRoute: typeof AppAgreementsRoute
   AppApiTokensRoute: typeof AppApiTokensRoute
   AppAuditLogsRoute: typeof AppAuditLogsRoute
+  AppConfigurationRoute: typeof AppConfigurationRoute
   AppKiosksRoute: typeof AppKiosksRoute
   AppMyAgreementsRoute: typeof AppMyAgreementsRoute
   AppMySessionsRoute: typeof AppMySessionsRoute
@@ -528,6 +548,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppAgreementsRoute: AppAgreementsRoute,
   AppApiTokensRoute: AppApiTokensRoute,
   AppAuditLogsRoute: AppAuditLogsRoute,
+  AppConfigurationRoute: AppConfigurationRoute,
   AppKiosksRoute: AppKiosksRoute,
   AppMyAgreementsRoute: AppMyAgreementsRoute,
   AppMySessionsRoute: AppMySessionsRoute,

--- a/apps/client/src/routes/app/configuration.tsx
+++ b/apps/client/src/routes/app/configuration.tsx
@@ -1,0 +1,51 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { RequirePermissions } from "@/auth/AuthProvider";
+import { ConfigurationPanel } from "@/components/config/configuration-panel";
+import { MissingPermissions } from "@/components/guards/missing-permissions";
+import { Page, PageContent, PageHeader, PageTitle } from "@/components/layout";
+import { Spinner } from "@/components/ui/spinner";
+
+export const permissions = ["config.read"];
+
+export const Route = createFileRoute("/app/configuration")({
+	component: () =>
+		RequirePermissions({
+			permissions,
+			forbiddenFallback: <MissingPermissions />,
+			children: <ConfigurationPage />,
+		}),
+});
+
+function ConfigurationPage() {
+	const { data, isLoading } = useQuery({
+		queryKey: ["config", "all"],
+		queryFn: () => trpc.config.getAll.query({}),
+		staleTime: 30_000, // 30 seconds
+	});
+
+	return (
+		<Page>
+			<PageHeader>
+				<PageTitle>Configuration</PageTitle>
+			</PageHeader>
+			<PageContent>
+				{isLoading ? (
+					<div className="flex items-center justify-center p-8">
+						<Spinner className="h-8 w-8" />
+					</div>
+				) : data ? (
+					<ConfigurationPanel
+						definitions={data.definitions}
+						initialValues={data.values}
+					/>
+				) : (
+					<div className="text-center p-8 text-muted-foreground">
+						Failed to load configuration
+					</div>
+				)}
+			</PageContent>
+		</Page>
+	);
+}

--- a/packages/features/src/config/definitions/sessions.ts
+++ b/packages/features/src/config/definitions/sessions.ts
@@ -1,0 +1,65 @@
+import { ConfigRegistry } from "../registry";
+import type { ConfigDefinition } from "../types";
+
+/**
+ * Session Configuration
+ * Defines configuration options for user sessions
+ */
+export const sessionConfig: ConfigDefinition = {
+	groups: [
+		{
+			id: "session-timeout",
+			label: "Session Timeout Settings",
+			description:
+				"Configure automatic session logout based on session duration",
+			icon: "Clock",
+			fields: [
+				{
+					key: "session.timeout.regular.enabled",
+					label: "Enable Auto-Logout for Regular Sessions",
+					description:
+						"Automatically end regular sessions after a specified duration",
+					type: "boolean",
+					defaultValue: true,
+				},
+				{
+					key: "session.timeout.regular.hours",
+					label: "Regular Session Timeout (Hours)",
+					description:
+						"Number of hours before a regular session is automatically ended",
+					type: "number",
+					defaultValue: 12,
+					min: 0.1,
+					max: 168, // 1 week
+					step: 0.1,
+					showWhen: (values: Record<string, unknown>) =>
+						values["session.timeout.regular.enabled"] === true,
+				},
+				{
+					key: "session.timeout.staffing.enabled",
+					label: "Enable Auto-Logout for Staffing Sessions",
+					description:
+						"Automatically end staffing sessions after a specified duration",
+					type: "boolean",
+					defaultValue: true,
+				},
+				{
+					key: "session.timeout.staffing.hours",
+					label: "Staffing Session Timeout (Hours)",
+					description:
+						"Number of hours before a staffing session is automatically ended",
+					type: "number",
+					defaultValue: 8,
+					min: 0.1,
+					max: 168, // 1 week
+					step: 0.1,
+					showWhen: (values: Record<string, unknown>) =>
+						values["session.timeout.staffing.enabled"] === true,
+				},
+			],
+		},
+	],
+};
+
+// Register the configuration
+ConfigRegistry.register("sessions", sessionConfig);

--- a/packages/features/src/config/index.ts
+++ b/packages/features/src/config/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Configuration Framework
+ * Provides a robust system for managing application configuration
+ */
+
+export * from "./registry";
+export * from "./service";
+export * from "./types";
+
+// Import all configuration definitions to register them
+import "./definitions/sessions";

--- a/packages/features/src/config/registry.ts
+++ b/packages/features/src/config/registry.ts
@@ -1,0 +1,229 @@
+import { z } from "zod";
+import type { ConfigDefinition, ConfigField } from "./types";
+
+/**
+ * Configuration Registry
+ * Central registry for all configuration definitions in the system
+ */
+const definitions = new Map<string, ConfigDefinition>();
+const schemaCache = new Map<string, z.ZodType>();
+
+export const ConfigRegistry = {
+	/**
+	 * Register a configuration definition
+	 */
+	register(namespace: string, definition: ConfigDefinition): void {
+		if (definitions.has(namespace)) {
+			throw new Error(
+				`Configuration namespace "${namespace}" is already registered`,
+			);
+		}
+		definitions.set(namespace, definition);
+	},
+
+	/**
+	 * Get a configuration definition
+	 */
+	get(namespace: string): ConfigDefinition | undefined {
+		return definitions.get(namespace);
+	},
+
+	/**
+	 * Get all registered configuration definitions
+	 */
+	getAll(): Map<string, ConfigDefinition> {
+		return new Map(definitions);
+	},
+
+	/**
+	 * Get all configuration keys with their default values
+	 */
+	getAllDefaults(): Record<string, unknown> {
+		const defaults: Record<string, unknown> = {};
+
+		for (const definition of Array.from(definitions.values())) {
+			for (const group of definition.groups) {
+				for (const field of group.fields) {
+					defaults[field.key] = field.defaultValue;
+				}
+			}
+		}
+
+		return defaults;
+	},
+
+	/**
+	 * Get default value for a specific key
+	 */
+	getDefault(key: string): unknown {
+		for (const definition of Array.from(definitions.values())) {
+			for (const group of definition.groups) {
+				for (const field of group.fields) {
+					if (field.key === key) {
+						return field.defaultValue;
+					}
+				}
+			}
+		}
+		return undefined;
+	},
+
+	/**
+	 * Generate a Zod schema for a field based on its definition
+	 */
+	getFieldSchema(field: ConfigField): z.ZodType {
+		switch (field.type) {
+			case "number": {
+				let schema = z.number();
+
+				// Apply min constraint
+				if (field.min !== undefined) {
+					schema = schema.min(
+						field.min,
+						`${field.label} must be at least ${field.min}`,
+					);
+				}
+
+				// Apply max constraint
+				if (field.max !== undefined) {
+					schema = schema.max(
+						field.max,
+						`${field.label} must be at most ${field.max}`,
+					);
+				}
+
+				// Apply step constraint (validate that number is a multiple)
+				if (field.step !== undefined && field.step > 0) {
+					const step = field.step;
+					const min = field.min ?? 0;
+					schema = schema.refine((val) => {
+						const offset = val - min;
+						// Round to nearest step and check if close to original value
+						// This handles floating point precision issues better than modulo
+						const rounded = Math.round(offset / step) * step;
+						return Math.abs(rounded - offset) < Number.EPSILON * 10;
+					}, {
+                        message: `${field.label} must be a multiple of ${field.step}`,
+                    });
+				}
+
+				return schema;
+			}
+
+			case "boolean":
+				return z.boolean();
+
+			case "text":
+			case "textarea": {
+				const schema = z.string();
+
+				return schema;
+			}
+
+			case "select": {
+				if (!field.options || field.options.length === 0) {
+					return z.string();
+				}
+
+				// Create enum from options
+				const validValues = field.options.map((opt) => opt.value);
+				if (validValues.length === 1) {
+					return z.literal(validValues[0]);
+				}
+				return z.union([
+					z.literal(validValues[0]),
+					z.literal(validValues[1]),
+					...(validValues.slice(2).map((v) => z.literal(v)) as [
+						z.ZodLiteral<string>,
+						...z.ZodLiteral<string>[],
+					]),
+				]);
+			}
+
+			case "multiselect": {
+				if (!field.options || field.options.length === 0) {
+					return z.array(z.string());
+				}
+
+				// Create enum array from options
+				const validValues = field.options.map((opt) => opt.value);
+				let itemSchema: z.ZodType;
+
+				if (validValues.length === 1) {
+					itemSchema = z.literal(validValues[0]);
+				} else if (validValues.length === 2) {
+					itemSchema = z.union([
+						z.literal(validValues[0]),
+						z.literal(validValues[1]),
+					]);
+				} else {
+					itemSchema = z.enum(validValues as [string, string, ...string[]]);
+				}
+
+				return z.array(itemSchema);
+			}
+
+			default:
+				return z.unknown();
+		}
+	},
+
+	/**
+	 * Get or create a cached Zod schema for a configuration key
+	 */
+	getSchema(key: string): z.ZodType | undefined {
+		// Check cache first
+		if (schemaCache.has(key)) {
+			return schemaCache.get(key);
+		}
+
+		// Find the field definition
+		for (const definition of Array.from(definitions.values())) {
+			for (const group of definition.groups) {
+				for (const field of group.fields) {
+					if (field.key === key) {
+						const schema = this.getFieldSchema(field);
+						schemaCache.set(key, schema);
+						return schema;
+					}
+				}
+			}
+		}
+
+		return undefined;
+	},
+
+	/**
+	 * Validate a configuration value using Zod
+	 */
+	validate(
+		key: string,
+		value: unknown,
+	): { success: true } | { success: false; error: string } {
+		const schema = this.getSchema(key);
+
+		if (!schema) {
+			return { success: false, error: `Unknown configuration key: ${key}` };
+		}
+
+		const result = schema.safeParse(value);
+
+		if (result.success) {
+			return { success: true };
+		}
+
+		// Format Zod error message
+		const errorMessage = result.error.issues
+			.map((err: { message: string }) => err.message)
+			.join(", ");
+
+		return { success: false, error: errorMessage };
+	},
+
+	/**
+	 * Clear all registrations (useful for testing)
+	 */
+	clear(): void {
+		definitions.clear();
+	},
+};

--- a/packages/features/src/config/service.ts
+++ b/packages/features/src/config/service.ts
@@ -151,11 +151,9 @@ export const ConfigService = {
 			),
 		);
 
-		// Update cache
-		for (const [key, value] of Object.entries(values)) {
-			cache.set(key, value);
-		}
-		cacheTimestamp = Date.now();
+		// Clear cache to avoid serving stale data for other keys in multi-process scenarios
+		cache.clear();
+		cacheTimestamp = 0;
 	},
 
 	/**

--- a/packages/features/src/config/service.ts
+++ b/packages/features/src/config/service.ts
@@ -1,0 +1,181 @@
+import type { Prisma } from "@ecehive/prisma";
+import { prisma } from "@ecehive/prisma";
+import { ConfigRegistry } from "./registry";
+import type { ConfigState } from "./types";
+
+/**
+ * Configuration Service
+ * Handles reading and writing configuration values to the database
+ */
+const cache = new Map<string, unknown>();
+let cacheTimestamp = 0;
+const CACHE_TTL = 60000; // 1 minute
+
+function isCacheValid(): boolean {
+	return Date.now() - cacheTimestamp < CACHE_TTL;
+}
+
+export const ConfigService = {
+	/**
+	 * Get a single configuration value
+	 */
+	async get<T = unknown>(key: string): Promise<T> {
+		// Check cache first
+		if (isCacheValid() && cache.has(key)) {
+			return cache.get(key) as T;
+		}
+
+		// Fetch from database
+		const configValue = await prisma.configValue.findUnique({
+			where: { key },
+		});
+
+		if (configValue) {
+			const value = configValue.value as T;
+			cache.set(key, value);
+			return value;
+		}
+
+		// Return default value if not found
+		const defaultValue = ConfigRegistry.getDefault(key) as T;
+		return defaultValue;
+	},
+
+	/**
+	 * Get multiple configuration values
+	 */
+	async getMany(keys: string[]): Promise<Record<string, unknown>> {
+		const result: Record<string, unknown> = {};
+
+		// Check cache first
+		const keysToFetch: string[] = [];
+		for (const key of keys) {
+			if (isCacheValid() && cache.has(key)) {
+				result[key] = cache.get(key);
+			} else {
+				keysToFetch.push(key);
+			}
+		}
+
+		// Fetch remaining keys from database
+		if (keysToFetch.length > 0) {
+			const configValues = await prisma.configValue.findMany({
+				where: { key: { in: keysToFetch } },
+			});
+
+			const dbValues = new Map(configValues.map((cv) => [cv.key, cv.value]));
+
+			for (const key of keysToFetch) {
+				const value = dbValues.get(key) ?? ConfigRegistry.getDefault(key);
+				result[key] = value;
+				cache.set(key, value);
+			}
+		}
+
+		return result;
+	},
+
+	/**
+	 * Get all configuration values
+	 */
+	async getAll(): Promise<ConfigState> {
+		// Get all defaults first
+		const defaults = ConfigRegistry.getAllDefaults();
+
+		// Fetch all from database
+		const configValues = await prisma.configValue.findMany();
+
+		// Merge with defaults (database values override defaults)
+		const result: ConfigState = { ...defaults };
+		for (const cv of configValues) {
+			result[cv.key] = cv.value;
+		}
+
+		// Update cache
+		cache.clear();
+		for (const [key, value] of Object.entries(result)) {
+			cache.set(key, value);
+		}
+		cacheTimestamp = Date.now();
+
+		return result;
+	},
+
+	/**
+	 * Set a single configuration value
+	 */
+	async set(key: string, value: unknown): Promise<void> {
+		// Validate the value
+		const validation = ConfigRegistry.validate(key, value);
+		if (!validation.success) {
+			throw new Error(validation.error);
+		}
+
+		// Upsert to database
+		await prisma.configValue.upsert({
+			where: { key },
+			create: { key, value: value as Prisma.InputJsonValue },
+			update: { value: value as Prisma.InputJsonValue },
+		});
+
+		// Update cache
+		cache.set(key, value);
+		cacheTimestamp = Date.now();
+	},
+
+	/**
+	 * Set multiple configuration values
+	 */
+	async setMany(values: Record<string, unknown>): Promise<void> {
+		// Validate all values first and collect errors
+		const errors: string[] = [];
+		for (const [key, value] of Object.entries(values)) {
+			const validation = ConfigRegistry.validate(key, value);
+			if (!validation.success) {
+				errors.push(`${key}: ${validation.error}`);
+			}
+		}
+
+		if (errors.length > 0) {
+			throw new Error(`Validation failed: ${errors.join("; ")}`);
+		}
+
+		// Use transaction to update all values
+		await prisma.$transaction(
+			Object.entries(values).map(([key, value]) =>
+				prisma.configValue.upsert({
+					where: { key },
+					create: { key, value: value as Prisma.InputJsonValue },
+					update: { value: value as Prisma.InputJsonValue },
+				}),
+			),
+		);
+
+		// Update cache
+		for (const [key, value] of Object.entries(values)) {
+			cache.set(key, value);
+		}
+		cacheTimestamp = Date.now();
+	},
+
+	/**
+	 * Reset a configuration value to its default
+	 */
+	async reset(key: string): Promise<void> {
+		// Use deleteMany instead of delete to avoid error if record doesn't exist
+		// (record might not exist if value was never changed from default)
+		await prisma.configValue.deleteMany({
+			where: { key },
+		});
+
+		cache.delete(key);
+	},
+
+	/**
+	 * Clear the cache
+	 */
+	clearCache(): void {
+		cache.clear();
+		cacheTimestamp = 0;
+	},
+};

--- a/packages/features/src/config/types.ts
+++ b/packages/features/src/config/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Configuration framework types
+ * Defines the structure for building robust, type-safe configuration systems
+ */
+
+export type ConfigFieldType =
+	| "text"
+	| "number"
+	| "boolean"
+	| "select"
+	| "multiselect"
+	| "textarea";
+
+export interface ConfigFieldOption {
+	value: string;
+	label: string;
+}
+
+export interface ConfigField<T = unknown> {
+	key: string;
+	label: string;
+	description?: string;
+	type: ConfigFieldType;
+	defaultValue: T;
+	options?: ConfigFieldOption[]; // For select/multiselect
+	placeholder?: string;
+	min?: number; // For number types
+	max?: number; // For number types
+	step?: number; // For number types
+	required?: boolean;
+	// Conditional rendering: only show if this function returns true
+	showWhen?: (values: Record<string, unknown>) => boolean;
+}
+
+export interface ConfigGroup {
+	id: string;
+	label: string;
+	description?: string;
+	icon?: string;
+	fields: ConfigField[];
+	// Conditional rendering: only show group if this function returns true
+	showWhen?: (values: Record<string, unknown>) => boolean;
+}
+
+export interface ConfigDefinition {
+	groups: ConfigGroup[];
+}
+
+export interface ConfigValue {
+	key: string;
+	value: unknown;
+}
+
+export interface ConfigState {
+	[key: string]: unknown;
+}

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -2,6 +2,7 @@ export * from "./api-tokens";
 export * from "./assignments/generators";
 export * from "./audit-logs/list-audit-logs";
 export * from "./audit-logs/logger";
+export * from "./config";
 export * from "./db/locking";
 export * from "./periods/access";
 export * from "./periods/generate";

--- a/packages/prisma/migrations/20251230032923_add_config_values/migration.sql
+++ b/packages/prisma/migrations/20251230032923_add_config_values/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "ConfigValue" (
+    "id" SERIAL NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ConfigValue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConfigValue_key_key" ON "ConfigValue"("key");
+
+-- CreateIndex
+CREATE INDEX "ConfigValue_key_idx" ON "ConfigValue"("key");
+
+-- Add configuration permissions
+INSERT INTO "Permission" (name) VALUES
+  ('config.read'),
+  ('config.write')
+ON CONFLICT (name) DO NOTHING;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -382,3 +382,18 @@ model OneTimeAccessCode {
   // indexes
   @@index([code, expiresAt])
 }
+
+model ConfigValue {
+  id Int @id @default(autoincrement())
+
+  // fields
+  key   String @unique
+  value Json
+
+  // timestamps
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  // indexes
+  @@index([key])
+}

--- a/packages/trpc/server/router.ts
+++ b/packages/trpc/server/router.ts
@@ -2,6 +2,7 @@ import { agreementsRouter } from "./routers/agreements/_route";
 import { apiTokensRouter } from "./routers/apiTokens/_route";
 import { auditLogsRouter } from "./routers/auditLogs/_route";
 import { authRouter } from "./routers/auth/_route";
+import { configRouter } from "./routers/config/_route";
 import { kiosksRouter } from "./routers/kiosks/_route";
 import { oneTimeLoginCodesRouter } from "./routers/oneTimeLoginCodes/_route";
 import { periodExceptionsRouter } from "./routers/periodExceptions/_route";
@@ -21,6 +22,7 @@ export const appRouter = router({
 	auth: authRouter,
 	apiTokens: apiTokensRouter,
 	auditLogs: auditLogsRouter,
+	config: configRouter,
 	users: usersRouter,
 	roles: rolesRouter,
 	permissions: permissionsRouter,

--- a/packages/trpc/server/routers/config/_route.ts
+++ b/packages/trpc/server/routers/config/_route.ts
@@ -1,0 +1,31 @@
+import { permissionProtectedProcedure, router } from "../../trpc";
+import { getAllHandler } from "./get-all.route";
+import { getValueHandler } from "./get-value.route";
+import { resetValueHandler } from "./reset-value.route";
+import {
+	ZGetAllSchema,
+	ZGetValueSchema,
+	ZResetValueSchema,
+	ZSetManySchema,
+	ZSetValueSchema,
+} from "./schemas";
+import { setManyHandler } from "./set-many.route";
+import { setValueHandler } from "./set-value.route";
+
+export const configRouter = router({
+	getAll: permissionProtectedProcedure("config.read")
+		.input(ZGetAllSchema)
+		.query(getAllHandler),
+	getValue: permissionProtectedProcedure("config.read")
+		.input(ZGetValueSchema)
+		.query(getValueHandler),
+	setValue: permissionProtectedProcedure("config.write")
+		.input(ZSetValueSchema)
+		.mutation(setValueHandler),
+	setMany: permissionProtectedProcedure("config.write")
+		.input(ZSetManySchema)
+		.mutation(setManyHandler),
+	resetValue: permissionProtectedProcedure("config.write")
+		.input(ZResetValueSchema)
+		.mutation(resetValueHandler),
+});

--- a/packages/trpc/server/routers/config/get-all.route.ts
+++ b/packages/trpc/server/routers/config/get-all.route.ts
@@ -1,0 +1,66 @@
+import { ConfigRegistry, ConfigService } from "@ecehive/features";
+
+interface GetAllResult {
+	definitions: {
+		namespace: string;
+		groups: {
+			id: string;
+			label: string;
+			description?: string;
+			icon?: string;
+			fields: {
+				key: string;
+				label: string;
+				description?: string;
+				type: string;
+				defaultValue: unknown;
+				options?: { value: string; label: string }[];
+				placeholder?: string;
+				min?: number;
+				max?: number;
+				step?: number;
+				required?: boolean;
+			}[];
+		}[];
+	}[];
+	values: Record<string, unknown>;
+}
+
+export async function getAllHandler(): Promise<GetAllResult> {
+	// Get all configuration definitions
+	const allDefinitions = ConfigRegistry.getAll();
+	const definitions = Array.from(allDefinitions.entries()).map(
+		([namespace, def]) => ({
+			namespace,
+			groups: def.groups.map((group) => ({
+				id: group.id,
+				label: group.label,
+				description: group.description,
+				icon: group.icon,
+				fields: group.fields.map((field) => ({
+					key: field.key,
+					label: field.label,
+					description: field.description,
+					type: field.type,
+					defaultValue: field.defaultValue,
+					options: field.options,
+					placeholder: field.placeholder,
+					min: field.min,
+					max: field.max,
+					step: field.step,
+					required: field.required,
+					// Note: We don't serialize the showWhen function
+					// Client will handle conditional rendering based on values
+				})),
+			})),
+		}),
+	);
+
+	// Get all current values
+	const values = await ConfigService.getAll();
+
+	return {
+		definitions,
+		values,
+	};
+}

--- a/packages/trpc/server/routers/config/get-value.route.ts
+++ b/packages/trpc/server/routers/config/get-value.route.ts
@@ -1,0 +1,15 @@
+import { ConfigService } from "@ecehive/features";
+import type { z } from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+import type { ZGetValueSchema } from "./schemas";
+
+type GetValueInput = z.infer<typeof ZGetValueSchema>;
+
+export async function getValueHandler({
+	input,
+}: {
+	input: GetValueInput;
+	ctx: TPermissionProtectedProcedureContext;
+}): Promise<unknown> {
+	return await ConfigService.get(input.key);
+}

--- a/packages/trpc/server/routers/config/reset-value.route.ts
+++ b/packages/trpc/server/routers/config/reset-value.route.ts
@@ -1,7 +1,6 @@
 import { ConfigService } from "@ecehive/features";
 import { TRPCError } from "@trpc/server";
 import type { z } from "zod";
-import type { TPermissionProtectedProcedureContext } from "../../trpc";
 import type { ZResetValueSchema } from "./schemas";
 
 type ResetValueInput = z.infer<typeof ZResetValueSchema>;
@@ -10,7 +9,6 @@ export async function resetValueHandler({
 	input,
 }: {
 	input: ResetValueInput;
-	ctx: TPermissionProtectedProcedureContext;
 }): Promise<void> {
 	try {
 		await ConfigService.reset(input.key);

--- a/packages/trpc/server/routers/config/reset-value.route.ts
+++ b/packages/trpc/server/routers/config/reset-value.route.ts
@@ -1,0 +1,26 @@
+import { ConfigService } from "@ecehive/features";
+import { TRPCError } from "@trpc/server";
+import type { z } from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+import type { ZResetValueSchema } from "./schemas";
+
+type ResetValueInput = z.infer<typeof ZResetValueSchema>;
+
+export async function resetValueHandler({
+	input,
+}: {
+	input: ResetValueInput;
+	ctx: TPermissionProtectedProcedureContext;
+}): Promise<void> {
+	try {
+		await ConfigService.reset(input.key);
+	} catch (error) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message:
+				error instanceof Error
+					? error.message
+					: "Failed to reset configuration",
+		});
+	}
+}

--- a/packages/trpc/server/routers/config/schemas.ts
+++ b/packages/trpc/server/routers/config/schemas.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+/**
+ * Get all configuration definitions and current values
+ */
+export const ZGetAllSchema = z.object({});
+
+/**
+ * Get a single configuration value
+ */
+export const ZGetValueSchema = z.object({
+	key: z.string(),
+});
+
+/**
+ * Set a single configuration value
+ */
+export const ZSetValueSchema = z.object({
+	key: z.string(),
+	value: z.unknown(),
+});
+
+/**
+ * Set multiple configuration values
+ */
+export const ZSetManySchema = z.object({
+	values: z.record(z.string(), z.unknown()),
+});
+
+/**
+ * Reset a configuration value to default
+ */
+export const ZResetValueSchema = z.object({
+	key: z.string(),
+});
+
+/**
+ * Search configurations (returns keys matching search term)
+ */
+export const ZSearchSchema = z.object({
+	query: z.string().optional(),
+});

--- a/packages/trpc/server/routers/config/schemas.ts
+++ b/packages/trpc/server/routers/config/schemas.ts
@@ -17,14 +17,21 @@ export const ZGetValueSchema = z.object({
  */
 export const ZSetValueSchema = z.object({
 	key: z.string(),
-	value: z.unknown(),
+	value: z.unknown().refine((v) => v !== null && v !== undefined, {
+		message: "Value cannot be null or undefined",
+	}),
 });
 
 /**
  * Set multiple configuration values
  */
 export const ZSetManySchema = z.object({
-	values: z.record(z.string(), z.unknown()),
+	values: z.record(
+		z.string(),
+		z.unknown().refine((v) => v !== null && v !== undefined, {
+			message: "Value cannot be null or undefined",
+		}),
+	),
 });
 
 /**

--- a/packages/trpc/server/routers/config/set-many.route.ts
+++ b/packages/trpc/server/routers/config/set-many.route.ts
@@ -1,7 +1,6 @@
 import { ConfigService } from "@ecehive/features";
 import { TRPCError } from "@trpc/server";
 import type { z } from "zod";
-import type { TPermissionProtectedProcedureContext } from "../../trpc";
 import type { ZSetManySchema } from "./schemas";
 
 type SetManyInput = z.infer<typeof ZSetManySchema>;
@@ -10,7 +9,6 @@ export async function setManyHandler({
 	input,
 }: {
 	input: SetManyInput;
-	ctx: TPermissionProtectedProcedureContext;
 }): Promise<void> {
 	try {
 		await ConfigService.setMany(input.values);

--- a/packages/trpc/server/routers/config/set-many.route.ts
+++ b/packages/trpc/server/routers/config/set-many.route.ts
@@ -1,0 +1,24 @@
+import { ConfigService } from "@ecehive/features";
+import { TRPCError } from "@trpc/server";
+import type { z } from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+import type { ZSetManySchema } from "./schemas";
+
+type SetManyInput = z.infer<typeof ZSetManySchema>;
+
+export async function setManyHandler({
+	input,
+}: {
+	input: SetManyInput;
+	ctx: TPermissionProtectedProcedureContext;
+}): Promise<void> {
+	try {
+		await ConfigService.setMany(input.values);
+	} catch (error) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message:
+				error instanceof Error ? error.message : "Failed to set configurations",
+		});
+	}
+}

--- a/packages/trpc/server/routers/config/set-value.route.ts
+++ b/packages/trpc/server/routers/config/set-value.route.ts
@@ -1,0 +1,24 @@
+import { ConfigService } from "@ecehive/features";
+import { TRPCError } from "@trpc/server";
+import type { z } from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+import type { ZSetValueSchema } from "./schemas";
+
+type SetValueInput = z.infer<typeof ZSetValueSchema>;
+
+export async function setValueHandler({
+	input,
+}: {
+	input: SetValueInput;
+	ctx: TPermissionProtectedProcedureContext;
+}): Promise<void> {
+	try {
+		await ConfigService.set(input.key, input.value);
+	} catch (error) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message:
+				error instanceof Error ? error.message : "Failed to set configuration",
+		});
+	}
+}

--- a/packages/trpc/server/routers/config/set-value.route.ts
+++ b/packages/trpc/server/routers/config/set-value.route.ts
@@ -1,7 +1,6 @@
-import { ConfigService } from "@ecehive/features";
+import { ConfigRegistry, ConfigService } from "@ecehive/features";
 import { TRPCError } from "@trpc/server";
 import type { z } from "zod";
-import type { TPermissionProtectedProcedureContext } from "../../trpc";
 import type { ZSetValueSchema } from "./schemas";
 
 type SetValueInput = z.infer<typeof ZSetValueSchema>;
@@ -10,15 +9,25 @@ export async function setValueHandler({
 	input,
 }: {
 	input: SetValueInput;
-	ctx: TPermissionProtectedProcedureContext;
 }): Promise<void> {
+	// Ensure the key exists in the registry
+	const defaultValue = ConfigRegistry.getDefault(input.key);
+	if (defaultValue === undefined) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Unknown configuration key: ${input.key}`,
+		});
+	}
+
 	try {
 		await ConfigService.set(input.key, input.value);
 	} catch (error) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message:
-				error instanceof Error ? error.message : "Failed to set configuration",
+				error instanceof Error
+					? error.message
+					: `Failed to set configuration: ${String(error)}`,
 		});
 	}
 }

--- a/packages/workers/src/jobs/end-old-sessions.ts
+++ b/packages/workers/src/jobs/end-old-sessions.ts
@@ -5,25 +5,31 @@ import { CronJob } from "cron";
 /**
  * Ends all active sessions (endedAt == null) that started more than the configured timeout ago.
  * Separate timeouts for regular and staffing sessions.
- * Runs hourly.
+ * Runs every 5 minutes.
  */
 export async function endOldSessions(): Promise<void> {
 	try {
 		const now = new Date();
 
-		// Get configuration values
-		const regularEnabled = await ConfigService.get<boolean>(
+        // Get configuration values in a single batched request
+		const configValues = await ConfigService.getMany([
 			"session.timeout.regular.enabled",
-		);
-		const regularHours = await ConfigService.get<number>(
 			"session.timeout.regular.hours",
-		);
-		const staffingEnabled = await ConfigService.get<boolean>(
 			"session.timeout.staffing.enabled",
-		);
-		const staffingHours = await ConfigService.get<number>(
 			"session.timeout.staffing.hours",
-		);
+		]);
+		const regularEnabled = configValues[
+			"session.timeout.regular.enabled"
+		] as boolean;
+		const regularHours = configValues[
+			"session.timeout.regular.hours"
+		] as number;
+		const staffingEnabled = configValues[
+			"session.timeout.staffing.enabled"
+		] as boolean;
+		const staffingHours = configValues[
+			"session.timeout.staffing.hours"
+		] as number;
 
 		let totalEnded = 0;
 
@@ -92,4 +98,4 @@ export async function endOldSessions(): Promise<void> {
 	}
 }
 
-export const endOldSessionsJob = new CronJob("0 * * * *", endOldSessions);
+export const endOldSessionsJob = new CronJob("*/5 * * * *", endOldSessions);

--- a/packages/workers/src/jobs/end-old-sessions.ts
+++ b/packages/workers/src/jobs/end-old-sessions.ts
@@ -1,35 +1,91 @@
+import { ConfigService } from "@ecehive/features";
 import { prisma } from "@ecehive/prisma";
 import { CronJob } from "cron";
 
 /**
- * Ends all active sessions (endedAt == null) that started more than 12 hours ago.
+ * Ends all active sessions (endedAt == null) that started more than the configured timeout ago.
+ * Separate timeouts for regular and staffing sessions.
  * Runs hourly.
  */
 export async function endOldSessions(): Promise<void> {
 	try {
 		const now = new Date();
-		const cutoff = new Date(now.getTime() - 12 * 60 * 60 * 1000); // 12 hours
 
-		// Find active sessions started before cutoff
-		const sessions = await prisma.session.findMany({
-			where: {
-				endedAt: null,
-				startedAt: { lt: cutoff },
-			},
-			select: { id: true, startedAt: true },
-		});
+		// Get configuration values
+		const regularEnabled = await ConfigService.get<boolean>(
+			"session.timeout.regular.enabled",
+		);
+		const regularHours = await ConfigService.get<number>(
+			"session.timeout.regular.hours",
+		);
+		const staffingEnabled = await ConfigService.get<boolean>(
+			"session.timeout.staffing.enabled",
+		);
+		const staffingHours = await ConfigService.get<number>(
+			"session.timeout.staffing.hours",
+		);
 
-		if (sessions.length === 0) return;
+		let totalEnded = 0;
 
-		// Bulk update: set endedAt to now for matched sessions
-		const ids = sessions.map((s) => s.id);
+		// End regular sessions if enabled
+		if (regularEnabled) {
+			const regularCutoff = new Date(
+				now.getTime() - regularHours * 60 * 60 * 1000,
+			);
 
-		await prisma.session.updateMany({
-			where: { id: { in: ids }, endedAt: null },
-			data: { endedAt: now },
-		});
+			const regularSessions = await prisma.session.findMany({
+				where: {
+					endedAt: null,
+					startedAt: { lt: regularCutoff },
+					sessionType: "regular",
+				},
+				select: { id: true },
+			});
 
-		console.info(`Ended ${ids.length} stale session(s) older than 12 hours.`);
+			if (regularSessions.length > 0) {
+				const ids = regularSessions.map((s) => s.id);
+				await prisma.session.updateMany({
+					where: { id: { in: ids }, endedAt: null },
+					data: { endedAt: now },
+				});
+				totalEnded += ids.length;
+				console.info(
+					`Ended ${ids.length} regular session(s) older than ${regularHours} hours.`,
+				);
+			}
+		}
+
+		// End staffing sessions if enabled
+		if (staffingEnabled) {
+			const staffingCutoff = new Date(
+				now.getTime() - staffingHours * 60 * 60 * 1000,
+			);
+
+			const staffingSessions = await prisma.session.findMany({
+				where: {
+					endedAt: null,
+					startedAt: { lt: staffingCutoff },
+					sessionType: "staffing",
+				},
+				select: { id: true },
+			});
+
+			if (staffingSessions.length > 0) {
+				const ids = staffingSessions.map((s) => s.id);
+				await prisma.session.updateMany({
+					where: { id: { in: ids }, endedAt: null },
+					data: { endedAt: now },
+				});
+				totalEnded += ids.length;
+				console.info(
+					`Ended ${ids.length} staffing session(s) older than ${staffingHours} hours.`,
+				);
+			}
+		}
+
+		if (totalEnded > 0) {
+			console.info(`Total sessions ended: ${totalEnded}`);
+		}
 	} catch (err) {
 		console.error("endOldSessions error:", err);
 		throw err;


### PR DESCRIPTION
This pull request introduces a new configuration management UI to the client application. Users with the necessary permissions can now view, edit, search, and reset configuration options through a dedicated “Configuration” page. The implementation includes reusable components for configuration fields, which support specifying typed fields, validation requirements, and conditionals.

As a sample, this pull request also includes a basic setup for configurations of session auto-logout (both general and staffing).

<img width="2028" height="1416" alt="image" src="https://github.com/user-attachments/assets/24596942-09ee-41d3-8978-0764828f7cad" />
