### PR TITLE
Switch branding to use new name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to HUMS
 
-Thanks for your interest in contributing to **The Hive User Management System**.
+Thanks for your interest in contributing to **The Hive Unified Management System**.
 We’re excited to have you help improve the project - whether you’re fixing bugs, improving documentation, or adding new features.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <h1 align="center">HUMS</h1>
-  <h3 align="center">Hive User Management System</h3>
+  <h3 align="center">Hive Unified Management System</h3>
 
   <p align="center">
-    User management system for The Hive Makerspace at Georgia Tech.
+    Management system for The Hive Makerspace at Georgia Tech.
   </p>
 </p>
 

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>HUMS - Hive User Management System</title>
-        <meta name="description" content="HUMS - Hive User Management System" />
+        <title>HUMS - Hive Unified Management System</title>
+        <meta name="description" content="HUMS - Hive Unified Management System" />
     </head>
     <body>
         <div id="root"></div>


### PR DESCRIPTION
This pull request switches documentation to use the new project name.