### PR TITLE
Improve shift scheduling UI

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -48,6 +48,7 @@
 		"react": "^19.2.3",
 		"react-day-picker": "^9.12.0",
 		"react-dom": "19.2.3",
+		"react-resizable-panels": "^4.4.1",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.4.0",
 		"zod": "^4.3.5"

--- a/apps/client/src/components/shift-schedules/scheduler-grid.tsx
+++ b/apps/client/src/components/shift-schedules/scheduler-grid.tsx
@@ -130,15 +130,21 @@ export function SchedulerGrid({
 }: SchedulerGridProps) {
 	const isDarkMode = useIsDarkMode();
 
+	// Calculate minimum table width: 80px for time column + 120px per day column
+	const minTableWidth = 80 + visibleDays.length * 120;
+
 	return (
 		<div className="flex-1 overflow-auto relative">
-			<div className="inline-block min-w-full pb-24">
-				<table className="border-collapse">
+			<div className="pb-24" style={{ minWidth: minTableWidth }}>
+				<table className="w-full border-collapse table-fixed">
 					{/* Sticky Header Row */}
 					<thead>
 						<tr>
 							{/* Corner cell - sticky both ways */}
-							<th className="sticky left-0 top-0 z-30 bg-background p-2 min-w-[70px] border-b border-r">
+							<th
+								className="sticky left-0 top-0 z-30 bg-background p-2 border-b border-r"
+								style={{ width: 80 }}
+							>
 								<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
 									Time
 								</span>
@@ -147,7 +153,7 @@ export function SchedulerGrid({
 							{visibleDays.map((day) => (
 								<th
 									key={day.value}
-									className="sticky top-0 z-20 bg-background p-2 min-w-[120px] border-b"
+									className="sticky top-0 z-20 bg-background p-2 border-b"
 								>
 									<div className="text-center py-1">
 										<div className="hidden sm:block text-sm font-semibold">

--- a/apps/client/src/components/ui/resizable.tsx
+++ b/apps/client/src/components/ui/resizable.tsx
@@ -1,0 +1,61 @@
+import * as React from "react"
+import { GripVerticalIcon } from "lucide-react"
+import {
+  Group,
+  Panel,
+  Separator,
+  type GroupProps,
+  type PanelProps,
+  type SeparatorProps,
+} from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: GroupProps) {
+  return (
+    <Group
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({
+  ...props
+}: PanelProps) {
+  return <Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: SeparatorProps & {
+  withHandle?: boolean
+}) {
+  return (
+    <Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[orientation=vertical]:h-px data-[orientation=vertical]:w-full data-[orientation=vertical]:after:left-0 data-[orientation=vertical]:after:h-1 data-[orientation=vertical]:after:w-full data-[orientation=vertical]:after:translate-x-0 data-[orientation=vertical]:after:-translate-y-1/2 [&[data-orientation=vertical]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+          <GripVerticalIcon className="size-2.5" />
+        </div>
+      )}
+    </Separator>
+  )
+}
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle }

--- a/apps/overview/src/routeTree.gen.ts
+++ b/apps/overview/src/routeTree.gen.ts
@@ -29,8 +29,8 @@ const OverviewStaffingRoute = OverviewStaffingRouteImport.update({
 } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof OverviewIndexRoute
   '/staffing': typeof OverviewStaffingRoute
+  '/': typeof OverviewIndexRoute
 }
 export interface FileRoutesByTo {
   '/staffing': typeof OverviewStaffingRoute
@@ -44,7 +44,7 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/staffing'
+  fullPaths: '/staffing' | '/'
   fileRoutesByTo: FileRoutesByTo
   to: '/staffing' | '/'
   id: '__root__' | '/_overview' | '/_overview/staffing' | '/_overview/'
@@ -59,7 +59,7 @@ declare module '@tanstack/react-router' {
     '/_overview': {
       id: '/_overview'
       path: ''
-      fullPath: '/'
+      fullPath: ''
       preLoaderRoute: typeof OverviewRouteImport
       parentRoute: typeof rootRouteImport
     }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@ecehive/hums",
@@ -10,7 +9,7 @@
     },
     "apps/client": {
       "name": "@ecehive/client",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/trpc": "workspace:*",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -51,6 +50,7 @@
         "react": "^19.2.3",
         "react-day-picker": "^9.12.0",
         "react-dom": "19.2.3",
+        "react-resizable-panels": "^4.4.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.5",
@@ -73,7 +73,7 @@
     },
     "apps/kiosk": {
       "name": "@ecehive/kiosk",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/trpc": "workspace:*",
         "@radix-ui/react-separator": "^1.1.8",
@@ -118,7 +118,7 @@
     },
     "apps/overview": {
       "name": "@ecehive/overview",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/trpc": "workspace:*",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -166,7 +166,7 @@
     },
     "apps/server": {
       "name": "@ecehive/server",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/features": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/auth": {
       "name": "@ecehive/auth",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/logger": "workspace:*",
@@ -199,7 +199,7 @@
     },
     "packages/config": {
       "name": "@ecehive/config",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
         "@types/node": "^24.10.1",
@@ -207,7 +207,7 @@
     },
     "packages/email": {
       "name": "@ecehive/email",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.966.0",
         "@ecehive/env": "workspace:*",
@@ -228,7 +228,7 @@
     },
     "packages/env": {
       "name": "@ecehive/env",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@types/node": "^24.5.2",
         "zod": "^4.3.5",
@@ -240,7 +240,7 @@
     },
     "packages/features": {
       "name": "@ecehive/features",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/email": "workspace:*",
         "@ecehive/env": "workspace:*",
@@ -258,7 +258,7 @@
     },
     "packages/ldap": {
       "name": "@ecehive/ldap",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/logger": "workspace:*",
@@ -271,7 +271,7 @@
     },
     "packages/logger": {
       "name": "@ecehive/logger",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "tslog": "^4.9.3",
       },
@@ -281,7 +281,7 @@
     },
     "packages/prisma": {
       "name": "@ecehive/prisma",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@prisma/adapter-pg": "^7.1.0",
@@ -299,7 +299,7 @@
     },
     "packages/rest": {
       "name": "@ecehive/rest",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/features": "workspace:*",
         "@ecehive/prisma": "workspace:*",
@@ -315,7 +315,7 @@
     },
     "packages/trpc": {
       "name": "@ecehive/trpc",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@ecehive/auth": "workspace:*",
@@ -338,7 +338,7 @@
     },
     "packages/user-data": {
       "name": "@ecehive/user-data",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@ecehive/env": "workspace:*",
         "@ecehive/ldap": "workspace:*",
@@ -352,7 +352,7 @@
     },
     "packages/workers": {
       "name": "@ecehive/workers",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@ecehive/email": "workspace:*",
@@ -1551,6 +1551,8 @@
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-resizable-panels": ["react-resizable-panels@4.4.1", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-dpM9oI6rGlAq7VYDeafSRA1JmkJv8aNuKySR+tZLQQLfaeqTnQLSM52EcoI/QdowzsjVUCk6jViKS0xHWITVRQ=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 


### PR DESCRIPTION
This pull request makes improvements to the shift scheduling interface.

- Added a resizable sidebar for desktop-size devices.
- Made the time slot grid cells expand to fill the available horizontal space on larger monitors.
- Fixed a bug where the filters popover would close when anything was changed.

<img width="1509" height="883" alt="Screenshot 2026-01-17 at 15 09 44" src="https://github.com/user-attachments/assets/2cc0e7bd-4f29-42ae-985f-fca349f2d0f6" />

<img width="1509" height="883" alt="Screenshot 2026-01-17 at 15 09 54" src="https://github.com/user-attachments/assets/a5a2fcfb-7f7a-478a-b249-918fd0469cc3" />


