### PR TITLE
Add early tapout confirmation

### DIFF
--- a/apps/kiosk/src/App.tsx
+++ b/apps/kiosk/src/App.tsx
@@ -108,6 +108,7 @@ function App() {
 							errorDialog={tapWorkflow.errorDialog}
 							sessionTypeSelection={tapWorkflow.sessionTypeSelection}
 							tapOutActionSelection={tapWorkflow.tapOutActionSelection}
+							earlyLeaveConfirmation={tapWorkflow.earlyLeaveConfirmation}
 							pendingAgreement={tapWorkflow.pendingAgreement}
 							tapNotification={tapWorkflow.tapNotification}
 							suspension={tapWorkflow.suspension}
@@ -115,6 +116,8 @@ function App() {
 							onSessionTypeCancel={tapWorkflow.handleSessionTypeCancel}
 							onTapOutActionSelect={tapWorkflow.handleTapOutActionSelect}
 							onTapOutActionCancel={tapWorkflow.handleTapOutActionCancel}
+							onEarlyLeaveConfirm={tapWorkflow.handleEarlyLeaveConfirm}
+							onEarlyLeaveCancel={tapWorkflow.handleEarlyLeaveCancel}
 							onAgreementComplete={tapWorkflow.handleAgreementComplete}
 							onAgreementCancel={tapWorkflow.handleAgreementCancel}
 							onAgreementError={tapWorkflow.handleAgreementError}

--- a/apps/kiosk/src/components/early-leave-confirmation.tsx
+++ b/apps/kiosk/src/components/early-leave-confirmation.tsx
@@ -1,0 +1,79 @@
+import { AlertTriangle } from "lucide-react";
+import { motion } from "motion/react";
+import { Button } from "./ui/button";
+
+interface EarlyLeaveConfirmationProps {
+	userName: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export function EarlyLeaveConfirmation({
+	userName,
+	onConfirm,
+	onCancel,
+}: EarlyLeaveConfirmationProps) {
+	return (
+		<motion.div
+			className="absolute inset-0 z-50 flex items-center justify-center bg-black/95 backdrop-blur-md"
+			initial={{ opacity: 0 }}
+			animate={{ opacity: 1 }}
+			exit={{ opacity: 0 }}
+			transition={{ duration: 0.3 }}
+		>
+			<motion.div
+				className="max-w-3xl mx-auto gap-8 flex flex-col"
+				initial={{ opacity: 0, scale: 0.95, y: 16 }}
+				animate={{ opacity: 1, scale: 1, y: 0 }}
+				exit={{ opacity: 0, scale: 0.95, y: 16 }}
+				transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+			>
+				<motion.div
+					className="flex flex-col items-center gap-6"
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ delay: 0.1, duration: 0.35 }}
+				>
+					<motion.div
+						className="relative flex items-center justify-center"
+						initial={{ scale: 0.85, opacity: 0 }}
+						animate={{ scale: 1, opacity: 1 }}
+						transition={{ duration: 0.6, ease: "easeOut" }}
+					>
+						<AlertTriangle className="w-24 h-24 text-yellow-500" />
+					</motion.div>
+
+					<div className="text-center gap-4 flex flex-col">
+						<h2 className="text-5xl font-bold">{userName}</h2>
+						<p className="text-2xl text-muted-foreground max-w-xl">
+							You recently started a session. Are you sure you want to leave so
+							soon?
+						</p>
+					</div>
+				</motion.div>
+
+				<motion.div
+					className="flex justify-center gap-6"
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ delay: 0.2, duration: 0.35 }}
+				>
+					<Button
+						variant="outline"
+						className="text-xl px-8 py-6 h-auto"
+						onClick={onCancel}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						className="text-xl px-8 py-6 h-auto"
+						onClick={onConfirm}
+					>
+						Yes, Leave
+					</Button>
+				</motion.div>
+			</motion.div>
+		</motion.div>
+	);
+}

