### PR TITLE
Remove minimum secrets length

### DIFF
--- a/packages/env/src/schema.ts
+++ b/packages/env/src/schema.ts
@@ -1,11 +1,5 @@
 import z from "zod";
 
-/**
- * Minimum length for cryptographic secrets.
- * 32 characters provides at least 256 bits of entropy when using base64.
- */
-const MIN_SECRET_LENGTH = 32;
-
 const BaseEnvSchema = z.object({
 	NODE_ENV: z
 		.enum(["development", "production", "test"])
@@ -14,20 +8,12 @@ const BaseEnvSchema = z.object({
 	DATABASE_URL: z.url(),
 	AUTH_SECRET: z
 		.string()
-		.min(
-			MIN_SECRET_LENGTH,
-			`AUTH_SECRET must be at least ${MIN_SECRET_LENGTH} characters. Generate with: openssl rand -base64 32`,
-		)
 		.transform((val) => {
 			const buffer = Buffer.from(val);
 			return new Uint8Array(buffer);
 		}),
 	ICAL_SECRET: z
 		.string()
-		.min(
-			MIN_SECRET_LENGTH,
-			`ICAL_SECRET must be at least ${MIN_SECRET_LENGTH} characters. Generate with: openssl rand -base64 32`,
-		)
 		.transform((val) => {
 			const buffer = Buffer.from(val);
 			return new Uint8Array(buffer);


### PR DESCRIPTION
This pull request removes the minimum secret length check to prevent issues with existing deployments. It is still a really good idea to follow this rule though, we just won't enforce it.