### PR TITLE
Add attendance issue pending review state

### DIFF
--- a/apps/client/src/components/attendance/columns.tsx
+++ b/apps/client/src/components/attendance/columns.tsx
@@ -13,8 +13,8 @@ type AttendanceRecord = {
 	isMakeup: boolean | null;
 	isExcused: boolean;
 	excuseNotes: string | null;
-	excusedBy: { id: number; name: string } | null;
-	excusedAt: Date | null;
+	reviewedBy: { id: number; name: string } | null;
+	reviewedAt: Date | null;
 	droppedNotes: string | null;
 	shiftOccurrence: {
 		timestamp: Date;

--- a/apps/client/src/components/shared/index.tsx
+++ b/apps/client/src/components/shared/index.tsx
@@ -1,4 +1,5 @@
 export { DataTable } from "./data-table";
+export { default as DateRangeSelector } from "./date-range-selector";
 export { PageSizeSelect } from "./page-size-select";
 export { SearchInput } from "./search-input";
 export { FilterBadge, FilterField, TableFilters } from "./table-filters";

--- a/packages/prisma/migrations/20260129030933_consolidate_review_fields/migration.sql
+++ b/packages/prisma/migrations/20260129030933_consolidate_review_fields/migration.sql
@@ -11,9 +11,10 @@ ALTER TABLE "ShiftAttendance" ADD COLUMN "reviewedById" INTEGER;
 
 -- Copy existing data from excusedBy/excusedAt to reviewedBy/reviewedAt
 -- This preserves the history of who excused records
+-- Handle edge cases where excusedAt might be set without excusedById
 UPDATE "ShiftAttendance" 
 SET "reviewedAt" = "excusedAt", "reviewedById" = "excusedById" 
-WHERE "excusedById" IS NOT NULL;
+WHERE "excusedById" IS NOT NULL OR "excusedAt" IS NOT NULL;
 
 -- DropForeignKey
 ALTER TABLE "ShiftAttendance" DROP CONSTRAINT "ShiftAttendance_excusedById_fkey";

--- a/packages/prisma/migrations/20260129030933_consolidate_review_fields/migration.sql
+++ b/packages/prisma/migrations/20260129030933_consolidate_review_fields/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `excusedAt` on the `ShiftAttendance` table. All the data in the column will be lost.
+  - You are about to drop the column `excusedById` on the `ShiftAttendance` table. All the data in the column will be lost.
+
+*/
+-- First add the new columns
+ALTER TABLE "ShiftAttendance" ADD COLUMN "reviewedAt" TIMESTAMP(3);
+ALTER TABLE "ShiftAttendance" ADD COLUMN "reviewedById" INTEGER;
+
+-- Copy existing data from excusedBy/excusedAt to reviewedBy/reviewedAt
+-- This preserves the history of who excused records
+UPDATE "ShiftAttendance" 
+SET "reviewedAt" = "excusedAt", "reviewedById" = "excusedById" 
+WHERE "excusedById" IS NOT NULL;
+
+-- DropForeignKey
+ALTER TABLE "ShiftAttendance" DROP CONSTRAINT "ShiftAttendance_excusedById_fkey";
+
+-- Now drop the old columns
+ALTER TABLE "ShiftAttendance" DROP COLUMN "excusedAt";
+ALTER TABLE "ShiftAttendance" DROP COLUMN "excusedById";
+
+-- AddForeignKey
+ALTER TABLE "ShiftAttendance" ADD CONSTRAINT "ShiftAttendance_reviewedById_fkey" FOREIGN KEY ("reviewedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -74,7 +74,7 @@ model User {
   // One-to-many
   sessions    Session[]
   attendances ShiftAttendance[]
-  excusedAttendances ShiftAttendance[] @relation("ShiftAttendanceExcusedBy")
+  reviewedAttendances ShiftAttendance[] @relation("ShiftAttendanceReviewedBy")
   suspensions Suspension[]
   createdSuspensions Suspension[] @relation("SuspensionCreatedBy")
   
@@ -248,11 +248,15 @@ model ShiftAttendance {
   didLeaveEarly     Boolean             @default(false)
   isExcused         Boolean             @default(false)
   droppedNotes      String?
-  excuseNotes       String?
-  excusedById       Int?
-  excusedAt         DateTime?
+  excuseNotes       String?             // Notes provided when excusing (only relevant when isExcused=true)
   timeIn            DateTime?
   timeOut           DateTime?
+  // Review tracking:
+  // - When null: issue is "pending review" (not yet reviewed by staff)
+  // - When set with isExcused=true: issue was reviewed and excused
+  // - When set with isExcused=false: issue was reviewed and marked as unexcused
+  reviewedAt        DateTime?
+  reviewedById      Int?
 
   // timestamps
   createdAt DateTime @default(now())
@@ -261,7 +265,7 @@ model ShiftAttendance {
   // relations
   shiftOccurrence ShiftOccurrence @relation(fields: [shiftOccurrenceId], references: [id], onDelete: Cascade)
   user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
-  excusedBy       User?           @relation("ShiftAttendanceExcusedBy", fields: [excusedById], references: [id], onDelete: SetNull)
+  reviewedBy      User?           @relation("ShiftAttendanceReviewedBy", fields: [reviewedById], references: [id], onDelete: SetNull)
 
   // constraints
   @@unique([shiftOccurrenceId, userId])

--- a/packages/trpc/server/routers/shiftAttendances/_route.ts
+++ b/packages/trpc/server/routers/shiftAttendances/_route.ts
@@ -7,6 +7,7 @@ import { grantExcuseHandler, ZGrantExcuseSchema } from "./grantExcuse.route";
 import { listForUserHandler, ZListForUserSchema } from "./listForUser.route";
 import { listIssuesHandler, ZListIssuesSchema } from "./listIssues.route";
 import { listMyHandler, ZListMySchema } from "./listMy.route";
+import { markReviewedHandler, ZMarkReviewedSchema } from "./markReviewed.route";
 import { myStatsHandler, ZMyStatsSchema } from "./myStats.route";
 import { revokeExcuseHandler, ZRevokeExcuseSchema } from "./revokeExcuse.route";
 
@@ -26,4 +27,7 @@ export const shiftAttendancesRouter = router({
 	revokeExcuse: permissionProtectedProcedure("shift_attendances.excuse")
 		.input(ZRevokeExcuseSchema)
 		.mutation(revokeExcuseHandler),
+	markReviewed: permissionProtectedProcedure("shift_attendances.excuse")
+		.input(ZMarkReviewedSchema)
+		.mutation(markReviewedHandler),
 });

--- a/packages/trpc/server/routers/shiftAttendances/listMy.route.ts
+++ b/packages/trpc/server/routers/shiftAttendances/listMy.route.ts
@@ -62,8 +62,8 @@ export async function listMyHandler(options: TListMyOptions) {
 				isMakeup: true,
 				isExcused: true,
 				excuseNotes: true,
-				excusedAt: true,
-				excusedBy: {
+				reviewedAt: true,
+				reviewedBy: {
 					select: {
 						id: true,
 						name: true,

--- a/packages/trpc/server/routers/shiftAttendances/revokeExcuse.route.ts
+++ b/packages/trpc/server/routers/shiftAttendances/revokeExcuse.route.ts
@@ -87,13 +87,14 @@ export async function revokeExcuseHandler(options: TRevokeExcuseOptions) {
 	}
 
 	// Update the attendance record
+	// Clear excuse info and review info so it goes back to pending
 	const updatedAttendance = await prisma.shiftAttendance.update({
 		where: { id: attendanceId },
 		data: {
 			isExcused: false,
 			excuseNotes: null,
-			excusedById: null,
-			excusedAt: null,
+			reviewedAt: null,
+			reviewedById: null,
 		},
 		include: {
 			user: {


### PR DESCRIPTION
This pull request adds a third "state" to attendance issues - pending review. So, instead of all issues being unexcused by default, issues now start as pending. A staff member can then excuse, or unexcuse, the issue. Until an action has been taken, pending issues count as unexcused.

The filters on the attendance issues page have also been updated to give a little bit more granularity.