--- a/apps/kiosk/src/components/flow-overlays.tsx
+++ b/apps/kiosk/src/components/flow-overlays.tsx
@@ -1,12 +1,14 @@
 import { Clock, LogOut, RefreshCw, Users } from "lucide-react";
 import type { ReactNode } from "react";
 import { AgreementFlow } from "@/components/agreement-flow";
+import { EarlyLeaveConfirmation } from "@/components/early-leave-confirmation";
 import { ErrorDialog } from "@/components/error-dialog";
 import type { SelectionOverlayOption } from "@/components/session-type-selector";
 import { SelectionOverlay } from "@/components/session-type-selector";
 import { SuspensionDialog } from "@/components/suspension-dialog";
 import { TapNotification } from "@/components/tap-notification";
 import type {
+	EarlyLeaveConfirmationState,
 	ErrorDialogState,
 	PendingAgreementState,
 	SessionTypeSelectionState,
@@ -20,6 +22,7 @@ interface FlowOverlaysProps {
 	errorDialog: ErrorDialogState;
 	sessionTypeSelection: SessionTypeSelectionState | null;
 	tapOutActionSelection: TapOutActionSelectionState | null;
+	earlyLeaveConfirmation: EarlyLeaveConfirmationState | null;
 	pendingAgreement: PendingAgreementState | null;
 	tapNotification: TapNotificationState;
 	suspension: SuspensionState | null;
@@ -29,6 +32,8 @@ interface FlowOverlaysProps {
 		action: "end_session" | "switch_to_staffing" | "switch_to_regular",
 	) => void;
 	onTapOutActionCancel: () => void;
+	onEarlyLeaveConfirm: () => void;
+	onEarlyLeaveCancel: () => void;
 	onAgreementComplete: () => void;
 	onAgreementCancel: () => void;
 	onAgreementError: (message: string) => void;
@@ -39,6 +44,7 @@ export function FlowOverlays({
 	errorDialog,
 	sessionTypeSelection,
 	tapOutActionSelection,
+	earlyLeaveConfirmation,
 	pendingAgreement,
 	tapNotification,
 	suspension,
@@ -46,6 +52,8 @@ export function FlowOverlays({
 	onSessionTypeCancel,
 	onTapOutActionSelect,
 	onTapOutActionCancel,
+	onEarlyLeaveConfirm,
+	onEarlyLeaveCancel,
 	onAgreementComplete,
 	onAgreementCancel,
 	onAgreementError,
@@ -56,6 +64,7 @@ export function FlowOverlays({
 		!!pendingAgreement ||
 		!!sessionTypeSelection ||
 		!!tapOutActionSelection ||
+		!!earlyLeaveConfirmation ||
 		!!suspension;
 
 	type OverlayConfig = {
@@ -188,6 +197,14 @@ export function FlowOverlays({
 					header={overlayConfig.header}
 					options={overlayConfig.options}
 					onCancel={overlayConfig.onCancel}
+				/>
+			)}
+
+			{earlyLeaveConfirmation && (
+				<EarlyLeaveConfirmation
+					userName={earlyLeaveConfirmation.userName}
+					onConfirm={onEarlyLeaveConfirm}
+					onCancel={onEarlyLeaveCancel}
 				/>
 			)}
 

--- a/apps/kiosk/src/types/index.ts
+++ b/apps/kiosk/src/types/index.ts
@@ -70,6 +70,22 @@ export type TapResponse =
 			};
 	  }
 	| {
+			status: "confirm_early_leave";
+			user: {
+				id: number;
+				name: string;
+				email: string;
+				username: string;
+			};
+			currentSession: {
+				id: number;
+				userId: number;
+				sessionType: "regular" | "staffing";
+				startedAt: Date;
+				endedAt: Date | null;
+			};
+	  }
+	| {
 			status: "agreements_required";
 			user: {
 				id: number;


### PR DESCRIPTION
This pull request adds a confirmation dialog to the kiosks when a user taps out of a session less than one minute after starting their session.