### PR TITLE
Add Slack integration framework and sessions integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Refer to each app's README for required variables.
 To start server, client, and kiosk with hot-reload, run the following in the workspace root,
 
 ```sh
-bun run -r dev
+bun dev
 ```
+
+Alternatively, run the above in a specific directory within `apps/` to individually start the server, client, or kiosk.
 
 You can then access the client at https://localhost:44831/.
 

--- a/apps/client/src/components/audit-logs/columns.tsx
+++ b/apps/client/src/components/audit-logs/columns.tsx
@@ -1,5 +1,5 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { HatGlassesIcon, UserCogIcon } from "lucide-react";
+import { HatGlassesIcon, SlackIcon, UserCogIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -108,6 +108,14 @@ function ActorCell({ log }: { log: AuditLogRow }) {
 						<TooltipContent>
 							API token {formatAuditLogApiTokenPrimary(log.apiToken)}
 						</TooltipContent>
+					</Tooltip>
+				) : null}
+				{log.source === "slack" ? (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<SlackIcon className="size-3 text-amber-500" />
+						</TooltipTrigger>
+						<TooltipContent>From Slack</TooltipContent>
 					</Tooltip>
 				) : null}
 				<span>{formatActor(log.user) ?? "System"}</span>

--- a/apps/client/src/components/audit-logs/types.ts
+++ b/apps/client/src/components/audit-logs/types.ts
@@ -27,7 +27,7 @@ export type AuditLogFilterApiToken = {
 export type AuditLogRow = {
 	id: number;
 	action: string;
-	source: "trpc" | "rest" | "kiosk";
+	source: "trpc" | "rest" | "kiosk" | "slack";
 	metadata: unknown;
 	createdAt: string | Date;
 	userId: number | null;

--- a/apps/client/src/components/config/config-field.tsx
+++ b/apps/client/src/components/config/config-field.tsx
@@ -156,6 +156,17 @@ export function ConfigField({
 					/>
 				);
 
+			case "secret":
+				return (
+					<Input
+						type="password"
+						value={inputValue as string}
+						onChange={(e) => handleChange(e.target.value)}
+						placeholder={field.placeholder}
+						disabled={!canWrite || isSaving}
+					/>
+				);
+
 			default:
 				return (
 					<Input

--- a/apps/client/src/components/config/config-group.tsx
+++ b/apps/client/src/components/config/config-group.tsx
@@ -1,4 +1,8 @@
-import { Clock as ClockIcon, Settings as SettingsIcon } from "lucide-react";
+import {
+	Clock as ClockIcon,
+	Settings as SettingsIcon,
+	Slack as SlackIcon,
+} from "lucide-react";
 import {
 	Card,
 	CardContent,
@@ -11,6 +15,7 @@ import { ConfigField } from "./config-field";
 const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
 	Clock: ClockIcon,
 	Settings: SettingsIcon,
+	Slack: SlackIcon,
 };
 
 interface ConfigFieldDef {

--- a/apps/client/src/components/users/columns.tsx
+++ b/apps/client/src/components/users/columns.tsx
@@ -42,6 +42,10 @@ export function generateColumns(user: AuthUser | null): ColumnDef<User>[] {
 			header: "Email",
 		},
 		{
+			accessorKey: "slackUsername",
+			header: "Slack Username",
+		},
+		{
 			accessorKey: "roles",
 			header: "Roles",
 			cell: ({ row }) => {

--- a/apps/client/src/components/users/create-dialog.tsx
+++ b/apps/client/src/components/users/create-dialog.tsx
@@ -39,8 +39,12 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 	const formId = useId();
 
 	const createUserMutation = useMutation({
-		mutationFn: (input: { username: string; name?: string; email?: string; slackUsername?: string }) =>
-			trpc.users.create.mutate(input),
+		mutationFn: (input: {
+			username: string;
+			name?: string;
+			email?: string;
+			slackUsername?: string;
+		}) => trpc.users.create.mutate(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["users"] });
 		},
@@ -185,7 +189,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 							);
 						}}
 					/>
-					
+
 					<form.Field
 						name="slackUsername"
 						children={(field) => {
@@ -193,7 +197,10 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 								field.state.meta.isTouched && !field.state.meta.isValid;
 							return (
 								<Field data-invalid={isInvalid}>
-									<FieldLabel htmlFor={field.name}>Slack Username</FieldLabel>
+									<FieldLabel htmlFor={field.name}>
+										Slack Username{" "}
+										<span className="text-muted-foreground">(optional)</span>
+									</FieldLabel>
 									<Input
 										id={field.name}
 										name={field.name}

--- a/apps/client/src/components/users/create-dialog.tsx
+++ b/apps/client/src/components/users/create-dialog.tsx
@@ -24,7 +24,8 @@ import { checkPermissions } from "@/lib/permissions";
 const formSchema = z.object({
 	username: z.string().min(1, "Username is required").max(100),
 	name: z.string().max(100),
-	email: z.union([z.email("Invalid email address"), z.literal("")]).optional(),
+	email: z.union([z.email("Invalid email address"), z.literal("")]),
+	slackUsername: z.string(),
 });
 
 type CreateDialogProps = {
@@ -38,7 +39,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 	const formId = useId();
 
 	const createUserMutation = useMutation({
-		mutationFn: (input: { username: string; name?: string; email?: string }) =>
+		mutationFn: (input: { username: string; name?: string; email?: string; slackUsername?: string }) =>
 			trpc.users.create.mutate(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["users"] });
@@ -50,6 +51,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 			username: "",
 			name: "",
 			email: "",
+			slackUsername: "",
 		},
 		validators: {
 			onSubmit: formSchema,
@@ -60,6 +62,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 					username: value.username,
 					name: value.name || undefined,
 					email: value.email || undefined,
+					slackUsername: value.slackUsername || undefined,
 				});
 				setOpen(false);
 				onUpdate?.();
@@ -176,6 +179,29 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 										onChange={(e) => field.handleChange(e.target.value)}
 										placeholder="Enter email address"
 										autoComplete="email"
+									/>
+									{isInvalid && <FieldError errors={field.state.meta.errors} />}
+								</Field>
+							);
+						}}
+					/>
+					
+					<form.Field
+						name="slackUsername"
+						children={(field) => {
+							const isInvalid =
+								field.state.meta.isTouched && !field.state.meta.isValid;
+							return (
+								<Field data-invalid={isInvalid}>
+									<FieldLabel htmlFor={field.name}>Slack Username</FieldLabel>
+									<Input
+										id={field.name}
+										name={field.name}
+										value={field.state.value}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										placeholder="Enter Slack username"
+										autoComplete="off"
 									/>
 									{isInvalid && <FieldError errors={field.state.meta.errors} />}
 								</Field>

--- a/apps/client/src/components/users/update-dialog.tsx
+++ b/apps/client/src/components/users/update-dialog.tsx
@@ -25,6 +25,7 @@ import { checkPermissions } from "@/lib/permissions";
 const formSchema = z.object({
 	name: z.string().min(1, "Name is required").max(100),
 	email: z.email("Email must be valid"),
+	slackUsername: z.string(),
 });
 
 type UpdateDialogProps = {
@@ -33,6 +34,7 @@ type UpdateDialogProps = {
 		username: string;
 		name: string;
 		email: string;
+		slackUsername: string;
 	};
 	onUpdate?: () => void;
 };
@@ -51,12 +53,14 @@ export function UserUpdateDialog({
 			id,
 			name,
 			email,
+			slackUsername,
 		}: {
 			id: number;
 			name: string;
 			email: string;
+			slackUsername: string;
 		}) => {
-			return trpc.users.update.mutate({ id, name, email });
+			return trpc.users.update.mutate({ id, name, email, slackUsername });
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["users"] });
@@ -67,6 +71,7 @@ export function UserUpdateDialog({
 		defaultValues: {
 			name: user.name,
 			email: user.email,
+			slackUsername: user.slackUsername ?? user.username,
 		},
 		validators: {
 			onSubmit: formSchema,
@@ -169,6 +174,29 @@ export function UserUpdateDialog({
 										onChange={(e) => field.handleChange(e.target.value)}
 										placeholder="user@example.com"
 										autoComplete="email"
+									/>
+									{isInvalid && <FieldError errors={field.state.meta.errors} />}
+								</Field>
+							);
+						}}
+					/>
+
+					<form.Field
+						name="slackUsername"
+						children={(field) => {
+							const isInvalid =
+								field.state.meta.isTouched && !field.state.meta.isValid;
+							return (
+								<Field data-invalid={isInvalid}>
+									<FieldLabel htmlFor={field.name}>Slack Username</FieldLabel>
+									<Input
+										id={field.name}
+										name={field.name}
+										value={field.state.value}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										placeholder="gburdell3"
+										autoComplete="off"
 									/>
 									{isInvalid && <FieldError errors={field.state.meta.errors} />}
 								</Field>

--- a/apps/client/src/components/users/update-dialog.tsx
+++ b/apps/client/src/components/users/update-dialog.tsx
@@ -49,7 +49,17 @@ export function UserUpdateDialog({
 	const formId = useId();
 
 	const updateUserMutation = useMutation({
-		mutationFn: ({ id, name, email, slackUsername }: { id: number; name: string; email: string; slackUsername?: string | null; }) => {
+		mutationFn: ({
+			id,
+			name,
+			email,
+			slackUsername,
+		}: {
+			id: number;
+			name: string;
+			email: string;
+			slackUsername?: string | null;
+		}) => {
 			// Pass through slackUsername as given:
 			// - undefined -> omit (leave unchanged)
 			// - null -> set column to NULL (clear)

--- a/apps/client/src/routes/app/_app/audit-logs.tsx
+++ b/apps/client/src/routes/app/_app/audit-logs.tsx
@@ -55,7 +55,7 @@ export const Route = createFileRoute("/app/_app/audit-logs")({
 });
 
 type FilterState = {
-	source: "" | "trpc" | "rest";
+	source: "" | "trpc" | "rest" | "slack";
 	actor: AuditLogFilterUser | null;
 	impersonatedBy: AuditLogFilterUser | null;
 	apiToken: AuditLogFilterApiToken | null;
@@ -307,6 +307,7 @@ function AuditLogsPage() {
 									<SelectContent>
 										<SelectItem value="trpc">TRPC</SelectItem>
 										<SelectItem value="rest">REST</SelectItem>
+										<SelectItem value="slack">Slack</SelectItem>
 									</SelectContent>
 								</Select>
 							</FilterField>

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "apps/client": {
       "name": "@ecehive/client",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/trpc": "workspace:*",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -72,7 +72,7 @@
     },
     "apps/kiosk": {
       "name": "@ecehive/kiosk",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/trpc": "workspace:*",
         "@radix-ui/react-separator": "^1.1.8",
@@ -117,7 +117,7 @@
     },
     "apps/server": {
       "name": "@ecehive/server",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/features": "workspace:*",
@@ -136,7 +136,7 @@
     },
     "packages/auth": {
       "name": "@ecehive/auth",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/logger": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/config": {
       "name": "@ecehive/config",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
         "@types/node": "^24.10.1",
@@ -158,7 +158,7 @@
     },
     "packages/email": {
       "name": "@ecehive/email",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.713.0",
         "@ecehive/env": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/env": {
       "name": "@ecehive/env",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@types/node": "^24.5.2",
         "zod": "^4.1.9",
@@ -191,7 +191,7 @@
     },
     "packages/features": {
       "name": "@ecehive/features",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/email": "workspace:*",
         "@ecehive/env": "workspace:*",
@@ -209,7 +209,7 @@
     },
     "packages/ldap": {
       "name": "@ecehive/ldap",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/logger": "workspace:*",
@@ -222,7 +222,7 @@
     },
     "packages/logger": {
       "name": "@ecehive/logger",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "tslog": "^4.9.3",
       },
@@ -232,7 +232,7 @@
     },
     "packages/prisma": {
       "name": "@ecehive/prisma",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@prisma/adapter-pg": "^7.1.0",
@@ -250,7 +250,7 @@
     },
     "packages/rest": {
       "name": "@ecehive/rest",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/features": "workspace:*",
         "@ecehive/prisma": "workspace:*",
@@ -266,7 +266,7 @@
     },
     "packages/trpc": {
       "name": "@ecehive/trpc",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@ecehive/auth": "workspace:*",
@@ -275,7 +275,7 @@
         "@ecehive/logger": "workspace:*",
         "@ecehive/prisma": "workspace:*",
         "@trpc/client": "11.7.2",
-        "@trpc/server": "11.7.2",
+        "@trpc/server": "11.8.0",
         "fastify": "^5.6.2",
         "nanoid": "^5.1.6",
         "superjson": "^2.2.6",
@@ -289,7 +289,7 @@
     },
     "packages/user-data": {
       "name": "@ecehive/user-data",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/ldap": "workspace:*",
@@ -303,7 +303,7 @@
     },
     "packages/workers": {
       "name": "@ecehive/workers",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@ecehive/email": "workspace:*",
@@ -1644,6 +1644,8 @@
     "@ecehive/email/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "@ecehive/email/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "@ecehive/trpc/@trpc/server": ["@trpc/server@11.8.0", "", { "peerDependencies": { "typescript": ">=5.7.2" } }, "sha512-DphyQnLuyX2nwJCQGWQ9zYz4hZGvRhSBqDhQ0SH3tDhQ3PU4u68xofA0pJ741Ir4InEAFD+TtJVLAQy+wVOkiQ=="],
 
     "@prisma/dev/std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"packages/*"
 	],
 	"scripts": {
+		"dev": "bun --filter './apps/*' dev",
 		"check": "biome check --write",
 		"typecheck": "bun --filter './packages/*' --filter './apps/*' typecheck",
 		"set-version": "bun scripts/set-package-versions.ts"

--- a/packages/features/src/config/definitions/sessions.ts
+++ b/packages/features/src/config/definitions/sessions.ts
@@ -9,7 +9,7 @@ export const sessionConfig = defineConfig({
 	groups: [
 		{
 			id: "session-timeout",
-			label: "Session Timeout Settings",
+			label: "Session Timeout",
 			description:
 				"Configure automatic session logout based on session duration",
 			icon: "Clock",

--- a/packages/features/src/config/definitions/slack.ts
+++ b/packages/features/src/config/definitions/slack.ts
@@ -1,0 +1,31 @@
+import { ConfigRegistry } from "../registry";
+import { defineConfig, type ExtractConfigType } from "../types";
+
+/**
+ * Slack Configuration
+ * Defines configuration options for Slack integration
+ */
+export const slackConfig = defineConfig({
+	groups: [
+		{
+			id: "slack-integration",
+			label: "Slack Integration Settings",
+			description: "Configure Slack integration options",
+			icon: "Slack",
+			fields: [
+				{
+					key: "slack.secret",
+					label: "Slack Signing Secret",
+					description: "The secret used to verify incoming Slack requests",
+					type: "secret",
+					defaultValue: "",
+				},
+			],
+		},
+	],
+} as const);
+
+export type SlackConfigType = ExtractConfigType<typeof slackConfig>;
+
+// Register the configuration
+ConfigRegistry.register("slack", slackConfig);

--- a/packages/features/src/config/definitions/slack.ts
+++ b/packages/features/src/config/definitions/slack.ts
@@ -9,8 +9,8 @@ export const slackConfig = defineConfig({
 	groups: [
 		{
 			id: "slack-integration",
-			label: "Slack Integration Settings",
-			description: "Configure Slack integration options",
+			label: "Slack Integration",
+			description: "Configure Slack integration",
 			icon: "Slack",
 			fields: [
 				{

--- a/packages/features/src/config/index.ts
+++ b/packages/features/src/config/index.ts
@@ -11,3 +11,4 @@ export * from "./types";
 // Import all configuration definitions to register them
 import "./definitions/sessions";
 import "./definitions/email";
+import "./definitions/slack";

--- a/packages/features/src/config/types.ts
+++ b/packages/features/src/config/types.ts
@@ -9,7 +9,8 @@ export type ConfigFieldType =
 	| "boolean"
 	| "select"
 	| "multiselect"
-	| "textarea";
+	| "textarea"
+	| "secret";
 
 export interface ConfigFieldOption {
 	value: string;

--- a/packages/features/src/users/create-user.ts
+++ b/packages/features/src/users/create-user.ts
@@ -13,6 +13,7 @@ export type CreateUserData = {
 	name?: string | null;
 	email?: string | null;
 	cardNumber?: string | null;
+	slackUsername?: string | null;
 	isSystemUser?: boolean;
 	roleIds?: number[];
 };
@@ -33,6 +34,7 @@ export async function createUser(data: CreateUserData) {
 		let name = providedData.name ?? username;
 		let email =
 			providedData.email ?? `${username}@${env.FALLBACK_EMAIL_DOMAIN}`;
+		let slackUsername: string | undefined = providedData.slackUsername ?? undefined;
 		let cardNumber: string | undefined = providedData.cardNumber ?? undefined;
 		const isSystemUser = providedData.isSystemUser ?? false;
 
@@ -56,6 +58,7 @@ export async function createUser(data: CreateUserData) {
 			username,
 			name,
 			email,
+			slackUsername,
 			isSystemUser,
 			...(cardNumber ? { cardNumber } : {}),
 			...(roleIds && roleIds.length > 0

--- a/packages/features/src/users/create-user.ts
+++ b/packages/features/src/users/create-user.ts
@@ -34,7 +34,8 @@ export async function createUser(data: CreateUserData) {
 		let name = providedData.name ?? username;
 		let email =
 			providedData.email ?? `${username}@${env.FALLBACK_EMAIL_DOMAIN}`;
-		let slackUsername: string | undefined = providedData.slackUsername ?? undefined;
+		const slackUsername: string | undefined =
+			providedData.slackUsername || undefined;
 		let cardNumber: string | undefined = providedData.cardNumber ?? undefined;
 		const isSystemUser = providedData.isSystemUser ?? false;
 

--- a/packages/prisma/migrations/20260107002932_add_slack_audit_log_source/migration.sql
+++ b/packages/prisma/migrations/20260107002932_add_slack_audit_log_source/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "AuditLogSource" ADD VALUE 'slack';

--- a/packages/prisma/migrations/20260107032335_add_slack_username_to_user/migration.sql
+++ b/packages/prisma/migrations/20260107032335_add_slack_username_to_user/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slackUsername]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "slackUsername" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_slackUsername_key" ON "User"("slackUsername");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -41,6 +41,7 @@ enum MinMaxUnit {
 enum AuditLogSource {
   trpc
   rest
+  slack
 }
 
 //

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -52,11 +52,12 @@ model User {
   id Int @id @default(autoincrement())
 
   // fields
-  username     String  @unique
+  username     String   @unique
   name         String
-  email        String  @unique
-  cardNumber   String? @unique
-  isSystemUser Boolean @default(false)
+  email        String   @unique
+  cardNumber   String?  @unique
+  slackUsername String? @unique
+  isSystemUser Boolean  @default(false)
 
   // timestamps
   createdAt DateTime @default(now())

--- a/packages/rest/src/auth.ts
+++ b/packages/rest/src/auth.ts
@@ -34,7 +34,6 @@ function extractToken(request: FastifyRequest) {
 }
 
 async function authGuard(request: FastifyRequest, reply: FastifyReply) {
-
 	// Default to unsuccessful
 	reply.success = false;
 

--- a/packages/rest/src/auth.ts
+++ b/packages/rest/src/auth.ts
@@ -1,7 +1,13 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import type { AuditLogger } from "@ecehive/features";
-import { createAuditLogger, verifyApiToken } from "@ecehive/features";
+import {
+	ConfigService,
+	createAuditLogger,
+	verifyApiToken,
+} from "@ecehive/features";
 import type { ApiToken } from "@ecehive/prisma";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { slackError } from "./shared/validation";
 
 function extractToken(request: FastifyRequest) {
 	const headerToken = request.headers["x-api-key"];
@@ -26,45 +32,176 @@ function extractToken(request: FastifyRequest) {
 	return null;
 }
 
-async function apiTokenGuard(request: FastifyRequest, reply: FastifyReply) {
-	const token = extractToken(request);
-	if (!token) {
-		return reply.code(401).send({
-			error: "missing_api_token",
-			message: "Provide an API token via Authorization or x-api-key",
+async function authGuard(request: FastifyRequest, reply: FastifyReply) {
+	// Check for Slack signature first, if not present, normal REST
+	if (request.headers["x-slack-signature"]) {
+		// Verify Slack signing secret signature (per Slack docs)
+		const sigHeader = request.headers["x-slack-signature"] as
+			| string
+			| undefined;
+		const tsHeader = request.headers["x-slack-request-timestamp"] as
+			| string
+			| undefined;
+		const signingSecret = await ConfigService.get("slack.secret");
+
+		if (!signingSecret) {
+			request.log.error("SLACK_SIGNING_SECRET is not configured");
+			return slackError(
+				reply,
+				"Server misconfiguration",
+				"Slack signing secret not configured",
+			);
+		}
+
+		if (!sigHeader || !tsHeader) {
+			request.log.warn(
+				{ hasSignature: !!sigHeader, hasTimestamp: !!tsHeader },
+				"Missing Slack signature/timestamp headers",
+			);
+			return slackError(
+				reply,
+				"Unauthorized request",
+				"Missing Slack signature or timestamp headers",
+			);
+		}
+
+		const ts = Number(tsHeader);
+		if (Number.isNaN(ts)) {
+			request.log.warn({ tsHeader }, "Invalid Slack timestamp header");
+			return slackError(
+				reply,
+				"Unauthorized request",
+				"Invalid Slack request timestamp",
+			);
+		}
+
+		const now = Math.floor(Date.now() / 1000);
+		const FIVE_MINUTES = 60 * 5;
+		if (Math.abs(now - ts) > FIVE_MINUTES) {
+			request.log.warn({ ts, now }, "Slack request timestamp out of range");
+			return slackError(
+				reply,
+				"Request expired",
+				"Slack request timestamp is too old",
+			);
+		}
+
+		// Read raw body (the onRequest hook runs before body parsers)
+		let rawBody: string | undefined = request.rawBody;
+		if (typeof rawBody !== "string") {
+			// Buffer the stream
+			try {
+				rawBody = await new Promise<string>((resolve, reject) => {
+					const chunks: Buffer[] = [];
+					request.raw.on("data", (chunk: Buffer) => chunks.push(chunk));
+					request.raw.on("end", () =>
+						resolve(Buffer.concat(chunks).toString("utf8")),
+					);
+					request.raw.on("error", (err) => reject(err));
+				});
+				// Attach for downstream handlers/parsers
+				request.rawBody = rawBody;
+				// Also try to parse urlencoded body and set request.body so downstream code can use it
+				try {
+					const params = new URLSearchParams(rawBody);
+					const obj: Record<string, string> = {};
+					Array.from(params.entries()).forEach(([k, v]) => {
+						obj[k] = v;
+					});
+					request.body = obj;
+					request.log.info(
+						{ parsedBody: request.body },
+						"Parsed Slack urlencoded body",
+					);
+				} catch (_err) {
+					request.log.warn(
+						{ err: _err },
+						"Failed to parse urlencoded Slack body",
+					);
+				}
+			} catch (err) {
+				request.log.warn({ err }, "Failed to read raw Slack request body");
+				return slackError(
+					reply,
+					"Invalid request",
+					"Failed to read Slack request body",
+				);
+			}
+		}
+
+		const basestring = `v0:${ts}:${rawBody}`;
+		const expected = createHmac("sha256", signingSecret)
+			.update(basestring)
+			.digest("hex");
+		// sigHeader is like "v0=..."
+		const sigParts = sigHeader.split("=");
+		const receivedHex = sigParts.length > 1 ? sigParts[1] : sigHeader;
+
+		let valid = false;
+		try {
+			const a = Buffer.from(receivedHex, "hex");
+			const b = Buffer.from(expected, "hex");
+			if (a.length === b.length) valid = timingSafeEqual(a, b);
+		} catch (err) {
+			request.log.warn({ err }, "Error comparing Slack signatures");
+			valid = false;
+		}
+
+		if (!valid) {
+			return slackError(
+				reply,
+				"Unauthorized request",
+				"Invalid Slack request signature",
+			);
+		}
+
+		// Verified — create audit logger (system origin)
+		// request.audit = createAuditLogger({
+		// 	userId: 0,
+		// 	apiTokenId: 0,
+		// 	source: "rest",
+		// });
+	} else {
+		const token = extractToken(request);
+		if (!token) {
+			return reply.code(401).send({
+				error: "missing_api_token",
+				message: "Provide an API token via Authorization or x-api-key",
+			});
+		}
+
+		const record = await verifyApiToken(token);
+		if (!record) {
+			return reply.code(401).send({
+				error: "invalid_api_token",
+				message: "API token is invalid or expired",
+			});
+		}
+
+		if (!record.createdById) {
+			return reply.code(403).send({
+				error: "api_token_missing_owner",
+				message: "API token must be associated with a user",
+			});
+		}
+
+		request.apiToken = record;
+		request.audit = createAuditLogger({
+			userId: record.createdById,
+			apiTokenId: record.id,
+			source: "rest",
 		});
 	}
-
-	const record = await verifyApiToken(token);
-	if (!record) {
-		return reply.code(401).send({
-			error: "invalid_api_token",
-			message: "API token is invalid or expired",
-		});
-	}
-
-	if (!record.createdById) {
-		return reply.code(403).send({
-			error: "api_token_missing_owner",
-			message: "API token must be associated with a user",
-		});
-	}
-
-	request.apiToken = record;
-	request.audit = createAuditLogger({
-		userId: record.createdById,
-		apiTokenId: record.id,
-		source: "rest",
-	});
 }
 
-export function registerApiTokenGuard(instance: FastifyInstance) {
-	instance.addHook("onRequest", apiTokenGuard);
+export function registerAuthGuard(instance: FastifyInstance) {
+	instance.addHook("onRequest", authGuard);
 }
 
 declare module "fastify" {
 	interface FastifyRequest {
 		apiToken?: ApiToken;
 		audit?: AuditLogger;
+		rawBody?: string;
 	}
 }

--- a/packages/rest/src/auth.ts
+++ b/packages/rest/src/auth.ts
@@ -34,6 +34,10 @@ function extractToken(request: FastifyRequest) {
 }
 
 async function authGuard(request: FastifyRequest, reply: FastifyReply) {
+
+	// Default to unsuccessful
+	reply.success = false;
+
 	// Check for Slack signature first, if not present, normal REST
 	if (request.headers["x-slack-signature"]) {
 		// Verify Slack signing secret signature (per Slack docs)

--- a/packages/rest/src/routes/slack.ts
+++ b/packages/rest/src/routes/slack.ts
@@ -252,7 +252,6 @@ export const slackRoutes: FastifyPluginAsync = async (fastify) => {
 	fastify.addHook(
 		"preHandler",
 		async (request: FastifyRequest, reply: FastifyReply) => {
-
 			if (!request.user) {
 				return slackError(
 					reply,

--- a/packages/rest/src/routes/slack.ts
+++ b/packages/rest/src/routes/slack.ts
@@ -1,6 +1,6 @@
-import { type Prisma, prisma } from "@ecehive/prisma";
 import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
+import { logRestAction } from "../shared/audit";
 import { slackError, slackSuccess } from "../shared/validation";
 
 // ===== Validation Schemas =====
@@ -108,13 +108,13 @@ export const slackRoutes: FastifyPluginAsync = async (fastify) => {
 			}
 
 			// Log the incoming command for audit/debug
-			// await logRestAction(request, `rest.slack.${payload.command.slice(1)}`, {
-			// 	command: `${payload.command} ${payload.text}`,
-			// 	user_name: payload.user_name,
-			// 	user_id: payload.user_id,
-			// 	channel_name: payload.channel_name,
-			// 	channel_id: payload.channel_id,
-			// });
+			await logRestAction(request, `rest.slack.${payload.command.slice(1)}`, {
+				command: `${payload.command} ${payload.text}`,
+				user_name: payload.user_name,
+				user_id: payload.user_id,
+				channel_name: payload.channel_name,
+				channel_id: payload.channel_id,
+			});
 
 			// Placeholder: actual command handling not implemented yet
 			return slackSuccess(

--- a/packages/rest/src/routes/slack.ts
+++ b/packages/rest/src/routes/slack.ts
@@ -262,8 +262,16 @@ export const slackRoutes: FastifyPluginAsync = async (fastify) => {
 				);
 			}
 
-			// Check command against registry
-			const commandInfo = slackCommands[request.body.command];
+			// Check command against registry by validating the Slack payload first
+			const parsedCommandPayload = SlackSchema.safeParse(request.body);
+			if (!parsedCommandPayload.success) {
+				return slackError(
+					reply,
+					"Invalid request",
+					"Slack payload malformed, please contact an app administrator.",
+				);
+			}
+			const commandInfo = slackCommands[parsedCommandPayload.data.command];
 			if (commandInfo?.permissions && commandInfo.permissions.length > 0) {
 				// System users bypass permission checks
 				if (authUser.user.isSystemUser) {

--- a/packages/rest/src/routes/slack.ts
+++ b/packages/rest/src/routes/slack.ts
@@ -1,4 +1,12 @@
-import type { FastifyPluginAsync } from "fastify";
+import {
+	checkStaffingPermission,
+	endSession,
+	getCurrentSession,
+	startSession,
+	switchSessionType,
+} from "@ecehive/features";
+import { prisma, type User } from "@ecehive/prisma";
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { logRestAction } from "../shared/audit";
 import { slackError, slackSuccess } from "../shared/validation";
@@ -56,6 +64,7 @@ type SlackCommand = {
 	command: string;
 	usage: string;
 	validation?: z.ZodString;
+	permissions?: string[];
 };
 
 const slackCommands: Record<string, SlackCommand> = {
@@ -63,17 +72,244 @@ const slackCommands: Record<string, SlackCommand> = {
 		command: "/login",
 		usage: "/login <GT Username>",
 		validation: UsernameValidationSchema,
+		permissions: ["sessions.manage"],
 	},
 	"/logout": {
 		command: "/logout",
 		usage: "/logout <GT Username>",
 		validation: UsernameValidationSchema,
+		permissions: ["sessions.manage"],
 	},
 };
+
+// ===== Helper Functions =====
+
+async function getUserPermissions(user: User) {
+	// Get user with roles and permissions in a single optimized query
+	const userWithRolesAndPermissions = await prisma.user.findUnique({
+		where: { id: user.id },
+		include: {
+			roles: {
+				select: {
+					id: true,
+					name: true,
+					permissions: {
+						select: {
+							name: true,
+						},
+					},
+				},
+			},
+		},
+	});
+
+	if (!userWithRolesAndPermissions) {
+		return {
+			user: {
+				...user,
+				roles: [],
+				permissions: [],
+			},
+		};
+	}
+
+	// Extract unique permission names from all roles
+	const permissionNames = new Set<string>();
+	userWithRolesAndPermissions.roles.forEach((role) => {
+		role.permissions.forEach((permission) => {
+			permissionNames.add(permission.name);
+		});
+	});
+
+	// Transform roles to exclude nested permissions
+	const roles = userWithRolesAndPermissions.roles.map((role) => ({
+		id: role.id,
+		name: role.name,
+	}));
+
+	return {
+		user: {
+			...user,
+			roles,
+			permissions: Array.from(permissionNames),
+		},
+	};
+}
+
+async function updateUserSession(
+	reply: FastifyReply,
+	targetUsername: string,
+	action: "login" | "logout",
+) {
+	return await prisma.$transaction(
+		async (tx) => {
+			const now = new Date();
+
+			// Get target user
+			const targetUser = await tx.user.findUnique({
+				where: { username: targetUsername },
+				select: {
+					id: true,
+					name: true,
+					username: true,
+					email: true,
+					isSystemUser: true,
+				},
+			});
+
+			if (!targetUser) {
+				return slackError(
+					reply,
+					"User not found",
+					`No HUMS user found with username "${targetUsername}".`,
+				);
+			}
+
+			// Check if target user has staffing permission
+			const hasStaffingPermission = await checkStaffingPermission(
+				tx,
+				targetUser.id,
+				targetUser.isSystemUser,
+			);
+
+			if (!hasStaffingPermission) {
+				return slackError(
+					reply,
+					"Insufficient permissions",
+					`The HUMS user ${targetUser.username} does not have permission to enter a staffing session.`,
+				);
+			}
+
+			// Get user's current session
+			const currentSession = await getCurrentSession(tx, targetUser.id);
+
+			switch (action) {
+				case "login": {
+					// If the user is already in a session, switch it to staffing if needed
+					if (currentSession) {
+						if (currentSession.sessionType === "staffing") {
+							return slackSuccess(
+								reply,
+								"Already in staffing session",
+								`User ${targetUser.username} is already in a staffing session.`,
+							);
+						}
+						await switchSessionType(tx, currentSession.id, "staffing", now);
+
+						return slackSuccess(
+							reply,
+							"Session switched to staffing",
+							`User ${targetUser.username} was already in a session. Their session has been switched to a staffing session.`,
+						);
+					} else {
+						// Start a new staffing session
+						await startSession(tx, targetUser.id, "staffing", now);
+						return slackSuccess(
+							reply,
+							"Staffing session started",
+							`User ${targetUser.username} has started a new staffing session.`,
+						);
+					}
+				}
+				case "logout": {
+					if (!currentSession || currentSession.sessionType !== "staffing") {
+						return slackError(
+							reply,
+							"No active staffing session",
+							`User ${targetUser.username} is not currently in a staffing session.`,
+						);
+					}
+
+					// End the current session
+					await endSession(tx, currentSession.id, now);
+
+					return slackSuccess(
+						reply,
+						"Session ended",
+						`User ${targetUser.username}'s session has been ended.`,
+					);
+				}
+				default: {
+					return slackError(
+						reply,
+						"Invalid action",
+						"An invalid action was specified.",
+					);
+				}
+			}
+		},
+		{
+			maxWait: 2500,
+			timeout: 2500,
+		},
+	);
+}
 
 // ===== Routes =====
 
 export const slackRoutes: FastifyPluginAsync = async (fastify) => {
+	// Pre-handler to check permissions for Slack commands
+	fastify.addHook(
+		"preHandler",
+		async (request: FastifyRequest, reply: FastifyReply) => {
+			const authUser = await getUserPermissions(request.user as User);
+
+			if (!authUser) {
+				return slackError(
+					reply,
+					"Unauthorized user",
+					"No HUMS user found with Slack username.",
+				);
+			}
+
+			// Check command against registry
+			const commandInfo = slackCommands[request.body.command];
+			if (commandInfo?.permissions && commandInfo.permissions.length > 0) {
+				// System users bypass permission checks
+				if (authUser.user.isSystemUser) {
+					return;
+				}
+				// Verify user has all required permissions
+				const hasPermissions = commandInfo.permissions.every((perm) =>
+					authUser.user.permissions.includes(perm),
+				);
+				if (!hasPermissions) {
+					return slackError(
+						reply,
+						"Insufficient permissions",
+						"You do not have permission to execute this command.",
+					);
+				}
+			}
+		},
+	);
+
+	// Post-handler for audit logging if command is successful
+	fastify.addHook(
+		"onSend",
+		async (request: FastifyRequest, reply: FastifyReply) => {
+			const parsed = SlackSchema.safeParse(request.body);
+			if (!parsed.success) {
+				// Invalid payload, skip logging
+				return;
+			}
+			const payload = parsed.data;
+
+			// Only log successful commands
+			if (reply.success !== true) {
+				return;
+			}
+			// Log the incoming command for audit/debug
+			await logRestAction(request, `rest.slack.${payload.command.slice(1)}`, {
+				command: `${payload.command} ${payload.text}`,
+				user_name: payload.user_name,
+				user_id: payload.user_id,
+				channel_name: payload.channel_name,
+				channel_id: payload.channel_id,
+			});
+		},
+	);
+
 	// Slack only sends POST requests for slash commands
 	fastify.post("/", async (request, reply) => {
 		try {
@@ -107,24 +343,25 @@ export const slackRoutes: FastifyPluginAsync = async (fastify) => {
 				}
 			}
 
-			// Log the incoming command for audit/debug
-			await logRestAction(request, `rest.slack.${payload.command.slice(1)}`, {
-				command: `${payload.command} ${payload.text}`,
-				user_name: payload.user_name,
-				user_id: payload.user_id,
-				channel_name: payload.channel_name,
-				channel_id: payload.channel_id,
-			});
-
-			// Placeholder: actual command handling not implemented yet
-			return slackSuccess(
-				reply,
-				"Command received",
-				`You invoked the command "${payload.command}" with text: "${payload.text}"`,
-			);
+			switch (payload.command) {
+				case "/login":
+					return await updateUserSession(reply, payload.text.trim(), "login");
+				case "/logout":
+					return await updateUserSession(reply, payload.text.trim(), "logout");
+				default:
+					return slackError(
+						reply,
+						"Unknown command",
+						`The command "${payload.command}" is not recognized.`,
+					);
+			}
 		} catch (err) {
-			console.error("Error in slack POST handler", { err });
-			throw err;
+			request.log.error({ err }, "Error processing Slack command");
+			return slackError(
+				reply,
+				"Server error",
+				"An internal error occurred while processing your command.",
+			);
 		}
 	});
 };

--- a/packages/rest/src/routes/slack.ts
+++ b/packages/rest/src/routes/slack.ts
@@ -1,0 +1,130 @@
+import { type Prisma, prisma } from "@ecehive/prisma";
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+import { slackError, slackSuccess } from "../shared/validation";
+
+// ===== Validation Schemas =====
+
+const UsernameValidationSchema = z
+	.string()
+	.trim()
+	.min(1)
+	.max(100)
+	.regex(
+		/^[a-zA-Z0-9_-]+$/,
+		"Username must contain only letters, numbers, hyphens, and underscores",
+	);
+
+// Slack slash command payload (application/x-www-form-urlencoded)
+// See: https://api.slack.com/interactivity/slash-commands
+const SlackSchema = z.object({
+	// Verification token provided by Slack (deprecated)
+	token: z.string().optional(),
+
+	// Team information (present for workspace commands)
+	team_id: z.string(),
+	team_domain: z.string(),
+
+	// Enterprise details are only present for enterprise installs
+	enterprise_id: z.string().optional(),
+	enterprise_name: z.string().optional(),
+
+	// Channel where the command was invoked
+	channel_id: z.string(),
+	channel_name: z.string(),
+
+	// User who invoked the command
+	user_id: z.string(),
+	user_name: z.string(),
+
+	// The command itself and the (possibly empty) text after it
+	command: z.string(),
+	text: z.string().optional().default(""),
+
+	// Response/interaction details
+	response_url: z.string(),
+	trigger_id: z.string(),
+	api_app_id: z.string(),
+
+	// Install flag
+	is_enterprise_install: z.string().optional(),
+});
+
+// ===== Slack Command Registry =====
+
+type SlackCommand = {
+	command: string;
+	usage: string;
+	validation?: z.ZodString;
+};
+
+const slackCommands: Record<string, SlackCommand> = {
+	"/login": {
+		command: "/login",
+		usage: "/login <GT Username>",
+		validation: UsernameValidationSchema,
+	},
+	"/logout": {
+		command: "/logout",
+		usage: "/logout <GT Username>",
+		validation: UsernameValidationSchema,
+	},
+};
+
+// ===== Routes =====
+
+export const slackRoutes: FastifyPluginAsync = async (fastify) => {
+	// Slack only sends POST requests for slash commands
+	fastify.post("/", async (request, reply) => {
+		try {
+			const parsed = SlackSchema.safeParse(request.body);
+			if (!parsed.success) {
+				return slackError(
+					reply,
+					"Invalid request",
+					"Slack payload malformed, please contact an app administrator.",
+				);
+			}
+
+			const payload = parsed.data;
+
+			// Check command against registry
+			const commandInfo = slackCommands[payload.command];
+			if (!commandInfo) {
+				return slackError(
+					reply,
+					"Unknown command",
+					`The command "${payload.command}" is not recognized.`,
+				);
+			} else if (commandInfo.validation) {
+				const validationResult = commandInfo.validation.safeParse(payload.text);
+				if (!validationResult.success) {
+					return slackError(
+						reply,
+						"Invalid command usage",
+						`Usage: ${commandInfo.usage}`,
+					);
+				}
+			}
+
+			// Log the incoming command for audit/debug
+			// await logRestAction(request, `rest.slack.${payload.command.slice(1)}`, {
+			// 	command: `${payload.command} ${payload.text}`,
+			// 	user_name: payload.user_name,
+			// 	user_id: payload.user_id,
+			// 	channel_name: payload.channel_name,
+			// 	channel_id: payload.channel_id,
+			// });
+
+			// Placeholder: actual command handling not implemented yet
+			return slackSuccess(
+				reply,
+				"Command received",
+				`You invoked the command "${payload.command}" with text: "${payload.text}"`,
+			);
+		} catch (err) {
+			console.error("Error in slack POST handler", { err });
+			throw err;
+		}
+	});
+};

--- a/packages/rest/src/routes/slack.ts
+++ b/packages/rest/src/routes/slack.ts
@@ -252,15 +252,16 @@ export const slackRoutes: FastifyPluginAsync = async (fastify) => {
 	fastify.addHook(
 		"preHandler",
 		async (request: FastifyRequest, reply: FastifyReply) => {
-			const authUser = await getUserPermissions(request.user as User);
 
-			if (!authUser) {
+			if (!request.user) {
 				return slackError(
 					reply,
 					"Unauthorized user",
 					"No HUMS user found with Slack username.",
 				);
 			}
+
+			const authUser = await getUserPermissions(request.user as User);
 
 			// Check command against registry by validating the Slack payload first
 			const parsedCommandPayload = SlackSchema.safeParse(request.body);

--- a/packages/rest/src/shared/validation.ts
+++ b/packages/rest/src/shared/validation.ts
@@ -139,8 +139,9 @@ export function slackError(
 	title: string,
 	details?: string,
 ) {
+	reply.success = false;
 	return reply.code(200).send({
-		response_type: "ephemeral",
+		response_type: "in_channel",
 		blocks: createSlackResponseBlocks(title, details),
 	});
 }
@@ -156,8 +157,9 @@ export function slackSuccess(
 	title: string,
 	details?: string,
 ) {
+	reply.success = true;
 	return reply.code(200).send({
-		response_type: "ephemeral",
+		response_type: "in_channel",
 		blocks: createSlackResponseBlocks(title, details),
 	});
 }

--- a/packages/rest/src/shared/validation.ts
+++ b/packages/rest/src/shared/validation.ts
@@ -93,3 +93,71 @@ export function internalError(reply: FastifyReply, message?: string) {
 		},
 	});
 }
+
+// ===== Slack Response Helpers =====
+
+/**
+ * Creates Slack message blocks for responses
+ * @param title - The title of the message
+ * @param details - Optional detailed text to include in the message
+ * @returns
+ */
+export function createSlackResponseBlocks(title: string, details?: string) {
+	const blocks: Array<Record<string, unknown>> = [
+		{
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `*${title}*`,
+			},
+		},
+	];
+
+	if (details) {
+		blocks.push({
+			type: "context",
+			elements: [
+				{
+					type: "mrkdwn",
+					text: `\`\`\`${details}\`\`\``,
+				},
+			],
+		});
+	}
+
+	return blocks;
+}
+
+/**
+ * Sends a Slack-formatted error response
+ * @param reply - The Fastify reply object
+ * @param title - The title of the error message
+ * @param details - Optional detailed text about the error
+ */
+export function slackError(
+	reply: FastifyReply,
+	title: string,
+	details?: string,
+) {
+	return reply.code(200).send({
+		response_type: "in_channel",
+		blocks: createSlackResponseBlocks(title, details),
+	});
+}
+
+/**
+ * Sends a Slack-formatted success response
+ * @param reply - The Fastify reply object
+ * @param title - The title of the success message
+ * @param details - Optional detailed text about the success
+ */
+export function slackSuccess(
+	reply: FastifyReply,
+	title: string,
+	details?: string,
+) {
+	return reply.code(200).send({
+		response_type: "in_channel",
+		blocks: createSlackResponseBlocks(title, details),
+	});
+}

--- a/packages/rest/src/shared/validation.ts
+++ b/packages/rest/src/shared/validation.ts
@@ -140,7 +140,7 @@ export function slackError(
 	details?: string,
 ) {
 	return reply.code(200).send({
-		response_type: "in_channel",
+		response_type: "ephemeral",
 		blocks: createSlackResponseBlocks(title, details),
 	});
 }
@@ -157,7 +157,7 @@ export function slackSuccess(
 	details?: string,
 ) {
 	return reply.code(200).send({
-		response_type: "in_channel",
+		response_type: "ephemeral",
 		blocks: createSlackResponseBlocks(title, details),
 	});
 }

--- a/packages/rest/src/shared/validation.ts
+++ b/packages/rest/src/shared/validation.ts
@@ -105,23 +105,21 @@ export function internalError(reply: FastifyReply, message?: string) {
 export function createSlackResponseBlocks(title: string, details?: string) {
 	const blocks: Array<Record<string, unknown>> = [
 		{
-			type: "section",
+			type: "header",
 			text: {
-				type: "mrkdwn",
-				text: `*${title}*`,
+				type: "plain_text",
+				text: title,
 			},
 		},
 	];
 
 	if (details) {
 		blocks.push({
-			type: "context",
-			elements: [
-				{
-					type: "mrkdwn",
-					text: `\`\`\`${details}\`\`\``,
-				},
-			],
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `>${details.replace("\n", "\n>")}`,
+			},
 		});
 	}
 
@@ -141,7 +139,7 @@ export function slackError(
 ) {
 	reply.success = false;
 	return reply.code(200).send({
-		response_type: "in_channel",
+		response_type: "ephemeral",
 		blocks: createSlackResponseBlocks(title, details),
 	});
 }
@@ -159,7 +157,7 @@ export function slackSuccess(
 ) {
 	reply.success = true;
 	return reply.code(200).send({
-		response_type: "in_channel",
+		response_type: "ephemeral",
 		blocks: createSlackResponseBlocks(title, details),
 	});
 }

--- a/packages/rest/src/shared/validation.ts
+++ b/packages/rest/src/shared/validation.ts
@@ -100,7 +100,7 @@ export function internalError(reply: FastifyReply, message?: string) {
  * Creates Slack message blocks for responses
  * @param title - The title of the message
  * @param details - Optional detailed text to include in the message
- * @returns
+ * @returns An array of Slack Block Kit blocks for the message
  */
 export function createSlackResponseBlocks(title: string, details?: string) {
 	const blocks: Array<Record<string, unknown>> = [
@@ -118,7 +118,7 @@ export function createSlackResponseBlocks(title: string, details?: string) {
 			type: "section",
 			text: {
 				type: "mrkdwn",
-				text: `>${details.replace("\n", "\n>")}`,
+				text: `>${details.replace(/\n/g, "\n>")}`,
 			},
 		});
 	}

--- a/packages/trpc/server/routers/auditLogs/list.route.ts
+++ b/packages/trpc/server/routers/auditLogs/list.route.ts
@@ -2,7 +2,7 @@ import { listAuditLogs } from "@ecehive/features";
 import { z } from "zod";
 import type { TPermissionProtectedProcedureContext } from "../../trpc";
 
-const auditLogSources = ["trpc", "rest"] as const;
+const auditLogSources = ["trpc", "rest", "slack"] as const;
 
 export const ZListAuditLogsSchema = z.object({
 	userId: z.number().int().positive().optional(),

--- a/packages/trpc/server/routers/users/create.route.ts
+++ b/packages/trpc/server/routers/users/create.route.ts
@@ -6,6 +6,7 @@ export const ZCreateSchema = z.object({
 	username: z.string().min(1).max(100),
 	name: z.string().max(100).optional(),
 	email: z.union([z.email("Invalid email address"), z.literal("")]).optional(),
+	slackUsername: z.string().max(100).optional(),
 	roleIds: z.array(z.number().min(1)).optional(),
 });
 
@@ -17,12 +18,13 @@ export type TCreateOptions = {
 };
 
 export async function createHandler(options: TCreateOptions) {
-	const { username, name, email, roleIds } = options.input;
+	const { username, name, email, slackUsername, roleIds } = options.input;
 
 	const newUser = await createUser({
 		username,
 		name: name || undefined,
 		email: email || undefined,
+		slackUsername: slackUsername || undefined,
 		roleIds,
 		isSystemUser: false,
 	});

--- a/packages/trpc/server/routers/users/create.route.ts
+++ b/packages/trpc/server/routers/users/create.route.ts
@@ -6,7 +6,7 @@ export const ZCreateSchema = z.object({
 	username: z.string().min(1).max(100),
 	name: z.string().max(100).optional(),
 	email: z.union([z.email("Invalid email address"), z.literal("")]).optional(),
-	slackUsername: z.string().max(100).optional(),
+	slackUsername: z.string().nullable().optional(),
 	roleIds: z.array(z.number().min(1)).optional(),
 });
 

--- a/packages/trpc/server/routers/users/list.route.ts
+++ b/packages/trpc/server/routers/users/list.route.ts
@@ -27,6 +27,7 @@ export async function listHandler(options: TListOptions) {
 			{ name: { contains: search, mode: "insensitive" } },
 			{ username: { contains: search, mode: "insensitive" } },
 			{ email: { contains: search, mode: "insensitive" } },
+			{ slackUsername: { contains: search, mode: "insensitive" } },
 		];
 	}
 

--- a/packages/trpc/server/routers/users/update.route.ts
+++ b/packages/trpc/server/routers/users/update.route.ts
@@ -8,7 +8,7 @@ export const ZUpdateSchema = z.object({
 	id: z.number().min(1),
 	name: z.string().min(1).max(100),
 	email: z.email(),
-	slackUsername: z.string().optional(),
+	slackUsername: z.string().nullable().optional(),
 	roleIds: z.array(z.number().min(1)).optional(),
 });
 
@@ -27,7 +27,7 @@ export async function updateHandler(options: TUpdateOptions) {
 		data: {
 			name,
 			email,
-			slackUsername,
+			slackUsername: slackUsername === "" ? null : slackUsername,
 			...(roleIds !== undefined
 				? {
 						roles: {

--- a/packages/trpc/server/routers/users/update.route.ts
+++ b/packages/trpc/server/routers/users/update.route.ts
@@ -8,6 +8,7 @@ export const ZUpdateSchema = z.object({
 	id: z.number().min(1),
 	name: z.string().min(1).max(100),
 	email: z.email(),
+	slackUsername: z.string().optional(),
 	roleIds: z.array(z.number().min(1)).optional(),
 });
 
@@ -19,13 +20,14 @@ export type TUpdateOptions = {
 };
 
 export async function updateHandler(options: TUpdateOptions) {
-	const { id, name, email, roleIds } = options.input;
+	const { id, name, email, slackUsername, roleIds } = options.input;
 
 	const updated = await prisma.user.update({
 		where: { id },
 		data: {
 			name,
 			email,
+			slackUsername,
 			...(roleIds !== undefined
 				? {
 						roles: {


### PR DESCRIPTION
This PR adds Slack integration functionality. Currently, it supports logging in and out of staffing sessions.

Changelog:
- Add Slack integration framework for defining commands, permissions checks, command text validation, and Slack signature validation
- Add login/logout support for staffing sessions through Slack slash commands
- Update users table to include Slack username for matching HUMS users and permissions to Slack usernames
- Update audit log to record Slack actions (currently staffing session management)
- Update config to include Slack secret