### PR TITLE
Add user suspension system

### DIFF
--- a/apps/client/src/components/navigation/app-sidebar.tsx
+++ b/apps/client/src/components/navigation/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "@tanstack/react-router";
 import {
+	BanIcon,
 	BugIcon,
 	CalendarIcon,
 	ChevronRightIcon,
@@ -54,6 +55,7 @@ import { permissions as appIndexPagePermissions } from "@/routes/app/index";
 import { permissions as kiosksPagePermissions } from "@/routes/app/kiosks";
 import { permissions as rolesPagePermissions } from "@/routes/app/roles";
 import { permissions as sessionsPagePermissions } from "@/routes/app/sessions";
+import { permissions as suspensionsPagePermissions } from "@/routes/app/suspensions";
 import { permissions as usersPagePermissions } from "@/routes/app/users";
 
 // Sidebar menu items, grouped by section
@@ -110,6 +112,12 @@ export const items: AppSidebarGroup[] = [
 				url: "/app/users",
 				icon: UserIcon,
 				permissions: usersPagePermissions,
+			},
+			{
+				title: "Suspensions",
+				url: "/app/suspensions",
+				icon: BanIcon,
+				permissions: suspensionsPagePermissions,
 			},
 			{
 				title: "Agreements",

--- a/apps/client/src/components/navigation/dynamic-breadcrumbs.tsx
+++ b/apps/client/src/components/navigation/dynamic-breadcrumbs.tsx
@@ -19,6 +19,7 @@ const routeLabels: Record<string, string> = {
 	"/app/periods": "Periods",
 	"/app/api-tokens": "API Tokens",
 	"/app/audit-logs": "Audit Logs",
+	"/app/suspensions": "Suspensions",
 	"/shifts": "Shifts",
 	"/shifts/": "Dashboard",
 	"/shifts/shift-schedules": "Shift Schedules",

--- a/apps/client/src/components/suspensions/columns.tsx
+++ b/apps/client/src/components/suspensions/columns.tsx
@@ -1,0 +1,125 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+import type { AuthUser } from "@/auth";
+import { Badge } from "@/components/ui/badge";
+import { checkPermissions } from "@/lib/permissions";
+import { SuspensionUpdateDialog } from "./update-dialog";
+
+type Suspension = {
+	id: number;
+	startDate: Date;
+	endDate: Date;
+	internalNotes: string | null;
+	externalNotes: string | null;
+	createdAt: Date;
+	user: {
+		id: number;
+		name: string;
+		username: string;
+		email: string;
+	};
+	createdBy: {
+		id: number;
+		name: string;
+		username: string;
+	} | null;
+};
+
+export type { Suspension };
+
+function getSuspensionStatus(
+	startDate: Date,
+	endDate: Date,
+): "active" | "upcoming" | "expired" {
+	const now = new Date();
+	if (endDate <= now) return "expired";
+	if (startDate <= now && endDate > now) return "active";
+	return "upcoming";
+}
+
+export function generateColumns(
+	user: AuthUser | null,
+): ColumnDef<Suspension>[] {
+	if (user === null) return [];
+
+	const canManage = checkPermissions(user, ["suspensions.manage"]);
+
+	return [
+		{
+			accessorKey: "user.name",
+			header: "User",
+			cell: ({ row }) => {
+				const suspension = row.original;
+				return (
+					<div className="flex flex-col">
+						<span className="font-medium">{suspension.user.name}</span>
+						<span className="text-sm text-muted-foreground">
+							{suspension.user.username}
+						</span>
+					</div>
+				);
+			},
+		},
+		{
+			accessorKey: "status",
+			header: "Status",
+			cell: ({ row }) => {
+				const suspension = row.original;
+				const status = getSuspensionStatus(
+					suspension.startDate,
+					suspension.endDate,
+				);
+
+				const variants = {
+					active: "destructive" as const,
+					upcoming: "warning" as const,
+					expired: "secondary" as const,
+				};
+
+				const labels = {
+					active: "Active",
+					upcoming: "Upcoming",
+					expired: "Expired",
+				};
+
+				return <Badge variant={variants[status]}>{labels[status]}</Badge>;
+			},
+		},
+		{
+			accessorKey: "startDate",
+			header: "Start Date",
+			cell: ({ row }) => {
+				const date = row.original.startDate;
+				return format(date, "MMM d, yyyy h:mm a");
+			},
+		},
+		{
+			accessorKey: "endDate",
+			header: "End Date",
+			cell: ({ row }) => {
+				const date = row.original.endDate;
+				return format(date, "MMM d, yyyy h:mm a");
+			},
+		},
+		{
+			accessorKey: "createdBy",
+			header: "Created By",
+			cell: ({ row }) => {
+				const createdBy = row.original.createdBy;
+				return createdBy ? createdBy.name : "—";
+			},
+		},
+		{
+			accessorKey: "actions",
+			header: "",
+			cell: ({ row }) => {
+				if (!canManage) return null;
+				return (
+					<div className="flex gap-2 items-center">
+						<SuspensionUpdateDialog suspension={row.original} />
+					</div>
+				);
+			},
+		},
+	];
+}

--- a/apps/client/src/components/suspensions/create-dialog.tsx
+++ b/apps/client/src/components/suspensions/create-dialog.tsx
@@ -109,7 +109,7 @@ export function SuspensionCreateDialog({
 					return;
 				}
 
-				if (endDate <= startDate) {
+				if (endDate < startDate) {
 					setServerError("End date must be after start date");
 					return;
 				}

--- a/apps/client/src/components/suspensions/create-dialog.tsx
+++ b/apps/client/src/components/suspensions/create-dialog.tsx
@@ -1,0 +1,464 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useForm, useStore } from "@tanstack/react-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDownIcon } from "lucide-react";
+import { useCallback, useId, useState } from "react";
+import type { JSX } from "react/jsx-runtime";
+import { z } from "zod";
+import { useAuth } from "@/auth/AuthProvider";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { checkPermissions } from "@/lib/permissions";
+import { parseDateTimeInput } from "./datetime";
+
+const formSchema = z.object({
+	userId: z.number("User is required"),
+	startDate: z.string().min(1, "Start date is required"),
+	startTime: z.string().min(1, "Start time is required"),
+	endDate: z.string().min(1, "End date is required"),
+	endTime: z.string().min(1, "End time is required"),
+	internalNotes: z.string().optional(),
+	externalNotes: z.string().optional(),
+});
+
+type CreateDialogProps = {
+	onUpdate?: () => void;
+};
+
+export function SuspensionCreateDialog({
+	onUpdate,
+}: CreateDialogProps): JSX.Element {
+	const [open, setOpen] = useState(false);
+	const [serverError, setServerError] = useState<string | null>(null);
+	const [userSearch, setUserSearch] = useState("");
+	const [startDatePopoverOpen, setStartDatePopoverOpen] = useState(false);
+	const [endDatePopoverOpen, setEndDatePopoverOpen] = useState(false);
+	const queryClient = useQueryClient();
+	const formId = useId();
+
+	const { data: usersData } = useQuery({
+		queryKey: ["users", { search: userSearch, limit: 20 }],
+		queryFn: async () => {
+			return await trpc.users.list.query({
+				search: userSearch || undefined,
+				limit: 20,
+			});
+		},
+		enabled: open,
+	});
+
+	const createMutation = useMutation({
+		mutationFn: (input: {
+			userId: number;
+			startDate: Date;
+			endDate: Date;
+			internalNotes?: string;
+			externalNotes?: string;
+		}) => trpc.suspensions.create.mutate(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["suspensions"] });
+		},
+	});
+
+	const form = useForm({
+		defaultValues: {
+			userId: undefined as number | undefined,
+			startDate: "",
+			startTime: "00:00:00",
+			endDate: "",
+			endTime: "23:59:59",
+			internalNotes: "",
+			externalNotes: "",
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: async ({ value }) => {
+			try {
+				const startDate = parseDateTimeInput(value.startDate, value.startTime);
+				const endDate = parseDateTimeInput(value.endDate, value.endTime);
+
+				if (!startDate || !endDate) {
+					setServerError("Invalid date or time format");
+					return;
+				}
+
+				if (endDate <= startDate) {
+					setServerError("End date must be after start date");
+					return;
+				}
+
+				if (value.userId === undefined) {
+					setServerError("User is required");
+					return;
+				}
+
+				await createMutation.mutateAsync({
+					userId: value.userId,
+					startDate,
+					endDate,
+					internalNotes: value.internalNotes || undefined,
+					externalNotes: value.externalNotes || undefined,
+				});
+				setOpen(false);
+				onUpdate?.();
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				setServerError(message);
+			}
+		},
+	});
+
+	const isSubmitting = useStore(form.store, (state) => state.isSubmitting);
+	const canSubmit = useStore(form.store, (state) => state.canSubmit);
+
+	const handleDialogChange = useCallback(
+		(nextOpen: boolean) => {
+			setOpen(nextOpen);
+			if (!nextOpen) {
+				form.reset();
+				setServerError(null);
+				setUserSearch("");
+			}
+		},
+		[form],
+	);
+
+	const user = useAuth().user;
+	const canCreate = user && checkPermissions(user, ["suspensions.manage"]);
+
+	return (
+		<Dialog open={open} onOpenChange={handleDialogChange}>
+			<DialogTrigger asChild>
+				<Button disabled={!canCreate}>Create Suspension</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-[600px]">
+				<DialogHeader>
+					<DialogTitle>Create Suspension</DialogTitle>
+					<DialogDescription>
+						Create a new suspension for a user. The user will be notified via
+						email when the suspension starts.
+					</DialogDescription>
+				</DialogHeader>
+				<form
+					id={formId}
+					className="space-y-4"
+					onSubmit={(event) => {
+						event.preventDefault();
+						form.handleSubmit();
+					}}
+					noValidate
+				>
+					<form.Field
+						name="userId"
+						children={(field) => {
+							const isInvalid =
+								field.state.meta.isTouched && !field.state.meta.isValid;
+							return (
+								<Field data-invalid={isInvalid}>
+									<FieldLabel htmlFor={field.name}>User</FieldLabel>
+									<Select
+										value={field.state.value?.toString() ?? ""}
+										onValueChange={(value) =>
+											field.handleChange(Number.parseInt(value, 10))
+										}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="Select a user" />
+										</SelectTrigger>
+										<SelectContent>
+											<div className="p-2">
+												<Input
+													placeholder="Search users..."
+													value={userSearch}
+													onChange={(e) => setUserSearch(e.target.value)}
+													className="mb-2"
+												/>
+											</div>
+											{usersData?.users.map((u) => (
+												<SelectItem key={u.id} value={u.id.toString()}>
+													{u.name} ({u.username})
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+									{isInvalid && <FieldError errors={field.state.meta.errors} />}
+								</Field>
+							);
+						}}
+					/>
+
+					<div className="space-y-4">
+						<div>
+							<FieldLabel className="mb-3">Start Date & Time</FieldLabel>
+							<div className="flex gap-4">
+								<form.Field
+									name="startDate"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										const selectedDate = field.state.value
+											? new Date(`${field.state.value}T00:00:00`)
+											: undefined;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Popover
+													open={startDatePopoverOpen}
+													onOpenChange={setStartDatePopoverOpen}
+												>
+													<PopoverTrigger asChild>
+														<Button
+															variant="outline"
+															id={field.name}
+															className="w-full justify-between font-normal"
+														>
+															{selectedDate
+																? selectedDate.toLocaleDateString()
+																: "Select date"}
+															<ChevronDownIcon />
+														</Button>
+													</PopoverTrigger>
+													<PopoverContent
+														className="w-auto overflow-hidden p-0"
+														align="start"
+													>
+														<Calendar
+															mode="single"
+															selected={selectedDate}
+															captionLayout="dropdown"
+															onSelect={(date) => {
+																if (date) {
+																	const year = date.getFullYear();
+																	const month = String(
+																		date.getMonth() + 1,
+																	).padStart(2, "0");
+																	const day = String(date.getDate()).padStart(
+																		2,
+																		"0",
+																	);
+																	field.handleChange(`${year}-${month}-${day}`);
+																}
+																setStartDatePopoverOpen(false);
+															}}
+														/>
+													</PopoverContent>
+												</Popover>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+								<form.Field
+									name="startTime"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Input
+													type="time"
+													id={field.name}
+													step="1"
+													value={field.state.value}
+													onBlur={field.handleBlur}
+													onChange={(e) => field.handleChange(e.target.value)}
+													className="bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+												/>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+							</div>
+						</div>
+
+						<div>
+							<FieldLabel className="mb-3">End Date & Time</FieldLabel>
+							<div className="flex gap-4">
+								<form.Field
+									name="endDate"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										const selectedDate = field.state.value
+											? new Date(`${field.state.value}T00:00:00`)
+											: undefined;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Popover
+													open={endDatePopoverOpen}
+													onOpenChange={setEndDatePopoverOpen}
+												>
+													<PopoverTrigger asChild>
+														<Button
+															variant="outline"
+															id={field.name}
+															className="w-full justify-between font-normal"
+														>
+															{selectedDate
+																? selectedDate.toLocaleDateString()
+																: "Select date"}
+															<ChevronDownIcon />
+														</Button>
+													</PopoverTrigger>
+													<PopoverContent
+														className="w-auto overflow-hidden p-0"
+														align="start"
+													>
+														<Calendar
+															mode="single"
+															selected={selectedDate}
+															captionLayout="dropdown"
+															onSelect={(date) => {
+																if (date) {
+																	const year = date.getFullYear();
+																	const month = String(
+																		date.getMonth() + 1,
+																	).padStart(2, "0");
+																	const day = String(date.getDate()).padStart(
+																		2,
+																		"0",
+																	);
+																	field.handleChange(`${year}-${month}-${day}`);
+																}
+																setEndDatePopoverOpen(false);
+															}}
+														/>
+													</PopoverContent>
+												</Popover>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+								<form.Field
+									name="endTime"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Input
+													type="time"
+													id={field.name}
+													step="1"
+													value={field.state.value}
+													onBlur={field.handleBlur}
+													onChange={(e) => field.handleChange(e.target.value)}
+													className="bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+												/>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+							</div>
+						</div>
+					</div>
+
+					<form.Field
+						name="internalNotes"
+						children={(field) => {
+							return (
+								<Field>
+									<FieldLabel htmlFor={field.name}>
+										Internal Notes{" "}
+										<span className="text-muted-foreground">
+											(not shared with user)
+										</span>
+									</FieldLabel>
+									<Textarea
+										id={field.name}
+										name={field.name}
+										value={field.state.value}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										placeholder="Add internal notes for staff..."
+										rows={3}
+									/>
+								</Field>
+							);
+						}}
+					/>
+
+					<form.Field
+						name="externalNotes"
+						children={(field) => {
+							return (
+								<Field>
+									<FieldLabel htmlFor={field.name}>
+										External Notes{" "}
+										<span className="text-muted-foreground">
+											(shared with user in email)
+										</span>
+									</FieldLabel>
+									<Textarea
+										id={field.name}
+										name={field.name}
+										value={field.state.value}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										placeholder="Add notes that will be sent to the user..."
+										rows={3}
+									/>
+								</Field>
+							);
+						}}
+					/>
+
+					{serverError && (
+						<p className="text-sm text-destructive">{serverError}</p>
+					)}
+
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button type="button" variant="outline">
+								Cancel
+							</Button>
+						</DialogClose>
+						<Button
+							type="submit"
+							disabled={isSubmitting || !canSubmit || !canCreate}
+						>
+							{isSubmitting ? <Spinner /> : "Create"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/client/src/components/suspensions/datetime.ts
+++ b/apps/client/src/components/suspensions/datetime.ts
@@ -1,0 +1,37 @@
+import { dayjs, getAppTimezone } from "@/lib/timezone";
+
+const DATE_FORMAT = "YYYY-MM-DD";
+const TIME_FORMAT = "HH:mm:ss";
+
+/**
+ * Format a Date object to a date string in the app timezone for the date picker.
+ */
+export function formatDateForInput(value?: Date | null): string {
+	if (!value) return "";
+	const appTz = getAppTimezone();
+	return dayjs(value).tz(appTz).format(DATE_FORMAT);
+}
+
+/**
+ * Format a Date object to a time string in the app timezone for the time picker.
+ */
+export function formatTimeForInput(value?: Date | null): string {
+	if (!value) return "";
+	const appTz = getAppTimezone();
+	return dayjs(value).tz(appTz).format(TIME_FORMAT);
+}
+
+/**
+ * Parse a date string and time string into a Date object, treating the input
+ * as being in the app timezone.
+ */
+export function parseDateTimeInput(
+	dateStr: string,
+	timeStr: string,
+): Date | null {
+	if (!dateStr || !timeStr) return null;
+	const appTz = getAppTimezone();
+	const combined = `${dateStr}T${timeStr}`;
+	const parsed = dayjs.tz(combined, appTz);
+	return parsed.isValid() ? parsed.toDate() : null;
+}

--- a/apps/client/src/components/suspensions/update-dialog.tsx
+++ b/apps/client/src/components/suspensions/update-dialog.tsx
@@ -1,0 +1,416 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useForm, useStore } from "@tanstack/react-form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ChevronDownIcon, PencilIcon } from "lucide-react";
+import { useCallback, useId, useState } from "react";
+import type { JSX } from "react/jsx-runtime";
+import { z } from "zod";
+import { useAuth } from "@/auth/AuthProvider";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { checkPermissions } from "@/lib/permissions";
+import type { Suspension } from "./columns";
+import {
+	formatDateForInput,
+	formatTimeForInput,
+	parseDateTimeInput,
+} from "./datetime";
+
+const formSchema = z.object({
+	startDate: z.string().min(1, "Start date is required"),
+	startTime: z.string().min(1, "Start time is required"),
+	endDate: z.string().min(1, "End date is required"),
+	endTime: z.string().min(1, "End time is required"),
+	internalNotes: z.string().optional(),
+	externalNotes: z.string().optional(),
+});
+
+type UpdateDialogProps = {
+	suspension: Suspension;
+	onUpdate?: () => void;
+};
+
+export function SuspensionUpdateDialog({
+	suspension,
+	onUpdate,
+}: UpdateDialogProps): JSX.Element {
+	const [open, setOpen] = useState(false);
+	const [serverError, setServerError] = useState<string | null>(null);
+	const [startDatePopoverOpen, setStartDatePopoverOpen] = useState(false);
+	const [endDatePopoverOpen, setEndDatePopoverOpen] = useState(false);
+	const queryClient = useQueryClient();
+	const formId = useId();
+
+	const updateMutation = useMutation({
+		mutationFn: (input: {
+			id: number;
+			startDate?: Date;
+			endDate?: Date;
+			internalNotes?: string | null;
+			externalNotes?: string | null;
+		}) => trpc.suspensions.update.mutate(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["suspensions"] });
+		},
+	});
+
+	const form = useForm({
+		defaultValues: {
+			startDate: formatDateForInput(suspension.startDate),
+			startTime: formatTimeForInput(suspension.startDate),
+			endDate: formatDateForInput(suspension.endDate),
+			endTime: formatTimeForInput(suspension.endDate),
+			internalNotes: suspension.internalNotes ?? "",
+			externalNotes: suspension.externalNotes ?? "",
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: async ({ value }) => {
+			try {
+				const startDate = parseDateTimeInput(value.startDate, value.startTime);
+				const endDate = parseDateTimeInput(value.endDate, value.endTime);
+
+				if (!startDate || !endDate) {
+					setServerError("Invalid date or time format");
+					return;
+				}
+
+				if (endDate <= startDate) {
+					setServerError("End date must be after start date");
+					return;
+				}
+
+				await updateMutation.mutateAsync({
+					id: suspension.id,
+					startDate,
+					endDate,
+					internalNotes: value.internalNotes || null,
+					externalNotes: value.externalNotes || null,
+				});
+				setOpen(false);
+				onUpdate?.();
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				setServerError(message);
+			}
+		},
+	});
+
+	const isSubmitting = useStore(form.store, (state) => state.isSubmitting);
+	const canSubmit = useStore(form.store, (state) => state.canSubmit);
+
+	const handleDialogChange = useCallback(
+		(nextOpen: boolean) => {
+			setOpen(nextOpen);
+			if (!nextOpen) {
+				form.reset();
+				setServerError(null);
+			}
+		},
+		[form],
+	);
+
+	const currentUser = useAuth().user;
+	const canUpdate =
+		currentUser && checkPermissions(currentUser, ["suspensions.manage"]);
+
+	return (
+		<Dialog open={open} onOpenChange={handleDialogChange}>
+			<DialogTrigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					disabled={!canUpdate}
+					aria-label={`Edit suspension for ${suspension.user.username}`}
+					title={`Edit suspension for ${suspension.user.username}`}
+				>
+					<PencilIcon className="h-4 w-4" />
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-[600px]">
+				<DialogHeader>
+					<DialogTitle>Edit Suspension</DialogTitle>
+					<DialogDescription>
+						Edit suspension for{" "}
+						<strong>
+							{suspension.user.name} ({suspension.user.username})
+						</strong>
+					</DialogDescription>
+				</DialogHeader>
+				<form
+					id={formId}
+					className="space-y-4"
+					onSubmit={(event) => {
+						event.preventDefault();
+						form.handleSubmit();
+					}}
+					noValidate
+				>
+					<div className="space-y-4">
+						<div>
+							<FieldLabel className="mb-3">Start Date & Time</FieldLabel>
+							<div className="flex gap-4">
+								<form.Field
+									name="startDate"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										const selectedDate = field.state.value
+											? new Date(`${field.state.value}T00:00:00`)
+											: undefined;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Popover
+													open={startDatePopoverOpen}
+													onOpenChange={setStartDatePopoverOpen}
+												>
+													<PopoverTrigger asChild>
+														<Button
+															variant="outline"
+															id={field.name}
+															className="w-full justify-between font-normal"
+														>
+															{selectedDate
+																? selectedDate.toLocaleDateString()
+																: "Select date"}
+															<ChevronDownIcon />
+														</Button>
+													</PopoverTrigger>
+													<PopoverContent
+														className="w-auto overflow-hidden p-0"
+														align="start"
+													>
+														<Calendar
+															mode="single"
+															selected={selectedDate}
+															captionLayout="dropdown"
+															onSelect={(date) => {
+																if (date) {
+																	const year = date.getFullYear();
+																	const month = String(
+																		date.getMonth() + 1,
+																	).padStart(2, "0");
+																	const day = String(date.getDate()).padStart(
+																		2,
+																		"0",
+																	);
+																	field.handleChange(`${year}-${month}-${day}`);
+																}
+																setStartDatePopoverOpen(false);
+															}}
+														/>
+													</PopoverContent>
+												</Popover>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+								<form.Field
+									name="startTime"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Input
+													type="time"
+													id={field.name}
+													step="1"
+													value={field.state.value}
+													onBlur={field.handleBlur}
+													onChange={(e) => field.handleChange(e.target.value)}
+													className="bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+												/>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+							</div>
+						</div>
+
+						<div>
+							<FieldLabel className="mb-3">End Date & Time</FieldLabel>
+							<div className="flex gap-4">
+								<form.Field
+									name="endDate"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										const selectedDate = field.state.value
+											? new Date(`${field.state.value}T00:00:00`)
+											: undefined;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Popover
+													open={endDatePopoverOpen}
+													onOpenChange={setEndDatePopoverOpen}
+												>
+													<PopoverTrigger asChild>
+														<Button
+															variant="outline"
+															id={field.name}
+															className="w-full justify-between font-normal"
+														>
+															{selectedDate
+																? selectedDate.toLocaleDateString()
+																: "Select date"}
+															<ChevronDownIcon />
+														</Button>
+													</PopoverTrigger>
+													<PopoverContent
+														className="w-auto overflow-hidden p-0"
+														align="start"
+													>
+														<Calendar
+															mode="single"
+															selected={selectedDate}
+															captionLayout="dropdown"
+															onSelect={(date) => {
+																if (date) {
+																	const year = date.getFullYear();
+																	const month = String(
+																		date.getMonth() + 1,
+																	).padStart(2, "0");
+																	const day = String(date.getDate()).padStart(
+																		2,
+																		"0",
+																	);
+																	field.handleChange(`${year}-${month}-${day}`);
+																}
+																setEndDatePopoverOpen(false);
+															}}
+														/>
+													</PopoverContent>
+												</Popover>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+								<form.Field
+									name="endTime"
+									children={(field) => {
+										const isInvalid =
+											field.state.meta.isTouched && !field.state.meta.isValid;
+										return (
+											<Field data-invalid={isInvalid} className="flex-1">
+												<Input
+													type="time"
+													id={field.name}
+													step="1"
+													value={field.state.value}
+													onBlur={field.handleBlur}
+													onChange={(e) => field.handleChange(e.target.value)}
+													className="bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+												/>
+												{isInvalid && (
+													<FieldError errors={field.state.meta.errors} />
+												)}
+											</Field>
+										);
+									}}
+								/>
+							</div>
+						</div>
+					</div>
+
+					<form.Field
+						name="internalNotes"
+						children={(field) => {
+							return (
+								<Field>
+									<FieldLabel htmlFor={field.name}>
+										Internal Notes{" "}
+										<span className="text-muted-foreground">
+											(not shared with user)
+										</span>
+									</FieldLabel>
+									<Textarea
+										id={field.name}
+										name={field.name}
+										value={field.state.value}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										placeholder="Add internal notes for staff..."
+										rows={3}
+									/>
+								</Field>
+							);
+						}}
+					/>
+
+					<form.Field
+						name="externalNotes"
+						children={(field) => {
+							return (
+								<Field>
+									<FieldLabel htmlFor={field.name}>
+										External Notes{" "}
+										<span className="text-muted-foreground">
+											(shared with user in email)
+										</span>
+									</FieldLabel>
+									<Textarea
+										id={field.name}
+										name={field.name}
+										value={field.state.value}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										placeholder="Add notes that will be sent to the user..."
+										rows={3}
+									/>
+								</Field>
+							);
+						}}
+					/>
+
+					{serverError && (
+						<p className="text-sm text-destructive">{serverError}</p>
+					)}
+
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button type="button" variant="outline">
+								Cancel
+							</Button>
+						</DialogClose>
+						<Button
+							type="submit"
+							disabled={isSubmitting || !canSubmit || !canUpdate}
+						>
+							{isSubmitting ? <Spinner /> : "Save Changes"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/client/src/components/suspensions/update-dialog.tsx
+++ b/apps/client/src/components/suspensions/update-dialog.tsx
@@ -95,7 +95,7 @@ export function SuspensionUpdateDialog({
 					return;
 				}
 
-				if (endDate <= startDate) {
+				if (endDate < startDate) {
 					setServerError("End date must be after start date");
 					return;
 				}

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as ShiftsMyShiftsRouteImport } from './routes/shifts/my-shifts'
 import { Route as ShiftsManageUsersRouteImport } from './routes/shifts/manage-users'
 import { Route as ShiftsAttendanceRouteImport } from './routes/shifts/attendance'
 import { Route as AppUsersRouteImport } from './routes/app/users'
+import { Route as AppSuspensionsRouteImport } from './routes/app/suspensions'
 import { Route as AppSessionsRouteImport } from './routes/app/sessions'
 import { Route as AppRolesRouteImport } from './routes/app/roles'
 import { Route as AppMySessionsRouteImport } from './routes/app/my-sessions'
@@ -121,6 +122,11 @@ const AppUsersRoute = AppUsersRouteImport.update({
   path: '/users',
   getParentRoute: () => AppRoute,
 } as any)
+const AppSuspensionsRoute = AppSuspensionsRouteImport.update({
+  id: '/suspensions',
+  path: '/suspensions',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppSessionsRoute = AppSessionsRouteImport.update({
   id: '/sessions',
   path: '/sessions',
@@ -182,6 +188,7 @@ export interface FileRoutesByFullPath {
   '/app/my-sessions': typeof AppMySessionsRoute
   '/app/roles': typeof AppRolesRoute
   '/app/sessions': typeof AppSessionsRoute
+  '/app/suspensions': typeof AppSuspensionsRoute
   '/app/users': typeof AppUsersRoute
   '/shifts/attendance': typeof ShiftsAttendanceRoute
   '/shifts/manage-users': typeof ShiftsManageUsersRoute
@@ -208,6 +215,7 @@ export interface FileRoutesByTo {
   '/app/my-sessions': typeof AppMySessionsRoute
   '/app/roles': typeof AppRolesRoute
   '/app/sessions': typeof AppSessionsRoute
+  '/app/suspensions': typeof AppSuspensionsRoute
   '/app/users': typeof AppUsersRoute
   '/shifts/attendance': typeof ShiftsAttendanceRoute
   '/shifts/manage-users': typeof ShiftsManageUsersRoute
@@ -237,6 +245,7 @@ export interface FileRoutesById {
   '/app/my-sessions': typeof AppMySessionsRoute
   '/app/roles': typeof AppRolesRoute
   '/app/sessions': typeof AppSessionsRoute
+  '/app/suspensions': typeof AppSuspensionsRoute
   '/app/users': typeof AppUsersRoute
   '/shifts/attendance': typeof ShiftsAttendanceRoute
   '/shifts/manage-users': typeof ShiftsManageUsersRoute
@@ -267,6 +276,7 @@ export interface FileRouteTypes {
     | '/app/my-sessions'
     | '/app/roles'
     | '/app/sessions'
+    | '/app/suspensions'
     | '/app/users'
     | '/shifts/attendance'
     | '/shifts/manage-users'
@@ -293,6 +303,7 @@ export interface FileRouteTypes {
     | '/app/my-sessions'
     | '/app/roles'
     | '/app/sessions'
+    | '/app/suspensions'
     | '/app/users'
     | '/shifts/attendance'
     | '/shifts/manage-users'
@@ -321,6 +332,7 @@ export interface FileRouteTypes {
     | '/app/my-sessions'
     | '/app/roles'
     | '/app/sessions'
+    | '/app/suspensions'
     | '/app/users'
     | '/shifts/attendance'
     | '/shifts/manage-users'
@@ -464,6 +476,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppUsersRouteImport
       parentRoute: typeof AppRoute
     }
+    '/app/suspensions': {
+      id: '/app/suspensions'
+      path: '/suspensions'
+      fullPath: '/app/suspensions'
+      preLoaderRoute: typeof AppSuspensionsRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/app/sessions': {
       id: '/app/sessions'
       path: '/sessions'
@@ -540,6 +559,7 @@ interface AppRouteChildren {
   AppMySessionsRoute: typeof AppMySessionsRoute
   AppRolesRoute: typeof AppRolesRoute
   AppSessionsRoute: typeof AppSessionsRoute
+  AppSuspensionsRoute: typeof AppSuspensionsRoute
   AppUsersRoute: typeof AppUsersRoute
   AppIndexRoute: typeof AppIndexRoute
 }
@@ -554,6 +574,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppMySessionsRoute: AppMySessionsRoute,
   AppRolesRoute: AppRolesRoute,
   AppSessionsRoute: AppSessionsRoute,
+  AppSuspensionsRoute: AppSuspensionsRoute,
   AppUsersRoute: AppUsersRoute,
   AppIndexRoute: AppIndexRoute,
 }

--- a/apps/client/src/routes/app/suspensions.tsx
+++ b/apps/client/src/routes/app/suspensions.tsx
@@ -1,0 +1,126 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import React from "react";
+import { RequirePermissions, useAuth } from "@/auth";
+import { MissingPermissions } from "@/components/guards/missing-permissions";
+import {
+	Page,
+	PageActions,
+	PageContent,
+	PageHeader,
+	PageTitle,
+	TableContainer,
+	TableSearchInput,
+	TableToolbar,
+} from "@/components/layout";
+import {
+	DataTable,
+	SearchInput,
+	TablePaginationFooter,
+} from "@/components/shared";
+import { generateColumns } from "@/components/suspensions/columns";
+import { SuspensionCreateDialog } from "@/components/suspensions/create-dialog";
+import { usePaginationInfo } from "@/hooks/use-pagination-info";
+import { useTableState } from "@/hooks/use-table-state";
+
+export const Route = createFileRoute("/app/suspensions")({
+	component: () =>
+		RequirePermissions({
+			permissions,
+			children: <Suspensions />,
+			forbiddenFallback: <MissingPermissions />,
+		}),
+});
+
+export const permissions = ["suspensions.list"];
+
+function Suspensions() {
+	const {
+		page,
+		setPage,
+		pageSize,
+		setPageSize,
+		offset,
+		search,
+		setSearch,
+		debouncedSearch,
+		resetToFirstPage,
+	} = useTableState();
+
+	const queryParams = React.useMemo(() => {
+		return {
+			search:
+				debouncedSearch.trim() === "" ? undefined : debouncedSearch.trim(),
+			offset,
+			limit: pageSize,
+		};
+	}, [debouncedSearch, offset, pageSize]);
+
+	const { data = { suspensions: [], total: 0 }, isLoading } = useQuery({
+		queryKey: ["suspensions", queryParams],
+		queryFn: async () => {
+			return await trpc.suspensions.list.query(queryParams);
+		},
+		retry: false,
+	});
+
+	const columns = generateColumns(useAuth().user);
+	const { totalPages } = usePaginationInfo({
+		total: data.total,
+		pageSize,
+		offset,
+		currentCount: data.suspensions.length,
+	});
+
+	return (
+		<Page>
+			<PageHeader>
+				<PageTitle>Suspensions</PageTitle>
+				<PageActions>
+					<SuspensionCreateDialog onUpdate={() => resetToFirstPage()} />
+				</PageActions>
+			</PageHeader>
+
+			<PageContent>
+				<TableContainer>
+					<TableToolbar>
+						<TableSearchInput>
+							<SearchInput
+								placeholder="Search suspensions..."
+								value={search}
+								onChange={(value) => {
+									setSearch(value);
+									resetToFirstPage();
+								}}
+							/>
+						</TableSearchInput>
+					</TableToolbar>
+
+					<DataTable
+						columns={columns}
+						data={data.suspensions}
+						isLoading={isLoading}
+						emptyMessage="No suspensions found"
+						emptyDescription="Create a suspension to restrict user access"
+					/>
+
+					<TablePaginationFooter
+						page={page}
+						totalPages={totalPages}
+						onPageChange={setPage}
+						offset={offset}
+						currentCount={data.suspensions.length}
+						total={data.total}
+						itemName="suspensions"
+						pageSize={pageSize}
+						onPageSizeChange={(size) => {
+							setPageSize(size);
+							resetToFirstPage();
+						}}
+					/>
+				</TableContainer>
+			</PageContent>
+		</Page>
+	);
+}

--- a/apps/kiosk/src/App.tsx
+++ b/apps/kiosk/src/App.tsx
@@ -108,6 +108,7 @@ function App() {
 							tapOutActionSelection={tapWorkflow.tapOutActionSelection}
 							pendingAgreement={tapWorkflow.pendingAgreement}
 							tapNotification={tapWorkflow.tapNotification}
+							suspension={tapWorkflow.suspension}
 							onSessionTypeSelect={tapWorkflow.handleSessionTypeSelect}
 							onSessionTypeCancel={tapWorkflow.handleSessionTypeCancel}
 							onTapOutActionSelect={tapWorkflow.handleTapOutActionSelect}

--- a/apps/kiosk/src/components/flow-overlays.tsx
+++ b/apps/kiosk/src/components/flow-overlays.tsx
@@ -4,11 +4,13 @@ import { AgreementFlow } from "@/components/agreement-flow";
 import { ErrorDialog } from "@/components/error-dialog";
 import type { SelectionOverlayOption } from "@/components/session-type-selector";
 import { SelectionOverlay } from "@/components/session-type-selector";
+import { SuspensionDialog } from "@/components/suspension-dialog";
 import { TapNotification } from "@/components/tap-notification";
 import type {
 	ErrorDialogState,
 	PendingAgreementState,
 	SessionTypeSelectionState,
+	SuspensionState,
 	TapNotificationState,
 	TapOutActionSelectionState,
 } from "@/hooks/use-tap-workflow";
@@ -20,6 +22,7 @@ interface FlowOverlaysProps {
 	tapOutActionSelection: TapOutActionSelectionState | null;
 	pendingAgreement: PendingAgreementState | null;
 	tapNotification: TapNotificationState;
+	suspension: SuspensionState | null;
 	onSessionTypeSelect: (type: "regular" | "staffing") => void;
 	onSessionTypeCancel: () => void;
 	onTapOutActionSelect: (
@@ -38,6 +41,7 @@ export function FlowOverlays({
 	tapOutActionSelection,
 	pendingAgreement,
 	tapNotification,
+	suspension,
 	onSessionTypeSelect,
 	onSessionTypeCancel,
 	onTapOutActionSelect,
@@ -51,7 +55,8 @@ export function FlowOverlays({
 		!!errorDialog.message ||
 		!!pendingAgreement ||
 		!!sessionTypeSelection ||
-		!!tapOutActionSelection;
+		!!tapOutActionSelection ||
+		!!suspension;
 
 	type OverlayConfig = {
 		key: "session" | "tapout";
@@ -165,6 +170,15 @@ export function FlowOverlays({
 				<ErrorDialog
 					message={errorDialog.message}
 					isExiting={errorDialog.isExiting}
+				/>
+			)}
+
+			{suspension && (
+				<SuspensionDialog
+					userName={suspension.userName}
+					endDate={suspension.endDate}
+					externalNotes={suspension.externalNotes}
+					isExiting={suspension.isExiting}
 				/>
 			)}
 

--- a/apps/kiosk/src/components/suspension-dialog.tsx
+++ b/apps/kiosk/src/components/suspension-dialog.tsx
@@ -1,0 +1,90 @@
+import { format } from "date-fns";
+import { BanIcon } from "lucide-react";
+import { motion } from "motion/react";
+
+interface SuspensionDialogProps {
+	userName: string;
+	endDate: Date;
+	isExiting: boolean;
+}
+
+export function SuspensionDialog({
+	userName,
+	endDate,
+	isExiting,
+}: SuspensionDialogProps) {
+	const formattedEndDate = format(endDate, "MMMM d, yyyy 'at' h:mm a");
+
+	return (
+		<motion.div
+			className="absolute inset-0 z-50 p-8 flex items-center justify-center bg-black/95 backdrop-blur-md"
+			initial={{ opacity: 0 }}
+			animate={{ opacity: isExiting ? 0 : 1 }}
+			transition={{ duration: 0.3 }}
+		>
+			<motion.div
+				className="p-4 max-w-3xl mx-auto"
+				initial={{ opacity: 0, scale: 0.95, y: 16 }}
+				animate={{
+					opacity: isExiting ? 0 : 1,
+					scale: isExiting ? 0.95 : 1,
+					y: isExiting ? 16 : 0,
+				}}
+				transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+			>
+				<div className="border-destructive border-4 shadow-2xl transition-colors duration-300 p-8 bg-background rounded-lg">
+					<div className="flex flex-col items-center gap-8">
+						<div className="relative flex items-center justify-center">
+							<motion.div
+								initial={{ scale: 0.85, opacity: 0 }}
+								animate={{
+									scale: isExiting ? 0.85 : 1,
+									opacity: isExiting ? 0 : 1,
+								}}
+								transition={{ duration: 0.6, ease: "easeOut" }}
+							>
+								<BanIcon className="w-32 h-32 text-destructive" />
+							</motion.div>
+							<motion.div
+								className="absolute inset-0"
+								initial={{ scale: 0.9, opacity: 0.4 }}
+								animate={
+									isExiting
+										? { scale: 0.9, opacity: 0 }
+										: { scale: [0.9, 1.4], opacity: [0.4, 0] }
+								}
+								transition={
+									isExiting
+										? { duration: 0.3, ease: "easeInOut" }
+										: { duration: 1.2, repeat: Infinity, ease: "easeOut" }
+								}
+							>
+								<BanIcon className="w-32 h-32 text-destructive opacity-40" />
+							</motion.div>
+						</div>
+
+						<motion.div
+							className="text-center gap-4 flex flex-col"
+							initial={{ opacity: 0, y: 12 }}
+							animate={{ opacity: isExiting ? 0 : 1, y: isExiting ? 12 : 0 }}
+							transition={{ duration: 0.5, delay: 0.2 }}
+						>
+							<h2 className="text-5xl font-bold text-destructive">
+								ACCESS SUSPENDED
+							</h2>
+							<p className="text-3xl font-semibold">
+								{userName}, you are not permitted to enter.
+							</p>
+							<div className="bg-destructive/10 border border-destructive/30 rounded-lg p-4 mt-2">
+								<p className="text-xl text-muted-foreground">
+									Your suspension ends on:
+								</p>
+								<p className="text-2xl font-medium mt-1">{formattedEndDate}</p>
+							</div>
+						</motion.div>
+					</div>
+				</div>
+			</motion.div>
+		</motion.div>
+	);
+}

--- a/apps/kiosk/src/types/index.ts
+++ b/apps/kiosk/src/types/index.ts
@@ -83,6 +83,19 @@ export type TapResponse =
 				content: string;
 				confirmationText: string;
 			}[];
+	  }
+	| {
+			status: "suspended";
+			user: {
+				id: number;
+				name: string;
+				email: string;
+				username: string;
+			};
+			suspension: {
+				endDate: Date;
+				externalNotes: string | null;
+			};
 	  };
 
 export type TapEvent = Extract<

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -7,6 +7,7 @@ export type {
 } from "./template-renderer";
 export { renderEmail } from "./template-renderer";
 export type { SessionAutoLogoutEmailProps } from "./templates/SessionAutoLogoutEmail";
+export type { SuspensionNoticeEmailProps } from "./templates/SuspensionNoticeEmail";
 export type { WelcomeEmailProps } from "./templates/WelcomeEmail";
 export { htmlToPlainText } from "./text-generator";
 export type { EmailProvider, SendEmailParams } from "./types";

--- a/packages/email/src/template-renderer.tsx
+++ b/packages/email/src/template-renderer.tsx
@@ -6,6 +6,11 @@ import {
 	type SessionAutoLogoutEmailProps,
 } from "./templates/SessionAutoLogoutEmail";
 import {
+	SuspensionNoticeEmail,
+	type SuspensionNoticeEmailProps,
+	SuspensionNoticeEmailSubject,
+} from "./templates/SuspensionNoticeEmail";
+import {
 	WelcomeEmail,
 	type WelcomeEmailProps,
 	WelcomeEmailSubject,
@@ -15,7 +20,11 @@ import { htmlToPlainText } from "./text-generator";
 const logger = getLogger("email:renderer");
 
 // Re-export template props for external use
-export type { SessionAutoLogoutEmailProps, WelcomeEmailProps };
+export type {
+	SessionAutoLogoutEmailProps,
+	SuspensionNoticeEmailProps,
+	WelcomeEmailProps,
+};
 
 export type RenderEmailOptions =
 	| {
@@ -25,6 +34,10 @@ export type RenderEmailOptions =
 	| {
 			template: "session-auto-logout";
 			data: SessionAutoLogoutEmailProps;
+	  }
+	| {
+			template: "suspension-notice";
+			data: SuspensionNoticeEmailProps;
 	  };
 
 export interface RenderedEmail {
@@ -57,6 +70,14 @@ export async function renderEmail(
 					<SessionAutoLogoutEmail {...options.data} />,
 				);
 				subject = getSessionAutoLogoutSubject(options.data.sessionType);
+				break;
+			}
+
+			case "suspension-notice": {
+				html = renderToStaticMarkup(
+					<SuspensionNoticeEmail {...options.data} />,
+				);
+				subject = SuspensionNoticeEmailSubject;
 				break;
 			}
 		}

--- a/packages/email/src/templates/SuspensionNoticeEmail.tsx
+++ b/packages/email/src/templates/SuspensionNoticeEmail.tsx
@@ -63,8 +63,8 @@ export function SuspensionNoticeEmail({
 			</div>
 
 			<p>
-				During this suspension period, you will not be able visit or utilize The
-				Hive.
+				During this suspension period, you will not be able to visit or utilize
+				The Hive.
 			</p>
 
 			{externalNotes && (

--- a/packages/email/src/templates/SuspensionNoticeEmail.tsx
+++ b/packages/email/src/templates/SuspensionNoticeEmail.tsx
@@ -1,0 +1,103 @@
+import { EmailLayout } from "./EmailLayout";
+
+export interface SuspensionNoticeEmailProps {
+	userName: string;
+	startDate: Date;
+	endDate: Date;
+	externalNotes: string | null;
+}
+
+export const SuspensionNoticeEmailSubject =
+	"Important: Your Hive Access Has Been Suspended";
+
+export function SuspensionNoticeEmail({
+	userName,
+	startDate,
+	endDate,
+	externalNotes,
+}: SuspensionNoticeEmailProps) {
+	const formatDate = (date: Date) => {
+		return date.toLocaleDateString("en-US", {
+			weekday: "long",
+			year: "numeric",
+			month: "long",
+			day: "numeric",
+			hour: "numeric",
+			minute: "2-digit",
+			timeZoneName: "short",
+		});
+	};
+
+	return (
+		<EmailLayout
+			title="Your Hive Access Has Been Suspended"
+			preheader="Your access to The Hive has been temporarily suspended."
+		>
+			<p>
+				Hello <strong>{userName}</strong>,
+			</p>
+
+			<p>
+				This email is to notify you that your access to The Hive has been
+				temporarily suspended.
+			</p>
+
+			<div
+				style={{
+					backgroundColor: "#fef2f2",
+					border: "1px solid #fecaca",
+					borderRadius: "6px",
+					padding: "16px",
+					margin: "20px 0",
+				}}
+			>
+				<p style={{ margin: 0, fontWeight: 600, color: "#dc2626" }}>
+					Suspension Period
+				</p>
+				<p style={{ margin: "8px 0 0 0" }}>
+					<strong>Start:</strong> {formatDate(startDate)}
+				</p>
+				<p style={{ margin: "4px 0 0 0" }}>
+					<strong>End:</strong> {formatDate(endDate)}
+				</p>
+			</div>
+
+			<p>
+				During this suspension period, you will not be able visit or utilize The
+				Hive.
+			</p>
+
+			{externalNotes && (
+				<div
+					style={{
+						backgroundColor: "#f3f4f6",
+						border: "1px solid #d1d5db",
+						borderRadius: "6px",
+						padding: "16px",
+						margin: "20px 0",
+					}}
+				>
+					<p style={{ margin: 0, fontWeight: 600 }}>Additional Information</p>
+					<p style={{ margin: "8px 0 0 0", whiteSpace: "pre-wrap" }}>
+						{externalNotes}
+					</p>
+				</div>
+			)}
+
+			<p>
+				Your account access to the HUMS web portal remains active, and you can
+				view your suspension details and history there.
+			</p>
+
+			<p style={{ marginTop: "20px" }}>
+				If you have questions about this suspension, please reply to this email
+				or contact The Hive staff at{" "}
+				<a href="mailto:hive@ece.gatech.edu">hive@ece.gatech.edu</a>
+			</p>
+
+			<p style={{ marginTop: "16px", marginBottom: 0 }}>
+				<strong>The Hive Team</strong>
+			</p>
+		</EmailLayout>
+	);
+}

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -12,6 +12,7 @@ export * from "./shift-schedules/generate";
 export * from "./shift-schedules/queries";
 export * from "./shift-schedules/utils";
 export * from "./shift-schedules/validation";
+export * from "./suspensions";
 export * from "./time-utils";
 export * from "./timezone";
 export * from "./users";

--- a/packages/features/src/suspensions/index.ts
+++ b/packages/features/src/suspensions/index.ts
@@ -1,0 +1,2 @@
+export * from "./suspension-checks";
+export * from "./suspension-management";

--- a/packages/features/src/suspensions/suspension-checks.ts
+++ b/packages/features/src/suspensions/suspension-checks.ts
@@ -1,0 +1,144 @@
+import type { Prisma } from "@ecehive/prisma";
+
+export interface ActiveSuspension {
+	id: number;
+	startDate: Date;
+	endDate: Date;
+	externalNotes: string | null;
+}
+
+/**
+ * Check if a user has an active suspension
+ * An active suspension is one where startDate <= now AND endDate > now
+ */
+export async function getActiveSuspension(
+	tx: Prisma.TransactionClient,
+	userId: number,
+	at?: Date,
+): Promise<ActiveSuspension | null> {
+	const now = at ?? new Date();
+
+	const suspension = await tx.suspension.findFirst({
+		where: {
+			userId,
+			startDate: { lte: now },
+			endDate: { gt: now },
+		},
+		select: {
+			id: true,
+			startDate: true,
+			endDate: true,
+			externalNotes: true,
+		},
+		orderBy: { endDate: "desc" },
+	});
+
+	return suspension;
+}
+
+/**
+ * Check if a user is currently suspended
+ * Returns true if the user has any active suspension
+ */
+export async function isUserSuspended(
+	tx: Prisma.TransactionClient,
+	userId: number,
+	at?: Date,
+): Promise<boolean> {
+	const suspension = await getActiveSuspension(tx, userId, at);
+	return suspension !== null;
+}
+
+/**
+ * Get all active suspensions for a user
+ * A user could theoretically have overlapping suspensions
+ */
+export async function getActiveSuspensions(
+	tx: Prisma.TransactionClient,
+	userId: number,
+	at?: Date,
+): Promise<ActiveSuspension[]> {
+	const now = at ?? new Date();
+
+	const suspensions = await tx.suspension.findMany({
+		where: {
+			userId,
+			startDate: { lte: now },
+			endDate: { gt: now },
+		},
+		select: {
+			id: true,
+			startDate: true,
+			endDate: true,
+			externalNotes: true,
+		},
+		orderBy: { endDate: "desc" },
+	});
+
+	return suspensions;
+}
+
+/**
+ * Get suspensions that are starting soon and need email notifications
+ * Returns suspensions where:
+ * - startDate is within the next N minutes
+ * - emailSentAt is null (email not yet sent)
+ */
+export async function getSuspensionsStartingSoon(
+	tx: Prisma.TransactionClient,
+	withinMinutes: number = 5,
+): Promise<
+	Array<{
+		id: number;
+		userId: number;
+		startDate: Date;
+		endDate: Date;
+		externalNotes: string | null;
+		user: {
+			id: number;
+			name: string;
+			email: string;
+		};
+	}>
+> {
+	const now = new Date();
+	const cutoff = new Date(now.getTime() + withinMinutes * 60 * 1000);
+
+	const suspensions = await tx.suspension.findMany({
+		where: {
+			emailSentAt: null,
+			startDate: {
+				lte: cutoff,
+			},
+		},
+		select: {
+			id: true,
+			userId: true,
+			startDate: true,
+			endDate: true,
+			externalNotes: true,
+			user: {
+				select: {
+					id: true,
+					name: true,
+					email: true,
+				},
+			},
+		},
+	});
+
+	return suspensions;
+}
+
+/**
+ * Mark a suspension as having its email sent
+ */
+export async function markSuspensionEmailSent(
+	tx: Prisma.TransactionClient,
+	suspensionId: number,
+): Promise<void> {
+	await tx.suspension.update({
+		where: { id: suspensionId },
+		data: { emailSentAt: new Date() },
+	});
+}

--- a/packages/features/src/suspensions/suspension-checks.ts
+++ b/packages/features/src/suspensions/suspension-checks.ts
@@ -108,6 +108,7 @@ export async function getSuspensionsStartingSoon(
 		where: {
 			emailSentAt: null,
 			startDate: {
+				gt: now,
 				lte: cutoff,
 			},
 		},

--- a/packages/features/src/suspensions/suspension-management.ts
+++ b/packages/features/src/suspensions/suspension-management.ts
@@ -1,0 +1,221 @@
+import type { Prisma } from "@ecehive/prisma";
+
+export interface CreateSuspensionParams {
+	userId: number;
+	startDate: Date;
+	endDate: Date;
+	internalNotes?: string | null;
+	externalNotes?: string | null;
+	createdById?: number | null;
+}
+
+export interface UpdateSuspensionParams {
+	id: number;
+	startDate?: Date;
+	endDate?: Date;
+	internalNotes?: string | null;
+	externalNotes?: string | null;
+}
+
+/**
+ * Create a new suspension for a user
+ */
+export async function createSuspension(
+	tx: Prisma.TransactionClient,
+	params: CreateSuspensionParams,
+) {
+	const suspension = await tx.suspension.create({
+		data: {
+			userId: params.userId,
+			startDate: params.startDate,
+			endDate: params.endDate,
+			internalNotes: params.internalNotes,
+			externalNotes: params.externalNotes,
+			createdById: params.createdById,
+		},
+		include: {
+			user: {
+				select: {
+					id: true,
+					name: true,
+					username: true,
+					email: true,
+				},
+			},
+			createdBy: {
+				select: {
+					id: true,
+					name: true,
+					username: true,
+				},
+			},
+		},
+	});
+
+	return suspension;
+}
+
+/**
+ * Update an existing suspension
+ * Note: Suspensions should never be deleted, only updated
+ */
+export async function updateSuspension(
+	tx: Prisma.TransactionClient,
+	params: UpdateSuspensionParams,
+) {
+	const suspension = await tx.suspension.update({
+		where: { id: params.id },
+		data: {
+			startDate: params.startDate,
+			endDate: params.endDate,
+			internalNotes: params.internalNotes,
+			externalNotes: params.externalNotes,
+		},
+		include: {
+			user: {
+				select: {
+					id: true,
+					name: true,
+					username: true,
+					email: true,
+				},
+			},
+			createdBy: {
+				select: {
+					id: true,
+					name: true,
+					username: true,
+				},
+			},
+		},
+	});
+
+	return suspension;
+}
+
+/**
+ * Get a suspension by ID
+ */
+export async function getSuspension(tx: Prisma.TransactionClient, id: number) {
+	const suspension = await tx.suspension.findUnique({
+		where: { id },
+		include: {
+			user: {
+				select: {
+					id: true,
+					name: true,
+					username: true,
+					email: true,
+				},
+			},
+			createdBy: {
+				select: {
+					id: true,
+					name: true,
+					username: true,
+				},
+			},
+		},
+	});
+
+	return suspension;
+}
+
+/**
+ * List suspensions with optional filters
+ */
+export interface ListSuspensionsParams {
+	userId?: number;
+	active?: boolean;
+	search?: string;
+	offset?: number;
+	limit?: number;
+}
+
+export async function listSuspensions(
+	tx: Prisma.TransactionClient,
+	params: ListSuspensionsParams = {},
+) {
+	const { userId, active, search, offset = 0, limit = 50 } = params;
+	const now = new Date();
+
+	const where: Prisma.SuspensionWhereInput = {};
+
+	if (userId !== undefined) {
+		where.userId = userId;
+	}
+
+	if (active !== undefined) {
+		if (active) {
+			// Active suspensions: startDate <= now && endDate > now
+			where.startDate = { lte: now };
+			where.endDate = { gt: now };
+		} else {
+			// Inactive suspensions: endDate <= now OR startDate > now
+			where.OR = [{ endDate: { lte: now } }, { startDate: { gt: now } }];
+		}
+	}
+
+	if (search) {
+		where.OR = [
+			{ user: { name: { contains: search, mode: "insensitive" } } },
+			{ user: { username: { contains: search, mode: "insensitive" } } },
+			{ user: { email: { contains: search, mode: "insensitive" } } },
+			{ internalNotes: { contains: search, mode: "insensitive" } },
+			{ externalNotes: { contains: search, mode: "insensitive" } },
+		];
+	}
+
+	const [suspensions, total] = await Promise.all([
+		tx.suspension.findMany({
+			where,
+			include: {
+				user: {
+					select: {
+						id: true,
+						name: true,
+						username: true,
+						email: true,
+					},
+				},
+				createdBy: {
+					select: {
+						id: true,
+						name: true,
+						username: true,
+					},
+				},
+			},
+			orderBy: [{ startDate: "desc" }, { id: "desc" }],
+			skip: offset,
+			take: limit,
+		}),
+		tx.suspension.count({ where }),
+	]);
+
+	return { suspensions, total };
+}
+
+/**
+ * Get suspensions for a specific user
+ */
+export async function getUserSuspensions(
+	tx: Prisma.TransactionClient,
+	userId: number,
+) {
+	const suspensions = await tx.suspension.findMany({
+		where: { userId },
+		include: {
+			createdBy: {
+				select: {
+					id: true,
+					name: true,
+					username: true,
+				},
+			},
+		},
+		orderBy: [{ startDate: "desc" }, { id: "desc" }],
+	});
+
+	return suspensions;
+}

--- a/packages/prisma/migrations/20260106024658_add_suspensions/migration.sql
+++ b/packages/prisma/migrations/20260106024658_add_suspensions/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "Suspension" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "internalNotes" TEXT,
+    "externalNotes" TEXT,
+    "createdById" INTEGER,
+    "emailSentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Suspension_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Suspension_userId_idx" ON "Suspension"("userId");
+
+-- CreateIndex
+CREATE INDEX "Suspension_startDate_endDate_idx" ON "Suspension"("startDate", "endDate");
+
+-- CreateIndex
+CREATE INDEX "Suspension_emailSentAt_startDate_idx" ON "Suspension"("emailSentAt", "startDate");
+
+-- AddForeignKey
+ALTER TABLE "Suspension" ADD CONSTRAINT "Suspension_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Suspension" ADD CONSTRAINT "Suspension_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Add suspensions permissions
+INSERT INTO "Permission" (name) VALUES
+    ('suspensions.list'),
+    ('suspensions.manage')
+ON CONFLICT (name) DO NOTHING;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -71,6 +71,8 @@ model User {
   // One-to-many
   sessions    Session[]
   attendances ShiftAttendance[]
+  suspensions Suspension[]
+  createdSuspensions Suspension[] @relation("SuspensionCreatedBy")
   
   // Many-to-many (explicit)
   userAgreements UserAgreement[]
@@ -396,4 +398,30 @@ model ConfigValue {
 
   // indexes
   @@index([key])
+}
+
+model Suspension {
+  id Int @id @default(autoincrement())
+
+  // fields
+  userId        Int
+  startDate     DateTime
+  endDate       DateTime
+  internalNotes String?  @db.Text  // Not shared with user
+  externalNotes String?  @db.Text  // Shared with user
+  createdById   Int?
+  emailSentAt   DateTime?          // Track when suspension notice was sent
+
+  // timestamps
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  // relations
+  user      User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdBy User? @relation("SuspensionCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+
+  // indexes
+  @@index([userId])
+  @@index([startDate, endDate])
+  @@index([emailSentAt, startDate])
 }

--- a/packages/trpc/server/router.ts
+++ b/packages/trpc/server/router.ts
@@ -15,6 +15,7 @@ import { shiftAttendancesRouter } from "./routers/shiftAttendances/_route";
 import { shiftOccurrencesRouter } from "./routers/shiftOccurrences/_route";
 import { shiftSchedulesRouter } from "./routers/shiftSchedules/_route";
 import { shiftTypesRouter } from "./routers/shiftTypes/_route";
+import { suspensionsRouter } from "./routers/suspensions/_route";
 import { usersRouter } from "./routers/users/_route";
 import { router } from "./trpc";
 
@@ -34,6 +35,7 @@ export const appRouter = router({
 	shiftOccurrences: shiftOccurrencesRouter,
 	shiftAttendances: shiftAttendancesRouter,
 	sessions: sessionsRouter,
+	suspensions: suspensionsRouter,
 	kiosks: kiosksRouter,
 	oneTimeLoginCodes: oneTimeLoginCodesRouter,
 	reports: reportsRouter,

--- a/packages/trpc/server/routers/oneTimeLoginCodes/use.route.ts
+++ b/packages/trpc/server/routers/oneTimeLoginCodes/use.route.ts
@@ -1,3 +1,4 @@
+import { getActiveSuspension } from "@ecehive/features";
 import { prisma } from "@ecehive/prisma";
 import { TRPCError } from "@trpc/server";
 import z from "zod";
@@ -102,6 +103,16 @@ export async function useHandler(options: TUseOptions) {
 					throw new TRPCError({
 						code: "CONFLICT",
 						message: "You are already in a session",
+					});
+				}
+
+				// Check if user is suspended - they cannot start a new session
+				const activeSuspension = await getActiveSuspension(tx, userId, now);
+				if (activeSuspension) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message:
+							"Your access has been suspended. You cannot start a session at this time.",
 					});
 				}
 

--- a/packages/trpc/server/routers/suspensions/_route.ts
+++ b/packages/trpc/server/routers/suspensions/_route.ts
@@ -1,0 +1,32 @@
+import {
+	permissionProtectedProcedure,
+	protectedProcedure,
+	router,
+} from "../../trpc";
+import { createHandler, ZCreateSchema } from "./create.route";
+import { getHandler, ZGetSchema } from "./get.route";
+import { getMyActiveHandler, ZGetMyActiveSchema } from "./getMyActive.route";
+import { listHandler, ZListSchema } from "./list.route";
+import { listMyHandler, ZListMySchema } from "./listMy.route";
+import { updateHandler, ZUpdateSchema } from "./update.route";
+
+export const suspensionsRouter = router({
+	// Admin endpoints - require suspensions.list or suspensions.manage permissions
+	list: permissionProtectedProcedure("suspensions.list")
+		.input(ZListSchema)
+		.query(listHandler),
+	get: permissionProtectedProcedure("suspensions.list")
+		.input(ZGetSchema)
+		.query(getHandler),
+	create: permissionProtectedProcedure("suspensions.manage")
+		.input(ZCreateSchema)
+		.mutation(createHandler),
+	update: permissionProtectedProcedure("suspensions.manage")
+		.input(ZUpdateSchema)
+		.mutation(updateHandler),
+	// User endpoints - any authenticated user can view their own suspensions
+	listMy: protectedProcedure.input(ZListMySchema).query(listMyHandler),
+	getMyActive: protectedProcedure
+		.input(ZGetMyActiveSchema)
+		.query(getMyActiveHandler),
+});

--- a/packages/trpc/server/routers/suspensions/create.route.ts
+++ b/packages/trpc/server/routers/suspensions/create.route.ts
@@ -24,7 +24,7 @@ export async function createHandler(options: TCreateOptions) {
 		options.input;
 
 	// Validate that end date is after start date
-	if (endDate <= startDate) {
+	if (endDate < startDate) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message: "End date must be after start date",

--- a/packages/trpc/server/routers/suspensions/create.route.ts
+++ b/packages/trpc/server/routers/suspensions/create.route.ts
@@ -1,0 +1,56 @@
+import { createSuspension } from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZCreateSchema = z.object({
+	userId: z.number(),
+	startDate: z.date(),
+	endDate: z.date(),
+	internalNotes: z.string().optional().nullable(),
+	externalNotes: z.string().optional().nullable(),
+});
+
+export type TCreateSchema = z.infer<typeof ZCreateSchema>;
+
+export type TCreateOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TCreateSchema;
+};
+
+export async function createHandler(options: TCreateOptions) {
+	const { userId, startDate, endDate, internalNotes, externalNotes } =
+		options.input;
+
+	// Validate that end date is after start date
+	if (endDate <= startDate) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "End date must be after start date",
+		});
+	}
+
+	// Verify user exists
+	const user = await prisma.user.findUnique({
+		where: { id: userId },
+	});
+
+	if (!user) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "User not found",
+		});
+	}
+
+	const suspension = await createSuspension(prisma, {
+		userId,
+		startDate,
+		endDate,
+		internalNotes,
+		externalNotes,
+		createdById: options.ctx.user.id,
+	});
+
+	return suspension;
+}

--- a/packages/trpc/server/routers/suspensions/get.route.ts
+++ b/packages/trpc/server/routers/suspensions/get.route.ts
@@ -1,0 +1,31 @@
+import { getSuspension } from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZGetSchema = z.object({
+	id: z.number(),
+});
+
+export type TGetSchema = z.infer<typeof ZGetSchema>;
+
+export type TGetOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TGetSchema;
+};
+
+export async function getHandler(options: TGetOptions) {
+	const { id } = options.input;
+
+	const suspension = await getSuspension(prisma, id);
+
+	if (!suspension) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Suspension not found",
+		});
+	}
+
+	return suspension;
+}

--- a/packages/trpc/server/routers/suspensions/getMyActive.route.ts
+++ b/packages/trpc/server/routers/suspensions/getMyActive.route.ts
@@ -1,0 +1,35 @@
+import { getActiveSuspension } from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import z from "zod";
+import type { TProtectedProcedureContext } from "../../trpc";
+
+export const ZGetMyActiveSchema = z.object({}).optional();
+
+export type TGetMyActiveSchema = z.infer<typeof ZGetMyActiveSchema>;
+
+export type TGetMyActiveOptions = {
+	ctx: TProtectedProcedureContext;
+	input: TGetMyActiveSchema;
+};
+
+/**
+ * Get the current user's active suspension (if any)
+ * Returns null if not suspended
+ */
+export async function getMyActiveHandler(options: TGetMyActiveOptions) {
+	const userId = options.ctx.user.id;
+
+	const suspension = await getActiveSuspension(prisma, userId);
+
+	if (!suspension) {
+		return null;
+	}
+
+	// Only return fields safe to share with user
+	return {
+		id: suspension.id,
+		startDate: suspension.startDate,
+		endDate: suspension.endDate,
+		externalNotes: suspension.externalNotes,
+	};
+}

--- a/packages/trpc/server/routers/suspensions/list.route.ts
+++ b/packages/trpc/server/routers/suspensions/list.route.ts
@@ -1,0 +1,33 @@
+import { listSuspensions } from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZListSchema = z.object({
+	search: z.string().optional(),
+	userId: z.number().optional(),
+	active: z.boolean().optional(),
+	offset: z.number().default(0),
+	limit: z.number().default(50),
+});
+
+export type TListSchema = z.infer<typeof ZListSchema>;
+
+export type TListOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TListSchema;
+};
+
+export async function listHandler(options: TListOptions) {
+	const { search, userId, active, offset, limit } = options.input;
+
+	const result = await listSuspensions(prisma, {
+		search,
+		userId,
+		active,
+		offset,
+		limit,
+	});
+
+	return result;
+}

--- a/packages/trpc/server/routers/suspensions/listMy.route.ts
+++ b/packages/trpc/server/routers/suspensions/listMy.route.ts
@@ -1,0 +1,32 @@
+import { getUserSuspensions } from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import z from "zod";
+import type { TProtectedProcedureContext } from "../../trpc";
+
+export const ZListMySchema = z.object({}).optional();
+
+export type TListMySchema = z.infer<typeof ZListMySchema>;
+
+export type TListMyOptions = {
+	ctx: TProtectedProcedureContext;
+	input: TListMySchema;
+};
+
+/**
+ * List suspensions for the current user
+ * Note: Only returns external notes (shared notes), not internal notes
+ */
+export async function listMyHandler(options: TListMyOptions) {
+	const userId = options.ctx.user.id;
+
+	const suspensions = await getUserSuspensions(prisma, userId);
+
+	// Filter out internal notes - users should only see external notes
+	return suspensions.map((suspension) => ({
+		id: suspension.id,
+		startDate: suspension.startDate,
+		endDate: suspension.endDate,
+		externalNotes: suspension.externalNotes,
+		createdAt: suspension.createdAt,
+	}));
+}

--- a/packages/trpc/server/routers/suspensions/update.route.ts
+++ b/packages/trpc/server/routers/suspensions/update.route.ts
@@ -1,0 +1,58 @@
+import { updateSuspension } from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZUpdateSchema = z.object({
+	id: z.number(),
+	startDate: z.date().optional(),
+	endDate: z.date().optional(),
+	internalNotes: z.string().optional().nullable(),
+	externalNotes: z.string().optional().nullable(),
+});
+
+export type TUpdateSchema = z.infer<typeof ZUpdateSchema>;
+
+export type TUpdateOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TUpdateSchema;
+};
+
+export async function updateHandler(options: TUpdateOptions) {
+	const { id, startDate, endDate, internalNotes, externalNotes } =
+		options.input;
+
+	// Check if suspension exists
+	const existing = await prisma.suspension.findUnique({
+		where: { id },
+	});
+
+	if (!existing) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Suspension not found",
+		});
+	}
+
+	// Validate dates if both are provided
+	const finalStartDate = startDate ?? existing.startDate;
+	const finalEndDate = endDate ?? existing.endDate;
+
+	if (finalEndDate <= finalStartDate) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "End date must be after start date",
+		});
+	}
+
+	const suspension = await updateSuspension(prisma, {
+		id,
+		startDate,
+		endDate,
+		internalNotes,
+		externalNotes,
+	});
+
+	return suspension;
+}

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,6 +1,7 @@
 import { getLogger } from "@ecehive/logger";
 import { cleanupExpiredCodesJob } from "./jobs/cleanup-expired-codes";
 import { endOldSessionsJob } from "./jobs/end-old-sessions";
+import { sendSuspensionNoticesJob } from "./jobs/send-suspension-notices";
 import { updateShiftAttendanceJob } from "./jobs/update-shift-attendance";
 
 const logger = getLogger("workers");
@@ -9,7 +10,13 @@ export function start() {
 	updateShiftAttendanceJob.start();
 	endOldSessionsJob.start();
 	cleanupExpiredCodesJob.start();
+	sendSuspensionNoticesJob.start();
 	logger.info("Background workers initialized", {
-		jobs: ["updateShiftAttendance", "endOldSessions", "cleanupExpiredCodes"],
+		jobs: [
+			"updateShiftAttendance",
+			"endOldSessions",
+			"cleanupExpiredCodes",
+			"sendSuspensionNotices",
+		],
 	});
 }

--- a/packages/workers/src/jobs/send-suspension-notices.ts
+++ b/packages/workers/src/jobs/send-suspension-notices.ts
@@ -1,0 +1,82 @@
+import { queueEmail } from "@ecehive/email";
+import {
+	getSuspensionsStartingSoon,
+	markSuspensionEmailSent,
+} from "@ecehive/features";
+import { getLogger } from "@ecehive/logger";
+import { prisma } from "@ecehive/prisma";
+import { CronJob } from "cron";
+
+const logger = getLogger("workers:suspension-notices");
+
+/**
+ * Sends email notifications for suspensions that are starting soon.
+ *
+ * This worker runs every 5 minutes and:
+ * 1. Finds suspensions where startDate is within the next 5 minutes AND emailSentAt is null
+ * 2. Sends a suspension notice email to each affected user
+ * 3. Marks the suspension as having had its email sent
+ *
+ * The timing ensures:
+ * - An email is always sent for every suspension (checked every 5 minutes, looking 5 minutes ahead)
+ * - Only one email is sent per suspension (tracked via emailSentAt)
+ */
+export async function sendSuspensionNotices(): Promise<void> {
+	try {
+		// Get suspensions starting within the next 5 minutes that haven't had emails sent
+		const suspensions = await getSuspensionsStartingSoon(prisma, 5);
+
+		if (suspensions.length === 0) {
+			return;
+		}
+
+		logger.info("Processing suspension notices", { count: suspensions.length });
+
+		for (const suspension of suspensions) {
+			try {
+				// Queue the suspension notice email
+				await queueEmail({
+					to: suspension.user.email,
+					template: "suspension-notice",
+					data: {
+						userName: suspension.user.name,
+						startDate: suspension.startDate,
+						endDate: suspension.endDate,
+						externalNotes: suspension.externalNotes,
+					},
+				});
+
+				// Mark the suspension as having its email sent
+				await markSuspensionEmailSent(prisma, suspension.id);
+
+				logger.info("Queued suspension notice email", {
+					suspensionId: suspension.id,
+					userId: suspension.userId,
+					startDate: suspension.startDate.toISOString(),
+				});
+			} catch (error) {
+				logger.warn("Failed to queue suspension notice email", {
+					suspensionId: suspension.id,
+					userId: suspension.userId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				// Continue with other suspensions even if one fails
+			}
+		}
+
+		logger.info("Finished processing suspension notices", {
+			processed: suspensions.length,
+		});
+	} catch (err) {
+		logger.error("Failed to process suspension notices", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		throw err;
+	}
+}
+
+// Run every 5 minutes
+export const sendSuspensionNoticesJob = new CronJob(
+	"*/5 * * * *",
+	sendSuspensionNotices,
+);


### PR DESCRIPTION
This pull requests adds a simple user suspension system. When a user is suspended, they are prevented from tapping in to the space. They will be shown an error if they attempt to tap in at a kiosk or on the web client. Users will receive an email when their suspension starts.

Suspensions keep track of:
- Target user
- Start datetime
- End datetime
- Internal notes (visible to admins)
- External notes (visible to user)
- User who created the suspension
- Other misc. metadata
