### PR TITLE
Don't let system user update failure crash the server

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,16 +7,16 @@ import { createServer } from "./fastify";
 const logger = getLogger("server:startup");
 
 Promise.resolve()
-	.then(() => {
+	.then(async () => {
 		logger.info("Starting server initialization");
-		return updateSystemUsers();
-	})
-	.then(() => {
-		logger.info("System users synchronized");
-	})
-	.catch((err) => {
-		logger.fatal("Failed to update system users", { error: err.message });
-		process.exit(1);
+		try {
+			await updateSystemUsers();
+			logger.info("System users synchronized");
+		} catch (err) {
+			logger.warn("Failed to update system users, skipping", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
 	})
 	.then(() => workers.start())
 	.then(() => {


### PR DESCRIPTION
This pull request fixes a bug where the server fails to start if the system user update process fails for any reason.