### PR TITLE
Fix balancing against of full shifts

### DIFF
--- a/apps/client/src/components/shift-schedules/schedule-delta-utils.ts
+++ b/apps/client/src/components/shift-schedules/schedule-delta-utils.ts
@@ -138,24 +138,29 @@ function calculateMeetsBalancingRequirement(
 
 	// Check isBalancedAcrossPeriod: ALL other schedules must have >= current filled slots
 	// Note: Server checks against all schedules, not just same shift type
+	// Skip schedules that are already full - they shouldn't block others from registering
 	if (schedule.isBalancedAcrossPeriod) {
 		for (const other of allSchedules) {
 			if (other.id === schedule.id) continue;
+			if (other.slots > 0 && other.users.length >= other.slots) continue;
 			if (other.users.length < currentFilledSlots) return false;
 		}
 	}
 
 	// Check isBalancedAcrossDay: all schedules on the same day must have >= current filled slots
+	// Skip schedules that are already full - they shouldn't block others from registering
 	if (schedule.isBalancedAcrossDay) {
 		const sameDaySchedules = allSchedules.filter(
 			(s) => s.dayOfWeek === schedule.dayOfWeek && s.id !== schedule.id,
 		);
 		for (const other of sameDaySchedules) {
+			if (other.slots > 0 && other.users.length >= other.slots) continue;
 			if (other.users.length < currentFilledSlots) return false;
 		}
 	}
 
 	// Check isBalancedAcrossOverlap: all overlapping schedules must have >= current filled slots
+	// Skip schedules that are already full - they shouldn't block others from registering
 	if (schedule.isBalancedAcrossOverlap) {
 		const overlappingSchedules = allSchedules.filter((s) => {
 			if (s.id === schedule.id) return false;
@@ -169,6 +174,7 @@ function calculateMeetsBalancingRequirement(
 		});
 
 		for (const other of overlappingSchedules) {
+			if (other.slots > 0 && other.users.length >= other.slots) continue;
 			if (other.users.length < currentFilledSlots) return false;
 		}
 	}

--- a/packages/features/src/shift-schedules/queries.ts
+++ b/packages/features/src/shift-schedules/queries.ts
@@ -55,7 +55,12 @@ export async function getAllSchedulesForBalancing(
 	prisma: PrismaClient | PrismaTransaction,
 ) {
 	return prisma.shiftSchedule.findMany({
-		include: {
+		select: {
+			id: true,
+			dayOfWeek: true,
+			startTime: true,
+			endTime: true,
+			slots: true,
 			users: { select: { id: true } },
 		},
 	});


### PR DESCRIPTION
This pull request fixes an issue that would effectively break registering for a shift when there is a full shift with fewer slots at the same time.

Example of the issue:
1. Shift A has 3 slots. Two are full. This shift is balanced across overlap.
2. Shift B has 1 slot. All are full.
3. Shift A can have no more assignments made since 1 < 2.