### PR TITLE
Add control gateways

### DIFF
--- a/apps/client/src/components/control/create-gateway-dialog.tsx
+++ b/apps/client/src/components/control/create-gateway-dialog.tsx
@@ -1,0 +1,371 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useForm, useStore } from "@tanstack/react-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+import { useCallback, useId, useState } from "react";
+import type { JSX } from "react/jsx-runtime";
+import { z } from "zod";
+import { useAuth } from "@/auth/AuthProvider";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Sheet,
+	SheetClose,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { checkPermissions } from "@/lib/permissions";
+
+const formSchema = z.object({
+	name: z.string().min(1, "Name is required").max(255),
+	description: z.string().max(1000).optional(),
+	isActive: z.boolean(),
+	actions: z.array(
+		z.object({
+			controlPointId: z.string().uuid(),
+			action: z.enum(["TURN_ON", "TURN_OFF", "UNLOCK"]),
+		}),
+	),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type CreateGatewayDialogProps = {
+	onUpdate?: () => void;
+	onTokenCreated?: (token: { name: string; value: string }) => void;
+};
+
+const ACTION_LABELS: Record<string, string> = {
+	TURN_ON: "Turn On",
+	TURN_OFF: "Turn Off",
+	UNLOCK: "Unlock",
+};
+
+export function CreateGatewayDialog({
+	onUpdate,
+	onTokenCreated,
+}: CreateGatewayDialogProps): JSX.Element {
+	const [open, setOpen] = useState(false);
+	const [serverError, setServerError] = useState<string | null>(null);
+	const queryClient = useQueryClient();
+	const formId = useId();
+
+	const { data: pointsData } = useQuery({
+		queryKey: ["control", "points", "all"],
+		queryFn: async () => await trpc.control.points.list.query({ limit: 100 }),
+		enabled: open,
+	});
+
+	const controlPoints = pointsData?.points ?? [];
+
+	const createMutation = useMutation({
+		mutationFn: (input: {
+			name: string;
+			description?: string;
+			isActive?: boolean;
+			actions: Array<{
+				controlPointId: string;
+				action: "TURN_ON" | "TURN_OFF" | "UNLOCK";
+			}>;
+		}) => trpc.control.gateways.create.mutate(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["control", "gateways"] });
+		},
+	});
+
+	const form = useForm<FormValues>({
+		defaultValues: {
+			name: "",
+			description: "",
+			isActive: true,
+			actions: [],
+		},
+		validators: { onSubmit: formSchema },
+		onSubmit: async ({ value }) => {
+			try {
+				const result = await createMutation.mutateAsync({
+					name: value.name,
+					description: value.description || undefined,
+					isActive: value.isActive,
+					actions: value.actions,
+				});
+				setOpen(false);
+				onUpdate?.();
+				onTokenCreated?.({
+					name: value.name,
+					value: result.accessToken,
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				setServerError(message);
+			}
+		},
+	});
+
+	const isSubmitting = useStore(form.store, (state) => state.isSubmitting);
+	const canSubmit = useStore(form.store, (state) => state.canSubmit);
+
+	const handleDialogChange = useCallback(
+		(nextOpen: boolean) => {
+			setOpen(nextOpen);
+			if (nextOpen) {
+				form.reset();
+				setServerError(null);
+			}
+		},
+		[form],
+	);
+
+	const user = useAuth().user;
+	const canCreate = user && checkPermissions(user, ["control.gateways.create"]);
+
+	return (
+		<Sheet open={open} onOpenChange={handleDialogChange}>
+			<SheetTrigger asChild>
+				<Button hidden={!canCreate}>
+					<PlusIcon className="h-4 w-4 mr-2" />
+					New Gateway
+				</Button>
+			</SheetTrigger>
+			<SheetContent
+				side="right"
+				className="w-full sm:max-w-[600px] overflow-y-auto max-h-full"
+			>
+				<SheetHeader>
+					<SheetTitle>Create Control Gateway</SheetTitle>
+					<SheetDescription>
+						Add a new control gateway for external system integration. An access
+						token will be generated automatically.
+					</SheetDescription>
+				</SheetHeader>
+				<form
+					id={formId}
+					className="space-y-4 px-4 sm:px-6 mt-4"
+					onSubmit={(e) => {
+						e.preventDefault();
+						form.handleSubmit();
+					}}
+				>
+					<form.Field name="name">
+						{(field) => (
+							<Field>
+								<FieldLabel htmlFor={field.name}>Name</FieldLabel>
+								<Input
+									id={field.name}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="e.g., Front Door Gateway"
+								/>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+							</Field>
+						)}
+					</form.Field>
+
+					<form.Field name="description">
+						{(field) => (
+							<Field>
+								<FieldLabel htmlFor={field.name}>Description</FieldLabel>
+								<Textarea
+									id={field.name}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="Optional description..."
+									rows={2}
+								/>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+							</Field>
+						)}
+					</form.Field>
+
+					<div className="border rounded-lg p-4 space-y-4">
+						<div className="flex items-center justify-between">
+							<h4 className="font-medium text-sm">Gateway Actions</h4>
+							<form.Field name="actions">
+								{(field) => (
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={() =>
+											field.handleChange([
+												...field.state.value,
+												{
+													controlPointId: "",
+													action: "TURN_ON" as const,
+												},
+											])
+										}
+									>
+										<PlusIcon className="h-3 w-3 mr-1" />
+										Add Action
+									</Button>
+								)}
+							</form.Field>
+						</div>
+
+						<form.Field name="actions">
+							{(field) => (
+								<div className="space-y-2">
+									{field.state.value.length === 0 && (
+										<p className="text-sm text-muted-foreground text-center py-2">
+											No actions configured. Add actions to define what this
+											gateway will do.
+										</p>
+									)}
+									{field.state.value.map((action, index) => (
+										<div
+											key={index}
+											className="flex items-center gap-2 border rounded-md p-2"
+										>
+											<Select
+												value={action.controlPointId}
+												onValueChange={(value) => {
+													const updated = [...field.state.value];
+													updated[index] = {
+														...updated[index],
+														controlPointId: value,
+													};
+													// Auto-set action based on control class
+													const point = controlPoints.find(
+														(p) => p.id === value,
+													);
+													if (point) {
+														if (point.controlClass === "DOOR") {
+															updated[index].action = "UNLOCK";
+														} else if (updated[index].action === "UNLOCK") {
+															updated[index].action = "TURN_ON";
+														}
+													}
+													field.handleChange(updated);
+												}}
+											>
+												<SelectTrigger className="flex-1">
+													<SelectValue placeholder="Select control point" />
+												</SelectTrigger>
+												<SelectContent>
+													{controlPoints.map((point) => (
+														<SelectItem key={point.id} value={point.id}>
+															{point.name}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+
+											<Select
+												value={action.action}
+												onValueChange={(value) => {
+													const updated = [...field.state.value];
+													updated[index] = {
+														...updated[index],
+														action: value as "TURN_ON" | "TURN_OFF" | "UNLOCK",
+													};
+													field.handleChange(updated);
+												}}
+											>
+												<SelectTrigger className="w-[130px]">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{(() => {
+														const point = controlPoints.find(
+															(p) => p.id === action.controlPointId,
+														);
+														if (point?.controlClass === "DOOR") {
+															return (
+																<SelectItem value="UNLOCK">
+																	{ACTION_LABELS.UNLOCK}
+																</SelectItem>
+															);
+														}
+														return (
+															<>
+																<SelectItem value="TURN_ON">
+																	{ACTION_LABELS.TURN_ON}
+																</SelectItem>
+																<SelectItem value="TURN_OFF">
+																	{ACTION_LABELS.TURN_OFF}
+																</SelectItem>
+															</>
+														);
+													})()}
+												</SelectContent>
+											</Select>
+
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												onClick={() => {
+													const updated = field.state.value.filter(
+														(_, i) => i !== index,
+													);
+													field.handleChange(updated);
+												}}
+											>
+												<Trash2Icon className="h-4 w-4 text-destructive" />
+											</Button>
+										</div>
+									))}
+								</div>
+							)}
+						</form.Field>
+					</div>
+
+					<form.Field name="isActive">
+						{(field) => (
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									id={field.name}
+									checked={field.state.value}
+									onCheckedChange={(checked) =>
+										field.handleChange(checked === true)
+									}
+								/>
+								<label
+									htmlFor={field.name}
+									className="text-sm font-medium leading-none"
+								>
+									Active
+								</label>
+							</div>
+						)}
+					</form.Field>
+
+					{serverError && (
+						<p className="text-destructive text-sm">{serverError}</p>
+					)}
+				</form>
+				<SheetFooter className="mt-4 px-4 sm:px-6">
+					<SheetClose asChild>
+						<Button variant="outline">Cancel</Button>
+					</SheetClose>
+					<Button
+						form={formId}
+						type="submit"
+						disabled={isSubmitting || !canSubmit}
+					>
+						{isSubmitting ? <Spinner className="mr-2" /> : null}
+						Create
+					</Button>
+				</SheetFooter>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/apps/client/src/components/control/delete-gateway-dialog.tsx
+++ b/apps/client/src/components/control/delete-gateway-dialog.tsx
@@ -1,0 +1,92 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+import type { JSX } from "react/jsx-runtime";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+type ControlGateway = {
+	id: number;
+	name: string;
+};
+
+type DeleteGatewayDialogProps = {
+	gateway: ControlGateway;
+	onDelete?: () => void;
+};
+
+export function DeleteGatewayDialog({
+	gateway,
+	onDelete,
+}: DeleteGatewayDialogProps): JSX.Element {
+	const queryClient = useQueryClient();
+	const [open, setOpen] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const mutation = useMutation({
+		mutationFn: async () =>
+			trpc.control.gateways.delete.mutate({ id: gateway.id }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["control", "gateways"],
+			});
+			setOpen(false);
+			setError(null);
+			onDelete?.();
+		},
+		onError: (err) => {
+			const message = err instanceof Error ? err.message : String(err);
+			setError(message);
+		},
+	});
+
+	return (
+		<AlertDialog open={open} onOpenChange={setOpen}>
+			<AlertDialogTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					aria-label={`Delete gateway ${gateway.name}`}
+				>
+					<Trash2 className="h-4 w-4 text-destructive" />
+				</Button>
+			</AlertDialogTrigger>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>
+						Delete &ldquo;{gateway.name}&rdquo;?
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						This will permanently delete this gateway and all its configured
+						actions. External systems using this gateway&apos;s access token
+						will no longer be able to control equipment.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				{error && <p className="text-sm text-destructive px-6">{error}</p>}
+				<AlertDialogFooter>
+					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={(e) => {
+							e.preventDefault();
+							mutation.mutate();
+						}}
+						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+					>
+						{mutation.isPending ? "Deleting..." : "Delete"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/client/src/components/control/edit-gateway-dialog.tsx
+++ b/apps/client/src/components/control/edit-gateway-dialog.tsx
@@ -1,0 +1,384 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useForm, useStore } from "@tanstack/react-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { useCallback, useId, useState } from "react";
+import type { JSX } from "react/jsx-runtime";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Sheet,
+	SheetClose,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+
+const formSchema = z.object({
+	name: z.string().min(1, "Name is required").max(255),
+	description: z.string().max(1000).optional(),
+	isActive: z.boolean(),
+	actions: z.array(
+		z.object({
+			controlPointId: z.string().uuid(),
+			action: z.enum(["TURN_ON", "TURN_OFF", "UNLOCK"]),
+		}),
+	),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type ControlGateway = {
+	id: number;
+	name: string;
+	description: string | null;
+	isActive: boolean;
+};
+
+type EditGatewayDialogProps = {
+	gateway: ControlGateway;
+	onUpdate?: () => void;
+};
+
+const ACTION_LABELS: Record<string, string> = {
+	TURN_ON: "Turn On",
+	TURN_OFF: "Turn Off",
+	UNLOCK: "Unlock",
+};
+
+export function EditGatewayDialog({
+	gateway,
+	onUpdate,
+}: EditGatewayDialogProps): JSX.Element {
+	const [open, setOpen] = useState(false);
+	const [serverError, setServerError] = useState<string | null>(null);
+	const queryClient = useQueryClient();
+	const formId = useId();
+
+	const { data: gatewayDetails } = useQuery({
+		queryKey: ["control", "gateways", gateway.id],
+		queryFn: async () =>
+			await trpc.control.gateways.get.query({ id: gateway.id }),
+		enabled: open,
+	});
+
+	const { data: pointsData } = useQuery({
+		queryKey: ["control", "points", "all"],
+		queryFn: async () => await trpc.control.points.list.query({ limit: 100 }),
+		enabled: open,
+	});
+
+	const controlPoints = pointsData?.points ?? [];
+
+	const updateMutation = useMutation({
+		mutationFn: (input: {
+			id: number;
+			name?: string;
+			description?: string | null;
+			isActive?: boolean;
+			actions?: Array<{
+				controlPointId: string;
+				action: "TURN_ON" | "TURN_OFF" | "UNLOCK";
+			}>;
+		}) => trpc.control.gateways.update.mutate(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["control", "gateways"],
+			});
+		},
+	});
+
+	const form = useForm<FormValues>({
+		defaultValues: {
+			name: gateway.name,
+			description: gateway.description ?? "",
+			isActive: gateway.isActive,
+			actions: [],
+		},
+		validators: { onSubmit: formSchema },
+		onSubmit: async ({ value }) => {
+			try {
+				await updateMutation.mutateAsync({
+					id: gateway.id,
+					name: value.name,
+					description: value.description || null,
+					isActive: value.isActive,
+					actions: value.actions,
+				});
+				setOpen(false);
+				onUpdate?.();
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				setServerError(message);
+			}
+		},
+	});
+
+	const isSubmitting = useStore(form.store, (state) => state.isSubmitting);
+	const canSubmit = useStore(form.store, (state) => state.canSubmit);
+
+	const handleDialogChange = useCallback(
+		(nextOpen: boolean) => {
+			setOpen(nextOpen);
+			if (nextOpen) {
+				const details = gatewayDetails;
+				form.reset({
+					name: details?.name ?? gateway.name,
+					description: details?.description ?? gateway.description ?? "",
+					isActive: details?.isActive ?? gateway.isActive,
+					actions:
+						details?.actions?.map((a) => ({
+							controlPointId: a.controlPointId,
+							action: a.action as "TURN_ON" | "TURN_OFF" | "UNLOCK",
+						})) ?? [],
+				});
+				setServerError(null);
+			}
+		},
+		[form, gateway, gatewayDetails],
+	);
+
+	return (
+		<Sheet open={open} onOpenChange={handleDialogChange}>
+			<SheetTrigger asChild>
+				<Button variant="ghost" size="sm">
+					<PencilIcon className="h-4 w-4" />
+				</Button>
+			</SheetTrigger>
+			<SheetContent
+				side="right"
+				className="w-full sm:max-w-[600px] overflow-y-auto max-h-full"
+			>
+				<SheetHeader>
+					<SheetTitle>Edit Control Gateway</SheetTitle>
+					<SheetDescription>
+						Update gateway settings and actions.
+					</SheetDescription>
+				</SheetHeader>
+				<form
+					id={formId}
+					className="space-y-4 px-4 sm:px-6 mt-4"
+					onSubmit={(e) => {
+						e.preventDefault();
+						form.handleSubmit();
+					}}
+				>
+					<form.Field name="name">
+						{(field) => (
+							<Field>
+								<FieldLabel htmlFor={field.name}>Name</FieldLabel>
+								<Input
+									id={field.name}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+								/>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+							</Field>
+						)}
+					</form.Field>
+
+					<form.Field name="description">
+						{(field) => (
+							<Field>
+								<FieldLabel htmlFor={field.name}>Description</FieldLabel>
+								<Textarea
+									id={field.name}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									rows={2}
+								/>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+							</Field>
+						)}
+					</form.Field>
+
+					<div className="border rounded-lg p-4 space-y-4">
+						<div className="flex items-center justify-between">
+							<h4 className="font-medium text-sm">Gateway Actions</h4>
+							<form.Field name="actions">
+								{(field) => (
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={() =>
+											field.handleChange([
+												...field.state.value,
+												{
+													controlPointId: "",
+													action: "TURN_ON" as const,
+												},
+											])
+										}
+									>
+										<PlusIcon className="h-3 w-3 mr-1" />
+										Add Action
+									</Button>
+								)}
+							</form.Field>
+						</div>
+
+						<form.Field name="actions">
+							{(field) => (
+								<div className="space-y-2">
+									{field.state.value.length === 0 && (
+										<p className="text-sm text-muted-foreground text-center py-2">
+											No actions configured.
+										</p>
+									)}
+									{field.state.value.map((action, index) => (
+										<div
+											key={index}
+											className="flex items-center gap-2 border rounded-md p-2"
+										>
+											<Select
+												value={action.controlPointId}
+												onValueChange={(value) => {
+													const updated = [...field.state.value];
+													updated[index] = {
+														...updated[index],
+														controlPointId: value,
+													};
+													const point = controlPoints.find(
+														(p) => p.id === value,
+													);
+													if (point) {
+														if (point.controlClass === "DOOR") {
+															updated[index].action = "UNLOCK";
+														} else if (updated[index].action === "UNLOCK") {
+															updated[index].action = "TURN_ON";
+														}
+													}
+													field.handleChange(updated);
+												}}
+											>
+												<SelectTrigger className="flex-1">
+													<SelectValue placeholder="Select control point" />
+												</SelectTrigger>
+												<SelectContent>
+													{controlPoints.map((point) => (
+														<SelectItem key={point.id} value={point.id}>
+															{point.name}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+
+											<Select
+												value={action.action}
+												onValueChange={(value) => {
+													const updated = [...field.state.value];
+													updated[index] = {
+														...updated[index],
+														action: value as "TURN_ON" | "TURN_OFF" | "UNLOCK",
+													};
+													field.handleChange(updated);
+												}}
+											>
+												<SelectTrigger className="w-[130px]">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{(() => {
+														const point = controlPoints.find(
+															(p) => p.id === action.controlPointId,
+														);
+														if (point?.controlClass === "DOOR") {
+															return (
+																<SelectItem value="UNLOCK">
+																	{ACTION_LABELS.UNLOCK}
+																</SelectItem>
+															);
+														}
+														return (
+															<>
+																<SelectItem value="TURN_ON">
+																	{ACTION_LABELS.TURN_ON}
+																</SelectItem>
+																<SelectItem value="TURN_OFF">
+																	{ACTION_LABELS.TURN_OFF}
+																</SelectItem>
+															</>
+														);
+													})()}
+												</SelectContent>
+											</Select>
+
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												onClick={() => {
+													const updated = field.state.value.filter(
+														(_, i) => i !== index,
+													);
+													field.handleChange(updated);
+												}}
+											>
+												<Trash2Icon className="h-4 w-4 text-destructive" />
+											</Button>
+										</div>
+									))}
+								</div>
+							)}
+						</form.Field>
+					</div>
+
+					<form.Field name="isActive">
+						{(field) => (
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									id={field.name}
+									checked={field.state.value}
+									onCheckedChange={(checked) =>
+										field.handleChange(checked === true)
+									}
+								/>
+								<label
+									htmlFor={field.name}
+									className="text-sm font-medium leading-none"
+								>
+									Active
+								</label>
+							</div>
+						)}
+					</form.Field>
+
+					{serverError && (
+						<p className="text-destructive text-sm">{serverError}</p>
+					)}
+				</form>
+				<SheetFooter className="mt-4 px-4 sm:px-6">
+					<SheetClose asChild>
+						<Button variant="outline">Cancel</Button>
+					</SheetClose>
+					<Button
+						form={formId}
+						type="submit"
+						disabled={isSubmitting || !canSubmit}
+					>
+						{isSubmitting ? <Spinner className="mr-2" /> : null}
+						Save Changes
+					</Button>
+				</SheetFooter>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/apps/client/src/components/navigation/nav-config.ts
+++ b/apps/client/src/components/navigation/nav-config.ts
@@ -22,6 +22,7 @@ import {
 	LaptopMinimalCheckIcon,
 	LayoutDashboardIcon,
 	ListIcon,
+	NetworkIcon,
 	NotebookTextIcon,
 	PackageIcon,
 	PackageSearchIcon,
@@ -364,6 +365,13 @@ export const appModules: AppModule[] = [
 						icon: PlugZapIcon,
 						permissions: ["control.providers.list"],
 						description: "Manage control providers",
+					},
+					{
+						title: "Gateways",
+						url: "/app/control/gateways",
+						icon: NetworkIcon,
+						permissions: ["control.gateways.list"],
+						description: "Manage control gateways",
 					},
 					{
 						title: "Logs",

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as AppInventoryItemsRouteImport } from './routes/app/inventory/it
 import { Route as AppControlProvidersRouteImport } from './routes/app/control/providers'
 import { Route as AppControlPointsRouteImport } from './routes/app/control/points'
 import { Route as AppControlLogsRouteImport } from './routes/app/control/logs'
+import { Route as AppControlGatewaysRouteImport } from './routes/app/control/gateways'
 import { Route as AppAppUsersRouteImport } from './routes/app/_app/users'
 import { Route as AppAppSuspensionsRouteImport } from './routes/app/_app/suspensions'
 import { Route as AppAppSessionsRouteImport } from './routes/app/_app/sessions'
@@ -245,6 +246,11 @@ const AppControlLogsRoute = AppControlLogsRouteImport.update({
   path: '/logs',
   getParentRoute: () => AppControlRoute,
 } as any)
+const AppControlGatewaysRoute = AppControlGatewaysRouteImport.update({
+  id: '/gateways',
+  path: '/gateways',
+  getParentRoute: () => AppControlRoute,
+} as any)
 const AppAppUsersRoute = AppAppUsersRouteImport.update({
   id: '/users',
   path: '/users',
@@ -379,6 +385,7 @@ export interface FileRoutesByFullPath {
   '/app/sessions': typeof AppAppSessionsRoute
   '/app/suspensions': typeof AppAppSuspensionsRoute
   '/app/users': typeof AppAppUsersRoute
+  '/app/control/gateways': typeof AppControlGatewaysRoute
   '/app/control/logs': typeof AppControlLogsRoute
   '/app/control/points': typeof AppControlPointsRoute
   '/app/control/providers': typeof AppControlProvidersRoute
@@ -432,6 +439,7 @@ export interface FileRoutesByTo {
   '/app/sessions': typeof AppAppSessionsRoute
   '/app/suspensions': typeof AppAppSuspensionsRoute
   '/app/users': typeof AppAppUsersRoute
+  '/app/control/gateways': typeof AppControlGatewaysRoute
   '/app/control/logs': typeof AppControlLogsRoute
   '/app/control/points': typeof AppControlPointsRoute
   '/app/control/providers': typeof AppControlProvidersRoute
@@ -488,6 +496,7 @@ export interface FileRoutesById {
   '/app/_app/sessions': typeof AppAppSessionsRoute
   '/app/_app/suspensions': typeof AppAppSuspensionsRoute
   '/app/_app/users': typeof AppAppUsersRoute
+  '/app/control/gateways': typeof AppControlGatewaysRoute
   '/app/control/logs': typeof AppControlLogsRoute
   '/app/control/points': typeof AppControlPointsRoute
   '/app/control/providers': typeof AppControlProvidersRoute
@@ -547,6 +556,7 @@ export interface FileRouteTypes {
     | '/app/sessions'
     | '/app/suspensions'
     | '/app/users'
+    | '/app/control/gateways'
     | '/app/control/logs'
     | '/app/control/points'
     | '/app/control/providers'
@@ -600,6 +610,7 @@ export interface FileRouteTypes {
     | '/app/sessions'
     | '/app/suspensions'
     | '/app/users'
+    | '/app/control/gateways'
     | '/app/control/logs'
     | '/app/control/points'
     | '/app/control/providers'
@@ -655,6 +666,7 @@ export interface FileRouteTypes {
     | '/app/_app/sessions'
     | '/app/_app/suspensions'
     | '/app/_app/users'
+    | '/app/control/gateways'
     | '/app/control/logs'
     | '/app/control/points'
     | '/app/control/providers'
@@ -947,6 +959,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppControlLogsRouteImport
       parentRoute: typeof AppControlRoute
     }
+    '/app/control/gateways': {
+      id: '/app/control/gateways'
+      path: '/gateways'
+      fullPath: '/app/control/gateways'
+      preLoaderRoute: typeof AppControlGatewaysRouteImport
+      parentRoute: typeof AppControlRoute
+    }
     '/app/_app/users': {
       id: '/app/_app/users'
       path: '/users'
@@ -1135,6 +1154,7 @@ const AppAppRouteWithChildren =
   AppAppRoute._addFileChildren(AppAppRouteChildren)
 
 interface AppControlRouteChildren {
+  AppControlGatewaysRoute: typeof AppControlGatewaysRoute
   AppControlLogsRoute: typeof AppControlLogsRoute
   AppControlPointsRoute: typeof AppControlPointsRoute
   AppControlProvidersRoute: typeof AppControlProvidersRoute
@@ -1142,6 +1162,7 @@ interface AppControlRouteChildren {
 }
 
 const AppControlRouteChildren: AppControlRouteChildren = {
+  AppControlGatewaysRoute: AppControlGatewaysRoute,
   AppControlLogsRoute: AppControlLogsRoute,
   AppControlPointsRoute: AppControlPointsRoute,
   AppControlProvidersRoute: AppControlProvidersRoute,

--- a/apps/client/src/routes/app/control/gateways.tsx
+++ b/apps/client/src/routes/app/control/gateways.tsx
@@ -1,0 +1,312 @@
+import { trpc } from "@ecehive/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+	AlertTriangleIcon,
+	Loader2Icon,
+	NetworkIcon,
+	RefreshCcwIcon,
+} from "lucide-react";
+import React, { useState } from "react";
+import { toast } from "sonner";
+import { RequirePermissions, useAuth } from "@/auth/AuthProvider";
+import { CreateGatewayDialog } from "@/components/control/create-gateway-dialog";
+import { DeleteGatewayDialog } from "@/components/control/delete-gateway-dialog";
+import { EditGatewayDialog } from "@/components/control/edit-gateway-dialog";
+import { MissingPermissions } from "@/components/guards/missing-permissions";
+import {
+	Page,
+	PageActions,
+	PageContent,
+	PageHeader,
+	PageTitle,
+	TableContainer,
+	TableSearchInput,
+	TableToolbar,
+} from "@/components/layout";
+import {
+	DataTable,
+	SearchInput,
+	TablePaginationFooter,
+} from "@/components/shared";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { usePaginationInfo } from "@/hooks/use-pagination-info";
+import { useTableState } from "@/hooks/use-table-state";
+import type { RequiredPermissions as TRequiredPermissions } from "@/lib/permissions";
+import { checkPermissions } from "@/lib/permissions";
+
+export const Route = createFileRoute("/app/control/gateways")({
+	component: () =>
+		RequirePermissions({
+			permissions,
+			children: <GatewaysPage />,
+			forbiddenFallback: <MissingPermissions />,
+		}),
+});
+
+const permissions = ["control.gateways.list"] as TRequiredPermissions;
+
+type ControlGateway = {
+	id: number;
+	name: string;
+	description: string | null;
+	accessToken: string;
+	isActive: boolean;
+	createdAt: Date;
+	updatedAt: Date;
+	_count: { actions: number };
+};
+
+type GeneratedToken = {
+	name: string;
+	value: string;
+};
+
+function GatewaysPage() {
+	const { user } = useAuth();
+	const [tokenToShow, setTokenToShow] = useState<GeneratedToken | null>(null);
+	const {
+		page,
+		setPage,
+		pageSize,
+		setPageSize,
+		offset,
+		search,
+		setSearch,
+		debouncedSearch,
+		resetToFirstPage,
+	} = useTableState();
+
+	const queryParams = React.useMemo(
+		() => ({
+			search:
+				debouncedSearch.trim() === "" ? undefined : debouncedSearch.trim(),
+			offset,
+			limit: pageSize,
+		}),
+		[debouncedSearch, offset, pageSize],
+	);
+
+	const {
+		data = { gateways: [], total: 0 },
+		isLoading,
+		isFetching,
+		refetch,
+	} = useQuery({
+		queryKey: ["control", "gateways", queryParams],
+		queryFn: async () => await trpc.control.gateways.list.query(queryParams),
+		retry: false,
+	});
+
+	const canCreate = user && checkPermissions(user, ["control.gateways.create"]);
+	const canUpdate = user && checkPermissions(user, ["control.gateways.update"]);
+	const canDelete = user && checkPermissions(user, ["control.gateways.delete"]);
+
+	const columns: ColumnDef<ControlGateway>[] = [
+		{
+			accessorKey: "name",
+			header: "Name",
+			cell: ({ row }) => (
+				<div className="flex items-center gap-2">
+					<NetworkIcon className="h-4 w-4 text-muted-foreground" />
+					<div>
+						<span className="font-medium">{row.original.name}</span>
+						{row.original.description && (
+							<p className="text-xs text-muted-foreground">
+								{row.original.description}
+							</p>
+						)}
+					</div>
+				</div>
+			),
+		},
+		{
+			accessorKey: "accessToken",
+			header: "Access Token",
+			cell: ({ row }) => (
+				<code className="text-xs text-muted-foreground">
+					{row.original.accessToken}
+				</code>
+			),
+		},
+		{
+			accessorKey: "_count.actions",
+			header: "Actions",
+			cell: ({ row }) => (
+				<span className="text-muted-foreground">
+					{row.original._count.actions}
+				</span>
+			),
+		},
+		{
+			accessorKey: "isActive",
+			header: "Status",
+			cell: ({ row }) =>
+				row.original.isActive ? (
+					<Badge className="bg-green-500">Active</Badge>
+				) : (
+					<Badge variant="secondary">Inactive</Badge>
+				),
+		},
+		{
+			id: "actions",
+			header: "",
+			cell: ({ row }) => {
+				if (!canUpdate && !canDelete) return null;
+				return (
+					<div className="flex items-center gap-1">
+						{canUpdate && <EditGatewayDialog gateway={row.original} />}
+						{canDelete && <DeleteGatewayDialog gateway={row.original} />}
+					</div>
+				);
+			},
+		},
+	];
+
+	const { totalPages } = usePaginationInfo({
+		total: data.total,
+		pageSize,
+		offset,
+		currentCount: data.gateways.length,
+	});
+
+	return (
+		<Page>
+			<PageHeader>
+				<PageTitle>Control Gateways</PageTitle>
+				<PageActions>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => refetch()}
+						disabled={isFetching}
+					>
+						{isFetching ? (
+							<Loader2Icon className="h-4 w-4 animate-spin" />
+						) : (
+							<RefreshCcwIcon className="h-4 w-4" />
+						)}
+						<span className="ml-2 hidden sm:inline">Refresh</span>
+					</Button>
+					{canCreate && (
+						<CreateGatewayDialog
+							onTokenCreated={(payload) => setTokenToShow(payload)}
+						/>
+					)}
+				</PageActions>
+			</PageHeader>
+			<PageContent>
+				<TableContainer>
+					<TableToolbar>
+						<TableSearchInput>
+							<SearchInput
+								value={search}
+								onChange={(value) => {
+									setSearch(value);
+									resetToFirstPage();
+								}}
+								placeholder="Search gateways..."
+							/>
+						</TableSearchInput>
+					</TableToolbar>
+					<DataTable
+						columns={columns}
+						data={data.gateways}
+						isLoading={isLoading}
+					/>
+					<TablePaginationFooter
+						page={page}
+						totalPages={totalPages}
+						onPageChange={setPage}
+						offset={offset}
+						currentCount={data.gateways.length}
+						total={data.total}
+						itemName="gateways"
+						pageSize={pageSize}
+						onPageSizeChange={(size) => {
+							setPageSize(size);
+							resetToFirstPage();
+						}}
+					/>
+				</TableContainer>
+
+				<TokenRevealDialog
+					token={tokenToShow}
+					onClose={() => setTokenToShow(null)}
+				/>
+			</PageContent>
+		</Page>
+	);
+}
+
+function TokenRevealDialog({
+	token,
+	onClose,
+}: {
+	token: GeneratedToken | null;
+	onClose: () => void;
+}) {
+	const [copied, setCopied] = useState(false);
+
+	return (
+		<Dialog
+			open={token !== null}
+			onOpenChange={(next) => {
+				if (!next) {
+					setCopied(false);
+					onClose();
+				}
+			}}
+		>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Gateway created</DialogTitle>
+					<DialogDescription>
+						Copy and store this access token in a secure location. You will not
+						be able to retrieve it again.
+					</DialogDescription>
+				</DialogHeader>
+				{token && (
+					<div className="space-y-3">
+						<p className="text-sm text-muted-foreground">
+							Gateway: <span className="font-medium">{token.name}</span>
+						</p>
+						<div className="rounded border bg-muted/60 p-3 font-mono text-sm break-all">
+							{token.value}
+						</div>
+						<Button
+							variant={copied ? "secondary" : "default"}
+							onClick={async () => {
+								try {
+									await navigator.clipboard.writeText(token.value);
+									setCopied(true);
+									toast.success("Copied token to clipboard");
+								} catch {
+									toast.error("Unable to copy token");
+								}
+							}}
+						>
+							{copied ? "Copied" : "Copy token"}
+						</Button>
+					</div>
+				)}
+				<div className="flex items-center gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-900 dark:border-yellow-900/50 dark:bg-yellow-900/20 dark:text-yellow-100">
+					<AlertTriangleIcon className="size-4" />
+					<span>
+						Store this token securely. Lost tokens require creating a new
+						gateway.
+					</span>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 
 - [Periods](./periods.md)
 - [Attendance Tracking](./attendance-tracking.md)
+- [Control Gateways](./control-gateways.md)
 
 ## Usage
 

--- a/docs/control-gateways.md
+++ b/docs/control-gateways.md
@@ -1,0 +1,274 @@
+# Control Gateways
+
+Control Gateways allow external systems to trigger control point actions via a simple HTTP API. A gateway bundles one or more control-point actions behind a single access token, enabling integration with card readers, kiosks, IoT devices, and other systems that can present a credential value.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Concepts](#concepts)
+- [Administration](#administration)
+- [Invoking a Gateway](#invoking-a-gateway)
+- [Authorization Model](#authorization-model)
+- [Error Handling](#error-handling)
+- [Examples](#examples)
+
+---
+
+## Overview
+
+A **Control Gateway** acts as a bridge between an external system and one or more HUMS control points (doors, switches, etc.). The external system authenticates using the gateway's access token and identifies the acting user with a credential value (e.g., a card scan). HUMS then checks the user's authorization for each configured action and executes them.
+
+### Flow
+
+1. External system sends `POST /api/rest/control/gateways/invoke` with the gateway access token and a credential value.
+2. HUMS validates the access token and looks up the gateway.
+3. HUMS identifies the user from the credential value (via HMAC-SHA256 hash lookup).
+4. For each action configured on the gateway, HUMS checks if the user is authorized.
+5. Authorized actions are executed on the corresponding control points.
+6. A summary of results is returned.
+
+---
+
+## Concepts
+
+### Gateway
+
+A named configuration containing:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | A descriptive name for the gateway |
+| **Description** | Optional notes about the gateway's purpose |
+| **Access Token** | A unique 64-character hex token used for authentication |
+| **Active** | Whether the gateway accepts invocations |
+| **Actions** | One or more control point + action pairs |
+
+### Gateway Actions
+
+Each gateway can have multiple actions. An action pairs a **control point** with an **operation**:
+
+| Action | Applies To | Description |
+|--------|-----------|-------------|
+| `UNLOCK` | Door | Unlocks a door control point |
+| `TURN_ON` | Switch | Turns on a switch control point |
+| `TURN_OFF` | Switch | Turns off a switch control point |
+
+Action types are validated against the control point's class — doors only support `UNLOCK`, and switches only support `TURN_ON` / `TURN_OFF`.
+
+---
+
+## Administration
+
+Control gateways are managed from the **Control > Gateways** page in the admin client.
+
+### Required Permissions
+
+| Permission | Description |
+|------------|-------------|
+| `control.gateways.list` | View the list of gateways |
+| `control.gateways.get` | View gateway details |
+| `control.gateways.create` | Create new gateways |
+| `control.gateways.update` | Edit existing gateways |
+| `control.gateways.delete` | Delete gateways |
+
+### Creating a Gateway
+
+1. Navigate to **Control > Gateways** in the admin client.
+2. Click **New Gateway**.
+3. Enter a name and optional description.
+4. Add one or more actions by selecting a control point and the desired operation.
+5. Click **Create**.
+
+After creation, the access token is displayed **once** in a dialog. Copy and store it immediately — the token cannot be retrieved again. If lost, you must create a new gateway.
+
+### Editing a Gateway
+
+You can update a gateway's name, description, active status, and actions at any time. The access token cannot be changed or viewed after initial creation.
+
+### Deleting a Gateway
+
+Deleting a gateway immediately invalidates its access token. Any external system using that token will receive `401 Unauthorized` responses.
+
+---
+
+## Invoking a Gateway
+
+### Endpoint
+
+```
+POST /api/rest/control/gateways/invoke
+```
+
+This endpoint does **not** use the standard API token authentication. Instead, it uses the gateway's own access token.
+
+### Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `X-Gateway-Token` | Yes | The gateway's access token |
+| `Content-Type` | Yes | Must be `application/json` |
+
+### Request Body
+
+```json
+{
+  "credentialValue": "the-users-credential-value"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `credentialValue` | string | Yes | The raw credential value (e.g., a card number) to identify the user |
+
+### Success Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "gatewayId": 1,
+    "gatewayName": "Front Door Gateway",
+    "userId": 42,
+    "username": "jdoe",
+    "results": [
+      {
+        "controlPointId": "uuid-here",
+        "controlPointName": "Front Door",
+        "action": "UNLOCK",
+        "success": true
+      }
+    ]
+  }
+}
+```
+
+### Result Fields
+
+Each entry in `results` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `controlPointId` | string | The control point's UUID |
+| `controlPointName` | string | Human-readable name |
+| `action` | string | The action that was attempted |
+| `success` | boolean | Whether the action executed successfully |
+| `error` | string? | Error message if `success` is `false` |
+| `skipped` | boolean? | `true` if the action was skipped |
+| `skipReason` | string? | Reason the action was skipped |
+
+Actions may be skipped when:
+- The control point is inactive
+- The control provider is inactive
+- The user is not authorized for the control point
+
+---
+
+## Authorization Model
+
+When a gateway is invoked, each action is independently checked against the user's permissions on the target control point. The gateway itself does not grant any additional permissions — it only defines which actions to attempt.
+
+Authorization is determined per control point:
+
+1. **System users** bypass all authorization checks.
+2. **Direct authorization**: The user is explicitly listed in the control point's authorized users.
+3. **Role-based authorization**: The user has a role listed in the control point's authorized roles.
+4. **Unrestricted**: The control point has no authorized users or roles configured (open to all).
+
+If a user is not authorized for a particular action, that action is skipped with a `skipReason` of `"User is not authorized for this control point"`. Other actions in the same gateway invocation are still attempted.
+
+---
+
+## Error Handling
+
+### Error Response Format
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable error message"
+  }
+}
+```
+
+### Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `UNAUTHORIZED` | 401 | Missing or invalid `X-Gateway-Token` header |
+| `INVALID_TOKEN` | 401 | The access token does not match any gateway |
+| `INVALID_CREDENTIAL` | 401 | No user found for the provided credential value |
+| `GATEWAY_INACTIVE` | 403 | The gateway exists but is not active |
+| `VALIDATION_ERROR` | 400 | Request body validation failed |
+
+---
+
+## Examples
+
+### Unlock a Door
+
+```bash
+curl -X POST "https://your-domain.com/api/rest/control/gateways/invoke" \
+  -H "X-Gateway-Token: your_gateway_access_token" \
+  -H "Content-Type: application/json" \
+  -d '{"credentialValue": "12345678"}'
+```
+
+### Response — Successful Unlock
+
+```json
+{
+  "success": true,
+  "data": {
+    "gatewayId": 1,
+    "gatewayName": "Lab Entry Gateway",
+    "userId": 15,
+    "username": "asmith",
+    "results": [
+      {
+        "controlPointId": "a1b2c3d4-...",
+        "controlPointName": "Lab Door",
+        "action": "UNLOCK",
+        "success": true
+      }
+    ]
+  }
+}
+```
+
+### Response — Unauthorized User
+
+```json
+{
+  "success": true,
+  "data": {
+    "gatewayId": 1,
+    "gatewayName": "Lab Entry Gateway",
+    "userId": 99,
+    "username": "visitor1",
+    "results": [
+      {
+        "controlPointId": "a1b2c3d4-...",
+        "controlPointName": "Lab Door",
+        "action": "UNLOCK",
+        "success": false,
+        "skipped": true,
+        "skipReason": "User is not authorized for this control point"
+      }
+    ]
+  }
+}
+```
+
+### Response — Invalid Token
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "INVALID_TOKEN",
+    "message": "Invalid gateway access token"
+  }
+}
+```

--- a/packages/features/src/control/create-control-gateway.ts
+++ b/packages/features/src/control/create-control-gateway.ts
@@ -1,0 +1,110 @@
+/**
+ * Control Gateways - Create
+ */
+
+import type { ControlAction } from "@ecehive/prisma";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+
+export interface CreateControlGatewayActionInput {
+	controlPointId: string;
+	action: "TURN_ON" | "TURN_OFF" | "UNLOCK";
+}
+
+export interface CreateControlGatewayInput {
+	name: string;
+	description?: string;
+	isActive?: boolean;
+	actions: CreateControlGatewayActionInput[];
+}
+
+/**
+ * Generates a cryptographically secure access token for a gateway
+ */
+function generateAccessToken(): string {
+	const bytes = crypto.getRandomValues(new Uint8Array(32));
+	return Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+/**
+ * Creates a new control gateway with associated actions
+ */
+export async function createControlGateway(input: CreateControlGatewayInput) {
+	// Validate that all referenced control points exist
+	if (input.actions.length > 0) {
+		const controlPointIds = Array.from(
+			new Set(input.actions.map((a) => a.controlPointId)),
+		);
+		const existingPoints = await prisma.controlPoint.findMany({
+			where: { id: { in: controlPointIds } },
+			select: { id: true, controlClass: true },
+		});
+
+		const existingIds = new Set(existingPoints.map((p) => p.id));
+		const missingIds = controlPointIds.filter((id) => !existingIds.has(id));
+		if (missingIds.length > 0) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Control points not found: ${missingIds.join(", ")}`,
+			});
+		}
+
+		// Validate action compatibility with control class
+		for (const action of input.actions) {
+			const point = existingPoints.find((p) => p.id === action.controlPointId);
+			if (!point) continue;
+
+			if (point.controlClass === "DOOR" && action.action !== "UNLOCK") {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Door control points can only use the UNLOCK action (point: ${action.controlPointId})`,
+				});
+			}
+
+			if (
+				point.controlClass === "SWITCH" &&
+				action.action !== "TURN_ON" &&
+				action.action !== "TURN_OFF"
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Switch control points can only use TURN_ON or TURN_OFF actions (point: ${action.controlPointId})`,
+				});
+			}
+		}
+	}
+
+	const accessToken = generateAccessToken();
+
+	const gateway = await prisma.controlGateway.create({
+		data: {
+			name: input.name,
+			description: input.description,
+			accessToken,
+			isActive: input.isActive ?? true,
+			actions: {
+				create: input.actions.map((a) => ({
+					controlPointId: a.controlPointId,
+					action: a.action as ControlAction,
+				})),
+			},
+		},
+		include: {
+			actions: {
+				include: {
+					controlPoint: {
+						select: {
+							id: true,
+							name: true,
+							controlClass: true,
+						},
+					},
+				},
+			},
+		},
+	});
+
+	return gateway;
+}

--- a/packages/features/src/control/delete-control-gateway.ts
+++ b/packages/features/src/control/delete-control-gateway.ts
@@ -1,0 +1,29 @@
+/**
+ * Control Gateways - Delete
+ */
+
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Deletes a control gateway by ID
+ * Associated actions are cascade-deleted
+ */
+export async function deleteControlGateway(id: number) {
+	const existing = await prisma.controlGateway.findUnique({
+		where: { id },
+	});
+
+	if (!existing) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Control gateway not found",
+		});
+	}
+
+	await prisma.controlGateway.delete({
+		where: { id },
+	});
+
+	return { success: true };
+}

--- a/packages/features/src/control/get-control-gateway.ts
+++ b/packages/features/src/control/get-control-gateway.ts
@@ -1,0 +1,44 @@
+/**
+ * Control Gateways - Get
+ */
+
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Gets a control gateway by ID with its associated actions
+ * Access token is redacted to prevent exposure
+ */
+export async function getControlGatewayById(id: number) {
+	const gateway = await prisma.controlGateway.findUnique({
+		where: { id },
+		include: {
+			actions: {
+				include: {
+					controlPoint: {
+						select: {
+							id: true,
+							name: true,
+							location: true,
+							controlClass: true,
+							isActive: true,
+						},
+					},
+				},
+			},
+		},
+	});
+
+	if (!gateway) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Control gateway not found",
+		});
+	}
+
+	// Redact access token
+	return {
+		...gateway,
+		accessToken: `****${gateway.accessToken.slice(-4)}`,
+	};
+}

--- a/packages/features/src/control/index.ts
+++ b/packages/features/src/control/index.ts
@@ -1,13 +1,20 @@
 // Control Points
 
 export * from "./auto-turn-off-control-points";
+// Control Gateways
+export * from "./create-control-gateway";
 export * from "./create-control-point";
 export * from "./create-control-provider";
+export * from "./delete-control-gateway";
 export * from "./delete-control-point";
 export * from "./delete-control-provider";
+// Control Gateway
+export * from "./get-control-gateway";
 export * from "./get-control-point";
 // Control Providers
 export * from "./get-control-provider";
+export * from "./invoke-control-gateway";
+export * from "./list-control-gateways";
 // Control Logs
 export * from "./list-control-logs";
 export * from "./list-control-points";
@@ -17,5 +24,6 @@ export * from "./operate-control-points";
 export * from "./providers";
 // Session-Control Point Validation
 export * from "./session-control-validation";
+export * from "./update-control-gateway";
 export * from "./update-control-point";
 export * from "./update-control-provider";

--- a/packages/features/src/control/invoke-control-gateway.ts
+++ b/packages/features/src/control/invoke-control-gateway.ts
@@ -1,0 +1,228 @@
+/**
+ * Control Gateways - Invoke
+ *
+ * Handles the invocation of a control gateway. When called with
+ * an access token and a credential value, it:
+ * 1. Finds the gateway by access token
+ * 2. Finds the user by credential hash
+ * 3. Checks which gateway actions the user is authorized to perform
+ * 4. Executes authorized actions on the control points
+ */
+
+import type { ControlAction, ControlProviderType } from "@ecehive/prisma";
+import { prisma } from "@ecehive/prisma";
+import { hashCredential } from "../credentials/hash";
+import { getControlProvider } from "./providers";
+
+export interface InvokeControlGatewayInput {
+	accessToken: string;
+	credentialValue: string;
+}
+
+export interface GatewayActionResult {
+	controlPointId: string;
+	controlPointName: string;
+	action: ControlAction;
+	success: boolean;
+	error?: string;
+	skipped?: boolean;
+	skipReason?: string;
+}
+
+export interface InvokeControlGatewayResult {
+	gatewayId: number;
+	gatewayName: string;
+	userId: number;
+	username: string;
+	results: GatewayActionResult[];
+}
+
+/**
+ * Invokes a control gateway, executing authorized actions for the user
+ * identified by the provided credential value
+ */
+export async function invokeControlGateway(
+	input: InvokeControlGatewayInput,
+): Promise<InvokeControlGatewayResult> {
+	// Find the gateway by access token
+	const gateway = await prisma.controlGateway.findUnique({
+		where: { accessToken: input.accessToken },
+		include: {
+			actions: {
+				include: {
+					controlPoint: {
+						include: {
+							provider: true,
+							authorizedRoles: { select: { id: true } },
+							authorizedUsers: { select: { id: true } },
+						},
+					},
+				},
+			},
+		},
+	});
+
+	if (!gateway) {
+		throw new GatewayError("INVALID_TOKEN", "Invalid gateway access token");
+	}
+
+	if (!gateway.isActive) {
+		throw new GatewayError("GATEWAY_INACTIVE", "This gateway is not active");
+	}
+
+	// Find user by credential hash
+	const hash = hashCredential(input.credentialValue);
+	const credential = await prisma.credential.findUnique({
+		where: { hash },
+		include: {
+			user: {
+				include: {
+					roles: { select: { id: true } },
+				},
+			},
+		},
+	});
+
+	if (!credential) {
+		throw new GatewayError(
+			"INVALID_CREDENTIAL",
+			"No user found for the provided credential",
+		);
+	}
+
+	const user = credential.user;
+	const userRoleIds = new Set(user.roles.map((r) => r.id));
+
+	// Execute each configured action, checking authorization per action
+	const results: GatewayActionResult[] = [];
+
+	for (const gatewayAction of gateway.actions) {
+		const point = gatewayAction.controlPoint;
+
+		// Check if control point is active
+		if (!point.isActive) {
+			results.push({
+				controlPointId: point.id,
+				controlPointName: point.name,
+				action: gatewayAction.action,
+				success: false,
+				skipped: true,
+				skipReason: "Control point is not active",
+			});
+			continue;
+		}
+
+		// Check if provider is active
+		if (!point.provider.isActive) {
+			results.push({
+				controlPointId: point.id,
+				controlPointName: point.name,
+				action: gatewayAction.action,
+				success: false,
+				skipped: true,
+				skipReason: "Control provider is not active",
+			});
+			continue;
+		}
+
+		// Check user authorization for this control point
+		if (!user.isSystemUser) {
+			const isDirectlyAuthorized = point.authorizedUsers.some(
+				(u) => u.id === user.id,
+			);
+			const isRoleAuthorized = point.authorizedRoles.some((r) =>
+				userRoleIds.has(r.id),
+			);
+			const hasNoRestrictions =
+				point.authorizedUsers.length === 0 &&
+				point.authorizedRoles.length === 0;
+
+			if (!isDirectlyAuthorized && !isRoleAuthorized && !hasNoRestrictions) {
+				results.push({
+					controlPointId: point.id,
+					controlPointName: point.name,
+					action: gatewayAction.action,
+					success: false,
+					skipped: true,
+					skipReason: "User is not authorized for this control point",
+				});
+				continue;
+			}
+		}
+
+		// Execute the action
+		try {
+			const provider = getControlProvider(
+				point.provider.providerType as ControlProviderType,
+			);
+
+			const targetState =
+				gatewayAction.action === "TURN_ON" || gatewayAction.action === "UNLOCK";
+
+			const operationResult = await provider.writeState(
+				point.provider.config,
+				point.providerConfig,
+				targetState,
+				user.username,
+			);
+
+			// Log the operation
+			await prisma.controlLog.create({
+				data: {
+					controlPointId: point.id,
+					userId: user.id,
+					action: gatewayAction.action,
+					previousState: point.currentState,
+					newState: operationResult.success ? targetState : null,
+					success: operationResult.success,
+					errorMessage: operationResult.errorMessage,
+				},
+			});
+
+			// Update control point state for switches
+			if (operationResult.success && point.controlClass === "SWITCH") {
+				await prisma.controlPoint.update({
+					where: { id: point.id },
+					data: { currentState: targetState },
+				});
+			}
+
+			results.push({
+				controlPointId: point.id,
+				controlPointName: point.name,
+				action: gatewayAction.action,
+				success: operationResult.success,
+				error: operationResult.errorMessage,
+			});
+		} catch (error) {
+			results.push({
+				controlPointId: point.id,
+				controlPointName: point.name,
+				action: gatewayAction.action,
+				success: false,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	return {
+		gatewayId: gateway.id,
+		gatewayName: gateway.name,
+		userId: user.id,
+		username: user.username,
+		results,
+	};
+}
+
+/**
+ * Structured error for gateway operations
+ */
+export class GatewayError extends Error {
+	code: string;
+
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "GatewayError";
+		this.code = code;
+	}
+}

--- a/packages/features/src/control/list-control-gateways.ts
+++ b/packages/features/src/control/list-control-gateways.ts
@@ -1,0 +1,63 @@
+/**
+ * Control Gateways - List
+ */
+
+import type { Prisma } from "@ecehive/prisma";
+import { prisma } from "@ecehive/prisma";
+
+export interface ListControlGatewaysInput {
+	search?: string;
+	isActive?: boolean;
+	limit?: number;
+	offset?: number;
+}
+
+/**
+ * Lists control gateways with filtering and pagination
+ * Access tokens are redacted to prevent exposure
+ */
+export async function listControlGateways(input: ListControlGatewaysInput) {
+	const limit = input.limit ?? 25;
+	const offset = input.offset ?? 0;
+
+	const where: Prisma.ControlGatewayWhereInput = {};
+
+	if (input.search) {
+		where.OR = [
+			{ name: { contains: input.search, mode: "insensitive" } },
+			{ description: { contains: input.search, mode: "insensitive" } },
+		];
+	}
+
+	if (input.isActive !== undefined) {
+		where.isActive = input.isActive;
+	}
+
+	const [gateways, total] = await Promise.all([
+		prisma.controlGateway.findMany({
+			where,
+			include: {
+				_count: {
+					select: { actions: true },
+				},
+			},
+			orderBy: { name: "asc" },
+			take: limit,
+			skip: offset,
+		}),
+		prisma.controlGateway.count({ where }),
+	]);
+
+	// Redact access tokens from response
+	const redactedGateways = gateways.map((gateway) => ({
+		...gateway,
+		accessToken: `****${gateway.accessToken.slice(-4)}`,
+	}));
+
+	return {
+		gateways: redactedGateways,
+		total,
+		limit,
+		offset,
+	};
+}

--- a/packages/features/src/control/update-control-gateway.ts
+++ b/packages/features/src/control/update-control-gateway.ts
@@ -1,0 +1,140 @@
+/**
+ * Control Gateways - Update
+ */
+
+import type { ControlAction } from "@ecehive/prisma";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+
+export interface UpdateControlGatewayActionInput {
+	controlPointId: string;
+	action: "TURN_ON" | "TURN_OFF" | "UNLOCK";
+}
+
+export interface UpdateControlGatewayInput {
+	id: number;
+	name?: string;
+	description?: string | null;
+	isActive?: boolean;
+	actions?: UpdateControlGatewayActionInput[];
+}
+
+/**
+ * Updates an existing control gateway
+ */
+export async function updateControlGateway(input: UpdateControlGatewayInput) {
+	const existing = await prisma.controlGateway.findUnique({
+		where: { id: input.id },
+	});
+
+	if (!existing) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Control gateway not found",
+		});
+	}
+
+	// Validate actions if being updated
+	if (input.actions && input.actions.length > 0) {
+		const controlPointIds = Array.from(
+			new Set(input.actions.map((a) => a.controlPointId)),
+		);
+		const existingPoints = await prisma.controlPoint.findMany({
+			where: { id: { in: controlPointIds } },
+			select: { id: true, controlClass: true },
+		});
+
+		const existingIds = new Set(existingPoints.map((p) => p.id));
+		const missingIds = controlPointIds.filter((id) => !existingIds.has(id));
+		if (missingIds.length > 0) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Control points not found: ${missingIds.join(", ")}`,
+			});
+		}
+
+		// Validate action compatibility with control class
+		for (const action of input.actions) {
+			const point = existingPoints.find((p) => p.id === action.controlPointId);
+			if (!point) continue;
+
+			if (point.controlClass === "DOOR" && action.action !== "UNLOCK") {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Door control points can only use the UNLOCK action (point: ${action.controlPointId})`,
+				});
+			}
+
+			if (
+				point.controlClass === "SWITCH" &&
+				action.action !== "TURN_ON" &&
+				action.action !== "TURN_OFF"
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Switch control points can only use TURN_ON or TURN_OFF actions (point: ${action.controlPointId})`,
+				});
+			}
+		}
+	}
+
+	// Use a transaction to update gateway and replace actions atomically
+	const gateway = await prisma.$transaction(async (tx) => {
+		// Update gateway properties
+		const updated = await tx.controlGateway.update({
+			where: { id: input.id },
+			data: {
+				name: input.name,
+				description: input.description,
+				isActive: input.isActive,
+			},
+		});
+
+		// If actions are provided, replace all existing actions
+		if (input.actions !== undefined) {
+			await tx.controlGatewayAction.deleteMany({
+				where: { gatewayId: input.id },
+			});
+
+			if (input.actions.length > 0) {
+				await tx.controlGatewayAction.createMany({
+					data: input.actions.map((a) => ({
+						gatewayId: input.id,
+						controlPointId: a.controlPointId,
+						action: a.action as ControlAction,
+					})),
+				});
+			}
+		}
+
+		return tx.controlGateway.findUnique({
+			where: { id: updated.id },
+			include: {
+				actions: {
+					include: {
+						controlPoint: {
+							select: {
+								id: true,
+								name: true,
+								controlClass: true,
+							},
+						},
+					},
+				},
+			},
+		});
+	});
+
+	if (!gateway) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: "Failed to update control gateway",
+		});
+	}
+
+	// Redact access token
+	return {
+		...gateway,
+		accessToken: `****${gateway.accessToken.slice(-4)}`,
+	};
+}

--- a/packages/prisma/migrations/20260219222558_add_control_gateways/migration.sql
+++ b/packages/prisma/migrations/20260219222558_add_control_gateways/migration.sql
@@ -1,0 +1,54 @@
+-- CreateTable
+CREATE TABLE "ControlGateway" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "accessToken" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ControlGateway_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ControlGatewayAction" (
+    "id" SERIAL NOT NULL,
+    "gatewayId" INTEGER NOT NULL,
+    "controlPointId" TEXT NOT NULL,
+    "action" "ControlAction" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ControlGatewayAction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ControlGateway_accessToken_key" ON "ControlGateway"("accessToken");
+
+-- CreateIndex
+CREATE INDEX "ControlGateway_accessToken_idx" ON "ControlGateway"("accessToken");
+
+-- CreateIndex
+CREATE INDEX "ControlGatewayAction_gatewayId_idx" ON "ControlGatewayAction"("gatewayId");
+
+-- CreateIndex
+CREATE INDEX "ControlGatewayAction_controlPointId_idx" ON "ControlGatewayAction"("controlPointId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ControlGatewayAction_gatewayId_controlPointId_action_key" ON "ControlGatewayAction"("gatewayId", "controlPointId", "action");
+
+-- AddForeignKey
+ALTER TABLE "ControlGatewayAction" ADD CONSTRAINT "ControlGatewayAction_gatewayId_fkey" FOREIGN KEY ("gatewayId") REFERENCES "ControlGateway"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ControlGatewayAction" ADD CONSTRAINT "ControlGatewayAction_controlPointId_fkey" FOREIGN KEY ("controlPointId") REFERENCES "ControlPoint"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Add control gateway permissions
+INSERT INTO "Permission" (name) VALUES
+    ('control.gateways.list'),
+    ('control.gateways.get'),
+    ('control.gateways.create'),
+    ('control.gateways.update'),
+    ('control.gateways.delete')
+ON CONFLICT (name) DO NOTHING;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -463,6 +463,7 @@ model ControlPoint {
   authorizedUsers     User[]            @relation("ControlPointUsers")
   controlLogs         ControlLog[]
   devices             Device[]          @relation("DeviceControlPoints")
+  gatewayActions      ControlGatewayAction[]
 
   @@index([providerId])
 }
@@ -498,6 +499,36 @@ enum ControlAction {
   TURN_OFF
   UNLOCK
   READ_STATE
+}
+
+// ===== Control Gateways =====
+
+model ControlGateway {
+  id          Int                    @id @default(autoincrement())
+  name        String
+  description String?
+  accessToken String                 @unique
+  isActive    Boolean                @default(true)
+  createdAt   DateTime               @default(now())
+  updatedAt   DateTime               @default(now()) @updatedAt
+  actions     ControlGatewayAction[]
+
+  @@index([accessToken])
+}
+
+model ControlGatewayAction {
+  id             Int              @id @default(autoincrement())
+  gatewayId      Int
+  controlPointId String
+  action         ControlAction
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @default(now()) @updatedAt
+  gateway        ControlGateway   @relation(fields: [gatewayId], references: [id], onDelete: Cascade)
+  controlPoint   ControlPoint     @relation(fields: [controlPointId], references: [id], onDelete: Cascade)
+
+  @@unique([gatewayId, controlPointId, action])
+  @@index([gatewayId])
+  @@index([controlPointId])
 }
 
 // ===== Credentials =====

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
 import { registerAuthGuard } from "./auth";
+import { controlGatewayRoutes } from "./routes/control-gateways";
 import { controlPointsRoutes } from "./routes/control-points";
 import { openHoursRoutes } from "./routes/open-hours";
 import { rolesRoutes } from "./routes/roles";
@@ -27,6 +28,11 @@ export const restApiRoute: FastifyPluginAsync = async (fastify) => {
 	// These routes are registered before the auth guard is applied
 	fastify.register(openHoursRoutes, {
 		prefix: "/open-hours",
+	});
+
+	// Control gateway invocation uses its own access token authentication
+	fastify.register(controlGatewayRoutes, {
+		prefix: "/control/gateways",
 	});
 
 	// ===== Protected Routes (authentication required) =====

--- a/packages/rest/src/routes/control-gateways.ts
+++ b/packages/rest/src/routes/control-gateways.ts
@@ -1,0 +1,84 @@
+/**
+ * Control Gateways REST Route
+ *
+ * This route provides the public-facing endpoint for invoking control gateways.
+ * External systems call this endpoint with a gateway access token and a
+ * credential value to trigger configured control point actions.
+ *
+ * Authentication is handled by the gateway's own access token, not by the
+ * standard API token auth guard.
+ */
+
+import { GatewayError, invokeControlGateway } from "@ecehive/features";
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+import { internalError, validationError } from "../shared/validation";
+
+// ===== Validation Schemas =====
+
+const InvokeGatewayBodySchema = z.object({
+	credentialValue: z.string().trim().min(1, "Credential value is required"),
+});
+
+const GatewayAccessTokenHeaderSchema = z.object({
+	"x-gateway-token": z.string().min(1, "Gateway access token is required"),
+});
+
+// ===== Routes =====
+
+export const controlGatewayRoutes: FastifyPluginAsync = async (fastify) => {
+	// POST /control/gateways/invoke — invoke a control gateway
+	fastify.post<{ Body: unknown }>("/invoke", async (request, reply) => {
+		// Validate the access token from header
+		const headerParse = GatewayAccessTokenHeaderSchema.safeParse(
+			request.headers,
+		);
+		if (!headerParse.success) {
+			return reply.code(401).send({
+				success: false,
+				error: {
+					code: "UNAUTHORIZED",
+					message: "Missing or invalid gateway access token",
+				},
+			});
+		}
+
+		const body = InvokeGatewayBodySchema.safeParse(request.body);
+		if (!body.success) {
+			return validationError(reply, body.error);
+		}
+
+		const accessToken = headerParse.data["x-gateway-token"];
+
+		try {
+			const result = await invokeControlGateway({
+				accessToken,
+				credentialValue: body.data.credentialValue,
+			});
+
+			return {
+				success: true,
+				data: result,
+			};
+		} catch (error) {
+			if (error instanceof GatewayError) {
+				const statusMap: Record<string, number> = {
+					INVALID_TOKEN: 401,
+					GATEWAY_INACTIVE: 403,
+					INVALID_CREDENTIAL: 401,
+				};
+				const status = statusMap[error.code] ?? 400;
+
+				return reply.code(status).send({
+					success: false,
+					error: {
+						code: error.code,
+						message: error.message,
+					},
+				});
+			}
+
+			return internalError(reply);
+		}
+	});
+};

--- a/packages/trpc/server/routers/control/_route.ts
+++ b/packages/trpc/server/routers/control/_route.ts
@@ -6,6 +6,24 @@
  */
 
 import { permissionProtectedProcedure, router } from "../../trpc";
+// Gateway routes
+import {
+	createGatewayHandler,
+	ZCreateGatewaySchema,
+} from "./gateways/create.route";
+import {
+	deleteGatewayHandler,
+	ZDeleteGatewaySchema,
+} from "./gateways/delete.route";
+import { getGatewayHandler, ZGetGatewaySchema } from "./gateways/get.route";
+import {
+	listGatewaysHandler,
+	ZListGatewaysSchema,
+} from "./gateways/list.route";
+import {
+	updateGatewayHandler,
+	ZUpdateGatewaySchema,
+} from "./gateways/update.route";
 // Log routes
 import { listLogsHandler, ZListLogsSchema } from "./logs/list.route";
 // Control point routes
@@ -90,5 +108,24 @@ export const controlRouter = router({
 		list: permissionProtectedProcedure("control.logs.list")
 			.input(ZListLogsSchema)
 			.query(listLogsHandler),
+	}),
+
+	// Control Gateways
+	gateways: router({
+		list: permissionProtectedProcedure("control.gateways.list")
+			.input(ZListGatewaysSchema)
+			.query(listGatewaysHandler),
+		get: permissionProtectedProcedure("control.gateways.get")
+			.input(ZGetGatewaySchema)
+			.query(getGatewayHandler),
+		create: permissionProtectedProcedure("control.gateways.create")
+			.input(ZCreateGatewaySchema)
+			.mutation(createGatewayHandler),
+		update: permissionProtectedProcedure("control.gateways.update")
+			.input(ZUpdateGatewaySchema)
+			.mutation(updateGatewayHandler),
+		delete: permissionProtectedProcedure("control.gateways.delete")
+			.input(ZDeleteGatewaySchema)
+			.mutation(deleteGatewayHandler),
 	}),
 });

--- a/packages/trpc/server/routers/control/gateways/create.route.ts
+++ b/packages/trpc/server/routers/control/gateways/create.route.ts
@@ -1,0 +1,28 @@
+/**
+ * Control Gateway Routes - Create
+ */
+
+import { createControlGateway } from "@ecehive/features";
+import { z } from "zod";
+
+export const ZCreateGatewaySchema = z.object({
+	name: z.string().min(1).max(255),
+	description: z.string().max(1000).optional(),
+	isActive: z.boolean().optional(),
+	actions: z
+		.array(
+			z.object({
+				controlPointId: z.string().uuid(),
+				action: z.enum(["TURN_ON", "TURN_OFF", "UNLOCK"]),
+			}),
+		)
+		.default([]),
+});
+
+export async function createGatewayHandler({
+	input,
+}: {
+	input: z.infer<typeof ZCreateGatewaySchema>;
+}) {
+	return createControlGateway(input);
+}

--- a/packages/trpc/server/routers/control/gateways/delete.route.ts
+++ b/packages/trpc/server/routers/control/gateways/delete.route.ts
@@ -1,0 +1,18 @@
+/**
+ * Control Gateway Routes - Delete
+ */
+
+import { deleteControlGateway } from "@ecehive/features";
+import { z } from "zod";
+
+export const ZDeleteGatewaySchema = z.object({
+	id: z.number().int(),
+});
+
+export async function deleteGatewayHandler({
+	input,
+}: {
+	input: z.infer<typeof ZDeleteGatewaySchema>;
+}) {
+	return deleteControlGateway(input.id);
+}

--- a/packages/trpc/server/routers/control/gateways/get.route.ts
+++ b/packages/trpc/server/routers/control/gateways/get.route.ts
@@ -1,0 +1,18 @@
+/**
+ * Control Gateway Routes - Get
+ */
+
+import { getControlGatewayById } from "@ecehive/features";
+import { z } from "zod";
+
+export const ZGetGatewaySchema = z.object({
+	id: z.number().int(),
+});
+
+export async function getGatewayHandler({
+	input,
+}: {
+	input: z.infer<typeof ZGetGatewaySchema>;
+}) {
+	return getControlGatewayById(input.id);
+}

--- a/packages/trpc/server/routers/control/gateways/list.route.ts
+++ b/packages/trpc/server/routers/control/gateways/list.route.ts
@@ -1,0 +1,21 @@
+/**
+ * Control Gateway Routes - List
+ */
+
+import { listControlGateways } from "@ecehive/features";
+import { z } from "zod";
+
+export const ZListGatewaysSchema = z.object({
+	search: z.string().optional(),
+	isActive: z.boolean().optional(),
+	limit: z.number().int().min(1).max(100).default(25),
+	offset: z.number().int().min(0).default(0),
+});
+
+export async function listGatewaysHandler({
+	input,
+}: {
+	input: z.infer<typeof ZListGatewaysSchema>;
+}) {
+	return listControlGateways(input);
+}

--- a/packages/trpc/server/routers/control/gateways/update.route.ts
+++ b/packages/trpc/server/routers/control/gateways/update.route.ts
@@ -1,0 +1,29 @@
+/**
+ * Control Gateway Routes - Update
+ */
+
+import { updateControlGateway } from "@ecehive/features";
+import { z } from "zod";
+
+export const ZUpdateGatewaySchema = z.object({
+	id: z.number().int(),
+	name: z.string().min(1).max(255).optional(),
+	description: z.string().max(1000).nullish(),
+	isActive: z.boolean().optional(),
+	actions: z
+		.array(
+			z.object({
+				controlPointId: z.string().uuid(),
+				action: z.enum(["TURN_ON", "TURN_OFF", "UNLOCK"]),
+			}),
+		)
+		.optional(),
+});
+
+export async function updateGatewayHandler({
+	input,
+}: {
+	input: z.infer<typeof ZUpdateGatewaySchema>;
+}) {
+	return updateControlGateway(input);
+}


### PR DESCRIPTION
This pull request adds control gateways. Control gateways is a system that allows for small devices to make simple HTTP requests to perform a pre-defined control action. For example, a door card scanner to open a door. Control gateways are intended to be lightweight, and not full-blown web apps (like the Control kiosk).