### PR TITLE
Add an early-leave warning message

### DIFF
--- a/apps/kiosk/src/App.tsx
+++ b/apps/kiosk/src/App.tsx
@@ -109,6 +109,9 @@ function App() {
 							sessionTypeSelection={tapWorkflow.sessionTypeSelection}
 							tapOutActionSelection={tapWorkflow.tapOutActionSelection}
 							earlyLeaveConfirmation={tapWorkflow.earlyLeaveConfirmation}
+							shiftEarlyLeaveConfirmation={
+								tapWorkflow.shiftEarlyLeaveConfirmation
+							}
 							pendingAgreement={tapWorkflow.pendingAgreement}
 							tapNotification={tapWorkflow.tapNotification}
 							suspension={tapWorkflow.suspension}
@@ -118,6 +121,10 @@ function App() {
 							onTapOutActionCancel={tapWorkflow.handleTapOutActionCancel}
 							onEarlyLeaveConfirm={tapWorkflow.handleEarlyLeaveConfirm}
 							onEarlyLeaveCancel={tapWorkflow.handleEarlyLeaveCancel}
+							onShiftEarlyLeaveConfirm={
+								tapWorkflow.handleShiftEarlyLeaveConfirm
+							}
+							onShiftEarlyLeaveCancel={tapWorkflow.handleShiftEarlyLeaveCancel}
 							onAgreementComplete={tapWorkflow.handleAgreementComplete}
 							onAgreementCancel={tapWorkflow.handleAgreementCancel}
 							onAgreementError={tapWorkflow.handleAgreementError}

--- a/apps/kiosk/src/components/flow-overlays.tsx
+++ b/apps/kiosk/src/components/flow-overlays.tsx
@@ -5,6 +5,7 @@ import { EarlyLeaveConfirmation } from "@/components/early-leave-confirmation";
 import { ErrorDialog } from "@/components/error-dialog";
 import type { SelectionOverlayOption } from "@/components/session-type-selector";
 import { SelectionOverlay } from "@/components/session-type-selector";
+import { ShiftEarlyLeaveConfirmation } from "@/components/shift-early-leave-confirmation";
 import { SuspensionDialog } from "@/components/suspension-dialog";
 import { TapNotification } from "@/components/tap-notification";
 import type {
@@ -12,6 +13,7 @@ import type {
 	ErrorDialogState,
 	PendingAgreementState,
 	SessionTypeSelectionState,
+	ShiftEarlyLeaveConfirmationState,
 	SuspensionState,
 	TapNotificationState,
 	TapOutActionSelectionState,
@@ -23,6 +25,7 @@ interface FlowOverlaysProps {
 	sessionTypeSelection: SessionTypeSelectionState | null;
 	tapOutActionSelection: TapOutActionSelectionState | null;
 	earlyLeaveConfirmation: EarlyLeaveConfirmationState | null;
+	shiftEarlyLeaveConfirmation: ShiftEarlyLeaveConfirmationState | null;
 	pendingAgreement: PendingAgreementState | null;
 	tapNotification: TapNotificationState;
 	suspension: SuspensionState | null;
@@ -34,6 +37,8 @@ interface FlowOverlaysProps {
 	onTapOutActionCancel: () => void;
 	onEarlyLeaveConfirm: () => void;
 	onEarlyLeaveCancel: () => void;
+	onShiftEarlyLeaveConfirm: () => void;
+	onShiftEarlyLeaveCancel: () => void;
 	onAgreementComplete: () => void;
 	onAgreementCancel: () => void;
 	onAgreementError: (message: string) => void;
@@ -45,6 +50,7 @@ export function FlowOverlays({
 	sessionTypeSelection,
 	tapOutActionSelection,
 	earlyLeaveConfirmation,
+	shiftEarlyLeaveConfirmation,
 	pendingAgreement,
 	tapNotification,
 	suspension,
@@ -54,6 +60,8 @@ export function FlowOverlays({
 	onTapOutActionCancel,
 	onEarlyLeaveConfirm,
 	onEarlyLeaveCancel,
+	onShiftEarlyLeaveConfirm,
+	onShiftEarlyLeaveCancel,
 	onAgreementComplete,
 	onAgreementCancel,
 	onAgreementError,
@@ -65,6 +73,7 @@ export function FlowOverlays({
 		!!sessionTypeSelection ||
 		!!tapOutActionSelection ||
 		!!earlyLeaveConfirmation ||
+		!!shiftEarlyLeaveConfirmation ||
 		!!suspension;
 
 	type OverlayConfig = {
@@ -205,6 +214,15 @@ export function FlowOverlays({
 					userName={earlyLeaveConfirmation.userName}
 					onConfirm={onEarlyLeaveConfirm}
 					onCancel={onEarlyLeaveCancel}
+				/>
+			)}
+
+			{shiftEarlyLeaveConfirmation && (
+				<ShiftEarlyLeaveConfirmation
+					userName={shiftEarlyLeaveConfirmation.userName}
+					action={shiftEarlyLeaveConfirmation.action}
+					onConfirm={onShiftEarlyLeaveConfirm}
+					onCancel={onShiftEarlyLeaveCancel}
 				/>
 			)}
 

--- a/apps/kiosk/src/components/shift-early-leave-confirmation.tsx
+++ b/apps/kiosk/src/components/shift-early-leave-confirmation.tsx
@@ -1,0 +1,88 @@
+import { AlertTriangle } from "lucide-react";
+import { motion } from "motion/react";
+import { Button } from "./ui/button";
+
+interface ShiftEarlyLeaveConfirmationProps {
+	userName: string;
+	action: "end_session" | "switch_to_regular";
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export function ShiftEarlyLeaveConfirmation({
+	userName,
+	action,
+	onConfirm,
+	onCancel,
+}: ShiftEarlyLeaveConfirmationProps) {
+	const actionText = action === "end_session" ? "leave" : "switch to regular";
+	const buttonText = action === "end_session" ? "Yes, Leave" : "Yes, Switch";
+
+	return (
+		<motion.div
+			className="absolute inset-0 z-50 flex items-center justify-center bg-black/95 backdrop-blur-md"
+			initial={{ opacity: 0 }}
+			animate={{ opacity: 1 }}
+			exit={{ opacity: 0 }}
+			transition={{ duration: 0.3 }}
+		>
+			<motion.div
+				className="max-w-3xl mx-auto gap-8 flex flex-col"
+				initial={{ opacity: 0, scale: 0.95, y: 16 }}
+				animate={{ opacity: 1, scale: 1, y: 0 }}
+				exit={{ opacity: 0, scale: 0.95, y: 16 }}
+				transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+			>
+				<motion.div
+					className="flex flex-col items-center gap-6"
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ delay: 0.1, duration: 0.35 }}
+				>
+					<motion.div
+						className="relative flex items-center justify-center"
+						initial={{ scale: 0.85, opacity: 0 }}
+						animate={{ scale: 1, opacity: 1 }}
+						transition={{ duration: 0.6, ease: "easeOut" }}
+					>
+						<AlertTriangle className="w-24 h-24 text-yellow-500" />
+					</motion.div>
+
+					<div className="text-center gap-4 flex flex-col">
+						<h2 className="text-5xl font-bold">{userName}</h2>
+						<p className="text-2xl text-muted-foreground max-w-xl">
+							You are currently on a shift. If you {actionText} now, you will
+							leave your shift early and not receive full credit for your
+							attendance.
+						</p>
+						<p className="text-xl text-muted-foreground">
+							Are you sure you want to continue?
+						</p>
+					</div>
+				</motion.div>
+
+				<motion.div
+					className="flex justify-center gap-6"
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ delay: 0.2, duration: 0.35 }}
+				>
+					<Button
+						variant="outline"
+						className="text-xl px-8 py-6 h-auto"
+						onClick={onCancel}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						className="text-xl px-8 py-6 h-auto"
+						onClick={onConfirm}
+					>
+						{buttonText}
+					</Button>
+				</motion.div>
+			</motion.div>
+		</motion.div>
+	);
+}

--- a/apps/kiosk/src/types/index.ts
+++ b/apps/kiosk/src/types/index.ts
@@ -86,6 +86,23 @@ export type TapResponse =
 			};
 	  }
 	| {
+			status: "confirm_shift_early_leave";
+			user: {
+				id: number;
+				name: string;
+				email: string;
+				username: string;
+			};
+			currentSession: {
+				id: number;
+				userId: number;
+				sessionType: "regular" | "staffing";
+				startedAt: Date;
+				endedAt: Date | null;
+			};
+			action: "end_session" | "switch_to_regular";
+	  }
+	| {
 			status: "agreements_required";
 			user: {
 				id: number;


### PR DESCRIPTION
This pull request adds a warning message to kiosks when a user attempts to tap out but they currently have an active shift.

<img width="720" height="436" alt="image" src="https://github.com/user-attachments/assets/e8cbbd88-f66e-4f80-9c4f-28f2a0c428cc" />
