### PR TITLE
Add inventory app to nginx proxy config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -117,6 +117,20 @@ http {
             try_files $uri $uri/ /kiosk/index.html;
         }
 
+        # Inventory assets
+        location /inventory/assets/ {
+            alias /usr/share/nginx/html/inventory/assets/;
+            expires 1y;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+            try_files $uri =404;
+        }
+
+        # Inventory app 
+        location /inventory {
+            alias /usr/share/nginx/html/inventory;
+            try_files $uri $uri/ /inventory/index.html;
+        }
+
         # Overview assets
         location /overview/assets/ {
             alias /usr/share/nginx/html/overview/assets/;


### PR DESCRIPTION
Fix issue where the inventory app is not proxied by NGINX in prod.