### PR TITLE
Add support for manually creating past sessions

### DIFF
--- a/apps/client/src/components/sessions/admin-session-management-dialog.tsx
+++ b/apps/client/src/components/sessions/admin-session-management-dialog.tsx
@@ -284,7 +284,7 @@ export function AdminSessionManagementDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent className="sm:max-w-[500px]">
+			<DialogContent className="sm:max-w-[500px] max-h-[90vh] flex flex-col">
 				<DialogHeader>
 					<DialogTitle>Manage User Session</DialogTitle>
 					<DialogDescription>
@@ -292,7 +292,7 @@ export function AdminSessionManagementDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-6 py-4">
+				<div className="space-y-6 py-4 overflow-y-auto flex-1">
 					{/* User Selection */}
 					<div className="space-y-2">
 						<div className="text-sm font-medium">Select User</div>
@@ -530,6 +530,16 @@ export function AdminSessionManagementDialog({
 															<SelectItem value="staffing">Staffing</SelectItem>
 														</SelectContent>
 													</Select>
+													{pastSessionType === "staffing" && (
+														<Alert variant="destructive">
+															<AlertCircle className="h-4 w-4" />
+															<AlertDescription>
+																Past staffing sessions will not automatically
+																track shift attendance. Attendance must be
+																managed separately.
+															</AlertDescription>
+														</Alert>
+													)}
 												</div>
 
 												{/* Start Date/Time */}

--- a/packages/prisma/migrations/20260130221657_add_session_is_manually_created_flag/migration.sql
+++ b/packages/prisma/migrations/20260130221657_add_session_is_manually_created_flag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "isManuallyCreated" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -290,10 +290,11 @@ model Session {
   id Int @id @default(autoincrement())
 
   // fields
-  userId      Int
-  sessionType SessionType @default(regular)
-  startedAt   DateTime    @default(now())
-  endedAt     DateTime?
+  userId             Int
+  sessionType        SessionType @default(regular)
+  startedAt          DateTime    @default(now())
+  endedAt            DateTime?
+  isManuallyCreated  Boolean     @default(false)
 
   // relations
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/packages/trpc/server/routers/sessions/_route.ts
+++ b/packages/trpc/server/routers/sessions/_route.ts
@@ -5,6 +5,10 @@ import {
 	router,
 } from "../../trpc";
 import {
+	adminCreatePastSessionHandler,
+	ZAdminCreatePastSessionSchema,
+} from "./adminCreatePastSession.route";
+import {
 	adminEndSessionHandler,
 	ZAdminEndSessionSchema,
 } from "./adminEndSession.route";
@@ -47,4 +51,7 @@ export const sessionsRouter = router({
 	adminEndSession: permissionProtectedProcedure("sessions.manage")
 		.input(ZAdminEndSessionSchema)
 		.mutation(adminEndSessionHandler),
+	adminCreatePastSession: permissionProtectedProcedure("sessions.manage")
+		.input(ZAdminCreatePastSessionSchema)
+		.mutation(adminCreatePastSessionHandler),
 });

--- a/packages/trpc/server/routers/sessions/adminCreatePastSession.route.ts
+++ b/packages/trpc/server/routers/sessions/adminCreatePastSession.route.ts
@@ -1,0 +1,143 @@
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TPermissionProtectedProcedureContext } from "../../trpc";
+
+export const ZAdminCreatePastSessionSchema = z
+	.object({
+		userId: z.number().min(1),
+		sessionType: z.enum(["regular", "staffing"]),
+		startedAt: z.coerce.date(),
+		endedAt: z.coerce.date(),
+	})
+	.refine(
+		(data) => {
+			const now = new Date();
+			return data.startedAt < now && data.endedAt < now;
+		},
+		{
+			message: "Both start and end dates must be in the past",
+			path: ["startedAt"],
+		},
+	)
+	.refine(
+		(data) => {
+			return data.startedAt < data.endedAt;
+		},
+		{
+			message: "Start date must be before end date",
+			path: ["startedAt"],
+		},
+	);
+
+export type TAdminCreatePastSessionSchema = z.infer<
+	typeof ZAdminCreatePastSessionSchema
+>;
+
+export type TAdminCreatePastSessionOptions = {
+	ctx: TPermissionProtectedProcedureContext;
+	input: TAdminCreatePastSessionSchema;
+};
+
+/**
+ * Admin route to manually create a past session for a user
+ * Requires sessions.manage permission
+ * The session is marked as manually created
+ */
+export async function adminCreatePastSessionHandler(
+	options: TAdminCreatePastSessionOptions,
+) {
+	const { userId, sessionType, startedAt, endedAt } = options.input;
+
+	return await prisma.$transaction(
+		async (tx) => {
+			// Verify the user exists
+			const user = await tx.user.findUnique({
+				where: { id: userId },
+				select: {
+					id: true,
+					name: true,
+					username: true,
+					email: true,
+				},
+			});
+
+			if (!user) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "User not found",
+				});
+			}
+
+			// Check for overlapping sessions
+			const overlappingSessions = await tx.session.findMany({
+				where: {
+					userId,
+					OR: [
+						{
+							// Session starts during our new session
+							startedAt: {
+								gte: startedAt,
+								lt: endedAt,
+							},
+						},
+						{
+							// Session ends during our new session (for completed sessions)
+							endedAt: {
+								gt: startedAt,
+								lte: endedAt,
+							},
+						},
+						{
+							// Session spans our entire new session
+							AND: [
+								{ startedAt: { lte: startedAt } },
+								{
+									OR: [{ endedAt: { gte: endedAt } }, { endedAt: null }],
+								},
+							],
+						},
+					],
+				},
+			});
+
+			if (overlappingSessions.length > 0) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message:
+						"This session would overlap with an existing session for this user",
+				});
+			}
+
+			// Create the session with the manual flag
+			const session = await tx.session.create({
+				data: {
+					userId,
+					sessionType,
+					startedAt,
+					endedAt,
+					isManuallyCreated: true,
+				},
+			});
+
+			// Calculate duration for the response
+			const durationMs = endedAt.getTime() - startedAt.getTime();
+			const durationMinutes = Math.round(durationMs / (1000 * 60));
+			const hours = Math.floor(durationMinutes / 60);
+			const minutes = durationMinutes % 60;
+			const durationFormatted =
+				hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+
+			return {
+				session,
+				user,
+				durationMinutes,
+				durationFormatted,
+			};
+		},
+		{
+			maxWait: 5000,
+			timeout: 10000,
+		},
+	);
+}


### PR DESCRIPTION
This pull request adds support for allowing admins to create past sessions for users.

Creating past staffing sessions will not handle any type of attendance tracking, but can be used for general tracking reasons.