### PR TITLE
Add manage users page memory

### DIFF
--- a/apps/client/src/components/navigation/shifts-sidebar.tsx
+++ b/apps/client/src/components/navigation/shifts-sidebar.tsx
@@ -46,6 +46,7 @@ import {
 	SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { useGlitchEgg } from "@/hooks/use-glitch-egg";
+import { getLastVisitedManageUser } from "@/hooks/use-manage-users-memory";
 import { useShiftAccess } from "@/hooks/use-shift-access";
 import { checkPermissions } from "@/lib/permissions";
 import { permissions as attendancePagePermissions } from "@/routes/app/shifts/attendance";
@@ -233,19 +234,29 @@ export function ShiftsSidebar() {
 							)}
 							<SidebarGroupContent>
 								<SidebarMenu>
-									{visibleItems.map((item) => (
-										<SidebarMenuItem key={item.title}>
-											<SidebarMenuButton
-												asChild
-												isActive={isPathActive(item.url)}
-											>
-												<Link to={item.url}>
-													<item.icon />
-													<span>{item.title}</span>
-												</Link>
-											</SidebarMenuButton>
-										</SidebarMenuItem>
-									))}
+									{visibleItems.map((item) => {
+										// For Manage Users, check if there's a remembered user to navigate to
+										let targetUrl = item.url;
+										if (item.url === "/app/shifts/manage-users") {
+											const lastUserId = getLastVisitedManageUser();
+											if (lastUserId) {
+												targetUrl = `/app/shifts/manage-users/${lastUserId}`;
+											}
+										}
+										return (
+											<SidebarMenuItem key={item.title}>
+												<SidebarMenuButton
+													asChild
+													isActive={isPathActive(item.url)}
+												>
+													<Link to={targetUrl}>
+														<item.icon />
+														<span>{item.title}</span>
+													</Link>
+												</SidebarMenuButton>
+											</SidebarMenuItem>
+										);
+									})}
 								</SidebarMenu>
 							</SidebarGroupContent>
 						</SidebarGroup>

--- a/apps/client/src/hooks/use-manage-users-memory.ts
+++ b/apps/client/src/hooks/use-manage-users-memory.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect } from "react";
+
+const STORAGE_KEY = "hums:manage-users-last-visited";
+
+type ManageUsersMemory = {
+	userId: string;
+	timestamp: number;
+};
+
+/**
+ * Returns the last visited user ID in the Manage Users section,
+ * or null if none has been visited or the memory has expired.
+ */
+export function getLastVisitedManageUser(): string | null {
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (!stored) return null;
+
+		const memory: ManageUsersMemory = JSON.parse(stored);
+
+		// Memory expires after 24 hours
+		const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+		if (Date.now() - memory.timestamp > ONE_DAY_MS) {
+			localStorage.removeItem(STORAGE_KEY);
+			return null;
+		}
+
+		return memory.userId;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Saves the currently visited user ID as the last visited in Manage Users.
+ */
+function setLastVisitedManageUser(userId: string): void {
+	try {
+		const memory: ManageUsersMemory = {
+			userId,
+			timestamp: Date.now(),
+		};
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(memory));
+	} catch {
+		// Silently fail if localStorage is not available
+	}
+}
+
+/**
+ * Clears the last visited user memory.
+ */
+export function clearManageUsersMemory(): void {
+	try {
+		localStorage.removeItem(STORAGE_KEY);
+	} catch {
+		// Silently fail if localStorage is not available
+	}
+}
+
+/**
+ * Hook to track and remember the last visited user in the Manage Users section.
+ * Call this hook on the user detail page to remember the visit.
+ */
+export function useManageUsersMemory(userId?: string) {
+	// Remember this user visit when the component mounts or userId changes
+	useEffect(() => {
+		if (userId) {
+			setLastVisitedManageUser(userId);
+		}
+	}, [userId]);
+
+	const clearMemory = useCallback(() => {
+		clearManageUsersMemory();
+	}, []);
+
+	return {
+		clearMemory,
+	};
+}

--- a/apps/client/src/routes/app/shifts/manage-users.$userId.tsx
+++ b/apps/client/src/routes/app/shifts/manage-users.$userId.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useManageUsersMemory } from "@/hooks/use-manage-users-memory";
 import { checkPermissions, type RequiredPermissions } from "@/lib/permissions";
 
 export const Route = createFileRoute("/app/shifts/manage-users/$userId")({
@@ -57,6 +58,9 @@ function ManageUserDetailPage() {
 	const canManageAssignments = checkPermissions(currentUser, permissions);
 	const canViewUpcoming = checkPermissions(currentUser, permissions);
 	const canViewAttendance = checkPermissions(currentUser, permissions);
+
+	// Remember this user visit for sidebar navigation
+	useManageUsersMemory(userId);
 
 	// Fetch user info
 	const userQuery = useQuery({

--- a/apps/client/src/routes/app/shifts/manage-users.index.tsx
+++ b/apps/client/src/routes/app/shifts/manage-users.index.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Loader2Icon, RefreshCcwIcon, UserIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { RequirePermissions } from "@/auth/AuthProvider";
 import { PeriodNotSelected } from "@/components/errors/period-not-selected";
 import { MissingPermissions } from "@/components/guards/missing-permissions";
@@ -40,6 +40,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { clearManageUsersMemory } from "@/hooks/use-manage-users-memory";
 import { usePaginationInfo } from "@/hooks/use-pagination-info";
 import { useTableState } from "@/hooks/use-table-state";
 import type { RequiredPermissions } from "@/lib/permissions";
@@ -324,6 +325,12 @@ function RolesFilterInput({
 function ManageUsersPage() {
 	const { period: selectedPeriodId } = usePeriod();
 	const [filters, setFilters] = useState<ShiftFilters>(DEFAULT_FILTERS);
+
+	// Clear the "memory" when visiting the users list page
+	// This ensures clicking the sidebar will go to this page next time
+	useEffect(() => {
+		clearManageUsersMemory();
+	}, []);
 
 	const {
 		page,


### PR DESCRIPTION
This pull request adds memory to the Manage Users shift page so that it will remember the last user you were looking at and will direct you to that user's page when you attempt to visit the Manage Users page from the sidebar.