### PR TITLE
Add bulk shift registration

### DIFF
--- a/apps/client/src/components/shift-schedules/bulk-registration-sidebar.tsx
+++ b/apps/client/src/components/shift-schedules/bulk-registration-sidebar.tsx
@@ -1,0 +1,340 @@
+import { CalendarCheck, CalendarDays, Info, MapPin, X } from "lucide-react";
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import type { ShiftSchedule } from "./shift-scheduler-utils";
+import { DAYS_OF_WEEK, formatCompactTime } from "./shift-scheduler-utils";
+import type { useShiftMutations } from "./use-shift-mutations";
+
+interface BulkShiftType {
+	shiftTypeId: number;
+	shiftTypeName: string;
+	shiftTypeColor: string | null;
+	shiftTypeLocation: string;
+	/** Schedule IDs where this shift type has an available slot across all selected blocks */
+	scheduleIds: number[];
+	/** Total number of selected blocks where this type appears and is available */
+	availableBlockCount: number;
+	/** Total number of selected blocks */
+	totalSelectedBlocks: number;
+}
+
+interface BulkRegistrationSidebarProps {
+	selectedBlocks: Set<string>;
+	blocks: Map<
+		string,
+		{ schedules: ShiftSchedule[]; total: number; available: number }
+	>;
+	isWithinSignupWindow: boolean;
+	bulkRegisterMutation: ReturnType<
+		typeof useShiftMutations
+	>["bulkRegisterMutation"];
+	onClearSelection: () => void;
+	onExitBulkMode: () => void;
+}
+
+/**
+ * Sidebar shown during bulk registration mode.
+ * Displays shift types that have open slots across ALL selected time blocks,
+ * allowing the user to register for a specific shift type at all selected slots at once.
+ */
+export function BulkRegistrationSidebar({
+	selectedBlocks,
+	blocks,
+	isWithinSignupWindow,
+	bulkRegisterMutation,
+	onClearSelection,
+	onExitBulkMode,
+}: BulkRegistrationSidebarProps) {
+	// Compute eligible shift types: those that have a registerable schedule at every selected block
+	const bulkShiftTypes = useMemo(() => {
+		if (selectedBlocks.size === 0) return [];
+
+		const selectedBlockKeys = Array.from(selectedBlocks);
+
+		// For each shift type, find which selected blocks have a registerable schedule
+		const shiftTypeMap = new Map<
+			number,
+			{
+				shiftTypeName: string;
+				shiftTypeColor: string | null;
+				shiftTypeLocation: string;
+				scheduleIds: number[];
+				availableBlockCount: number;
+			}
+		>();
+
+		for (const blockKey of selectedBlockKeys) {
+			const blockData = blocks.get(blockKey);
+			if (!blockData) continue;
+
+			for (const schedule of blockData.schedules) {
+				if (!schedule.canRegister) continue;
+
+				if (!shiftTypeMap.has(schedule.shiftTypeId)) {
+					shiftTypeMap.set(schedule.shiftTypeId, {
+						shiftTypeName: schedule.shiftTypeName,
+						shiftTypeColor: schedule.shiftTypeColor,
+						shiftTypeLocation: schedule.shiftTypeLocation,
+						scheduleIds: [],
+						availableBlockCount: 0,
+					});
+				}
+
+				const entry = shiftTypeMap.get(schedule.shiftTypeId);
+				if (!entry) continue;
+				// Only add the schedule ID once (a schedule might span multiple blocks)
+				if (!entry.scheduleIds.includes(schedule.id)) {
+					entry.scheduleIds.push(schedule.id);
+				}
+				entry.availableBlockCount++;
+			}
+		}
+
+		// Filter to only shift types available at ALL selected blocks
+		const totalBlocks = selectedBlockKeys.length;
+		const result: BulkShiftType[] = [];
+
+		for (const [shiftTypeId, data] of shiftTypeMap) {
+			if (data.availableBlockCount >= totalBlocks) {
+				result.push({
+					shiftTypeId,
+					...data,
+					totalSelectedBlocks: totalBlocks,
+				});
+			}
+		}
+
+		return result.sort((a, b) =>
+			a.shiftTypeName.localeCompare(b.shiftTypeName),
+		);
+	}, [selectedBlocks, blocks]);
+
+	// Format selected blocks for display
+	const selectedBlockDetails = useMemo(() => {
+		return Array.from(selectedBlocks)
+			.map((key) => {
+				const [dayStr, timeStr] = key.split("-");
+				const dayOfWeek = Number.parseInt(dayStr, 10);
+				const timeBlock = Number.parseInt(timeStr, 10);
+				const day = DAYS_OF_WEEK.find((d) => d.value === dayOfWeek);
+				return {
+					key,
+					dayOfWeek,
+					timeBlock,
+					dayLabel: day?.short ?? `Day ${dayOfWeek}`,
+					timeLabel: formatCompactTime(timeBlock),
+				};
+			})
+			.sort((a, b) => {
+				if (a.dayOfWeek !== b.dayOfWeek) return a.dayOfWeek - b.dayOfWeek;
+				return a.timeBlock - b.timeBlock;
+			});
+	}, [selectedBlocks]);
+
+	const handleBulkRegister = (scheduleIds: number[]) => {
+		bulkRegisterMutation.mutate(scheduleIds, {
+			onSuccess: () => {
+				onClearSelection();
+			},
+		});
+	};
+
+	if (selectedBlocks.size === 0) {
+		return (
+			<div className="flex h-full flex-col">
+				<div className="border-b bg-card p-4">
+					<div className="flex items-center justify-between">
+						<h3 className="text-lg font-semibold">Bulk Registration</h3>
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={onExitBulkMode}
+							className="h-8 w-8"
+						>
+							<X className="h-4 w-4" />
+							<span className="sr-only">Exit bulk mode</span>
+						</Button>
+					</div>
+				</div>
+				<div className="flex h-full items-center justify-center p-8 text-center text-muted-foreground">
+					<div>
+						<CalendarDays className="mx-auto mb-3 h-10 w-10 opacity-50" />
+						<p className="text-sm">
+							Click time slots on the grid to select them
+						</p>
+						<p className="text-xs text-muted-foreground mt-1">
+							Click a slot again to deselect it
+						</p>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* Header */}
+			<div className="border-b bg-card p-4">
+				<div className="flex items-center justify-between mb-2">
+					<h3 className="text-lg font-semibold">Bulk Registration</h3>
+					<Button
+						variant="ghost"
+						size="icon"
+						onClick={onExitBulkMode}
+						className="h-8 w-8"
+					>
+						<X className="h-4 w-4" />
+						<span className="sr-only">Exit bulk mode</span>
+					</Button>
+				</div>
+				<p className="text-sm text-muted-foreground">
+					{selectedBlocks.size} slot{selectedBlocks.size !== 1 ? "s" : ""}{" "}
+					selected
+				</p>
+			</div>
+
+			{/* Selected blocks summary */}
+			<div className="border-b px-4 py-3">
+				<div className="flex items-center justify-between mb-2">
+					<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+						Selected Slots
+					</span>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={onClearSelection}
+						className="h-6 px-2 text-xs"
+					>
+						Clear all
+					</Button>
+				</div>
+				<div className="flex flex-wrap gap-1.5">
+					{selectedBlockDetails.map((block) => (
+						<Badge
+							key={block.key}
+							variant="secondary"
+							className="text-xs gap-1"
+						>
+							{block.dayLabel} {block.timeLabel}
+						</Badge>
+					))}
+				</div>
+			</div>
+
+			{/* Eligible shift types */}
+			<div className="flex-1 overflow-y-auto p-4 pb-24">
+				{!isWithinSignupWindow ? (
+					<div className="flex flex-col items-center justify-center text-center py-8">
+						<Info className="h-8 w-8 text-muted-foreground/50 mb-3" />
+						<p className="text-sm text-muted-foreground">
+							Registration is not currently open
+						</p>
+					</div>
+				) : bulkShiftTypes.length === 0 ? (
+					<div className="flex flex-col items-center justify-center text-center py-8">
+						<CalendarCheck className="h-8 w-8 text-muted-foreground/50 mb-3" />
+						<p className="text-sm font-medium mb-1">No shift types available</p>
+						<p className="text-xs text-muted-foreground">
+							No shift type has open, registerable slots at all selected time
+							slots. Try selecting fewer or different slots.
+						</p>
+					</div>
+				) : (
+					<div className="space-y-3">
+						<p className="text-xs text-muted-foreground">
+							These shift types have open slots at all selected time slots.
+							Register to sign up for all of them at once.
+						</p>
+						{bulkShiftTypes.map((shiftType) => (
+							<BulkShiftTypeCard
+								key={shiftType.shiftTypeId}
+								shiftType={shiftType}
+								isPending={bulkRegisterMutation.isPending}
+								onRegister={() => handleBulkRegister(shiftType.scheduleIds)}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function BulkShiftTypeCard({
+	shiftType,
+	isPending,
+	onRegister,
+}: {
+	shiftType: BulkShiftType;
+	isPending: boolean;
+	onRegister: () => void;
+}) {
+	return (
+		<div className="rounded-xl border-2 border-green-500/50 bg-green-50/50 dark:bg-green-950/20 p-4 transition-all">
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0 flex-1">
+					<div className="mb-2 flex items-center gap-2">
+						{shiftType.shiftTypeColor && (
+							<div
+								className="h-3 w-3 rounded-full shadow-sm ring-2 ring-white dark:ring-gray-800"
+								style={{ backgroundColor: shiftType.shiftTypeColor }}
+							/>
+						)}
+						<h4 className="truncate font-semibold">
+							{shiftType.shiftTypeName}
+						</h4>
+					</div>
+
+					<div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+						<span className="flex items-center gap-1">
+							<MapPin className="h-3.5 w-3.5" />
+							{shiftType.shiftTypeLocation}
+						</span>
+						<span className="flex items-center gap-1">
+							<CalendarCheck className="h-3.5 w-3.5" />
+							{shiftType.scheduleIds.length} shift
+							{shiftType.scheduleIds.length !== 1 ? "s" : ""}
+						</span>
+					</div>
+				</div>
+
+				<Button
+					size="sm"
+					onClick={onRegister}
+					disabled={isPending}
+					className="rounded-lg bg-green-600 text-white hover:bg-green-700 shrink-0"
+				>
+					{isPending ? (
+						<Spinner className="h-4 w-4" />
+					) : (
+						<>
+							Register
+							<Badge
+								variant="secondary"
+								className="ml-1.5 h-5 min-w-5 p-0 flex items-center justify-center text-[10px] bg-white/20 text-white"
+							>
+								{shiftType.scheduleIds.length}
+							</Badge>
+						</>
+					)}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Empty state for the bulk sidebar before bulk mode is activated.
+ */
+export function BulkRegistrationSidebarEmpty() {
+	return (
+		<div className="flex h-full items-center justify-center p-8 text-center text-muted-foreground">
+			<div>
+				<CalendarDays className="mx-auto mb-3 h-10 w-10 opacity-50" />
+				<p className="text-sm">Select a time slot to view details</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/client/src/components/shift-schedules/full-page-scheduler.tsx
+++ b/apps/client/src/components/shift-schedules/full-page-scheduler.tsx
@@ -1,6 +1,6 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { CalendarDays, ChevronLeft, Filter } from "lucide-react";
-import { useMemo, useState } from "react";
+import { CalendarDays, ChevronLeft, Filter, Layers } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogPortal } from "@/components/ui/dialog";
@@ -19,8 +19,14 @@ import {
 	ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { Spinner } from "@/components/ui/spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
+import { BulkRegistrationSidebar } from "./bulk-registration-sidebar";
 import type { ConnectionState } from "./connection-status";
 import { ConnectionStatus } from "./connection-status";
 import {
@@ -37,6 +43,7 @@ import {
 	type RequirementProgress,
 	type ShiftSchedule,
 } from "./shift-scheduler-utils";
+import { useShiftMutations } from "./use-shift-mutations";
 
 interface FullPageSchedulerProps {
 	open: boolean;
@@ -51,9 +58,15 @@ interface FullPageSchedulerProps {
 }
 
 // Legend Component
-function SchedulerLegend() {
+function SchedulerLegend({ bulkMode }: { bulkMode: boolean }) {
 	return (
 		<div className="flex flex-wrap items-center gap-4 text-xs">
+			{bulkMode && (
+				<div className="flex items-center gap-1.5">
+					<div className="w-3 h-3 rounded border-2 border-primary bg-primary/15" />
+					<span>Selected</span>
+				</div>
+			)}
 			<div className="flex items-center gap-1.5">
 				<div className="w-3 h-3 rounded bg-primary" />
 				<span>Registered</span>
@@ -95,7 +108,53 @@ export function FullPageScheduler({
 	);
 	const [showOnlyAvailable, setShowOnlyAvailable] = useState(false);
 	const [showOnlyRegistered, setShowOnlyRegistered] = useState(false);
+	const [bulkMode, setBulkMode] = useState(false);
+	const [selectedBlocks, setSelectedBlocks] = useState<Set<string>>(new Set());
 	const isMobile = useIsMobile();
+	const { bulkRegisterMutation } = useShiftMutations(periodId);
+
+	// Bulk mode handlers
+	const handleToggleBulkMode = useCallback((enabled: boolean) => {
+		setBulkMode(enabled);
+		if (!enabled) {
+			setSelectedBlocks(new Set());
+		}
+		// Clear single-select when entering bulk mode
+		if (enabled) {
+			setSelectedBlock(null);
+		}
+	}, []);
+
+	const handleToggleBulkBlock = useCallback(
+		(dayOfWeek: number, timeBlock: number) => {
+			const key = `${dayOfWeek}-${timeBlock}`;
+			setSelectedBlocks((prev) => {
+				const next = new Set(prev);
+				if (next.has(key)) {
+					next.delete(key);
+				} else {
+					next.add(key);
+				}
+				return next;
+			});
+		},
+		[],
+	);
+
+	const handleShiftClick = useCallback(
+		(dayOfWeek: number, timeBlock: number) => {
+			// Shift-click activates bulk mode and selects the clicked block
+			setBulkMode(true);
+			setSelectedBlock(null);
+			const key = `${dayOfWeek}-${timeBlock}`;
+			setSelectedBlocks(new Set([key]));
+		},
+		[],
+	);
+
+	const handleClearSelection = useCallback(() => {
+		setSelectedBlocks(new Set());
+	}, []);
 
 	// Get unique shift types for filter
 	const shiftTypes = useMemo(() => {
@@ -224,6 +283,38 @@ export function FullPageScheduler({
 										state={connectionState}
 										onReconnect={onReconnect}
 									/>
+
+									{/* Bulk mode toggle */}
+									{!isMobile && (
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Button
+													variant={bulkMode ? "default" : "outline"}
+													size="sm"
+													className="gap-1.5"
+													onClick={() => handleToggleBulkMode(!bulkMode)}
+												>
+													<Layers className="h-4 w-4" />
+													<span className="hidden sm:inline">Bulk</span>
+													{bulkMode && selectedBlocks.size > 0 && (
+														<Badge
+															variant="secondary"
+															className="ml-1 h-5 w-5 p-0 flex items-center justify-center text-[10px]"
+														>
+															{selectedBlocks.size}
+														</Badge>
+													)}
+												</Button>
+											</TooltipTrigger>
+											<TooltipContent>
+												<p>
+													{bulkMode
+														? "Exit bulk registration mode"
+														: "Enable bulk registration mode (or Shift+Click any slot)"}
+												</p>
+											</TooltipContent>
+										</Tooltip>
+									)}
 
 									{/* Filter button */}
 									<DropdownMenu open={filterOpen} onOpenChange={setFilterOpen}>
@@ -385,7 +476,7 @@ export function FullPageScheduler({
 											<>
 												{/* Legend */}
 												<div className="shrink-0 px-4 py-2 border-b bg-muted/30">
-													<SchedulerLegend />
+													<SchedulerLegend bulkMode={false} />
 												</div>
 
 												{/* Scrollable Grid */}
@@ -397,6 +488,10 @@ export function FullPageScheduler({
 													onSelectBlock={(dayOfWeek, timeBlock) =>
 														setSelectedBlock({ dayOfWeek, timeBlock })
 													}
+													bulkMode={false}
+													selectedBlocks={selectedBlocks}
+													onToggleBulkBlock={handleToggleBulkBlock}
+													onShiftClick={handleShiftClick}
 												/>
 											</>
 										)}
@@ -452,7 +547,7 @@ export function FullPageScheduler({
 												<>
 													{/* Legend */}
 													<div className="shrink-0 px-4 py-2 border-b bg-muted/30">
-														<SchedulerLegend />
+														<SchedulerLegend bulkMode={bulkMode} />
 													</div>
 
 													{/* Scrollable Grid */}
@@ -464,6 +559,10 @@ export function FullPageScheduler({
 														onSelectBlock={(dayOfWeek, timeBlock) =>
 															setSelectedBlock({ dayOfWeek, timeBlock })
 														}
+														bulkMode={bulkMode}
+														selectedBlocks={selectedBlocks}
+														onToggleBulkBlock={handleToggleBulkBlock}
+														onShiftClick={handleShiftClick}
 													/>
 												</>
 											)}
@@ -478,7 +577,16 @@ export function FullPageScheduler({
 										maxSize={1000}
 									>
 										<aside className="h-full bg-card flex flex-col overflow-hidden">
-											{selectedBlock ? (
+											{bulkMode ? (
+												<BulkRegistrationSidebar
+													selectedBlocks={selectedBlocks}
+													blocks={blocks}
+													isWithinSignupWindow={isWithinSignupWindow}
+													bulkRegisterMutation={bulkRegisterMutation}
+													onClearSelection={handleClearSelection}
+													onExitBulkMode={() => handleToggleBulkMode(false)}
+												/>
+											) : selectedBlock ? (
 												<DesktopShiftSidebar
 													schedules={selectedBlockSchedules}
 													dayOfWeek={selectedBlock.dayOfWeek}

--- a/apps/client/src/components/shift-schedules/full-page-scheduler.tsx
+++ b/apps/client/src/components/shift-schedules/full-page-scheduler.tsx
@@ -111,7 +111,8 @@ export function FullPageScheduler({
 	const [bulkMode, setBulkMode] = useState(false);
 	const [selectedBlocks, setSelectedBlocks] = useState<Set<string>>(new Set());
 	const isMobile = useIsMobile();
-	const { bulkRegisterMutation } = useShiftMutations(periodId);
+	const { registerMutation, bulkRegisterMutation } =
+		useShiftMutations(periodId);
 
 	// Bulk mode handlers
 	const handleToggleBulkMode = useCallback((enabled: boolean) => {
@@ -192,6 +193,31 @@ export function FullPageScheduler({
 	const blocks = useMemo(
 		() => groupSchedulesByDayAndTimeBlock(filteredSchedules, blockSize),
 		[filteredSchedules, blockSize],
+	);
+
+	// Double-click: auto-register if exactly one registerable shift type in the slot
+	const handleDoubleClick = useCallback(
+		(dayOfWeek: number, timeBlock: number) => {
+			if (!isWithinSignupWindow || registerMutation.isPending) return;
+
+			const key = `${dayOfWeek}-${timeBlock}`;
+			const blockData = blocks.get(key);
+			if (!blockData) return;
+
+			// Find schedules the user can register for and isn't already registered
+			const registerable = blockData.schedules.filter(
+				(s) => s.canRegister && s.availableSlots > 0 && !s.isRegistered,
+			);
+			if (registerable.length === 0) return;
+
+			// Check if all registerable schedules belong to the same shift type
+			const uniqueShiftTypes = new Set(registerable.map((s) => s.shiftTypeId));
+			if (uniqueShiftTypes.size !== 1) return;
+
+			// Auto-register for the first available schedule of that shift type
+			registerMutation.mutate(registerable[0].id);
+		},
+		[blocks, isWithinSignupWindow, registerMutation],
 	);
 
 	// Determine visible days
@@ -492,6 +518,7 @@ export function FullPageScheduler({
 													selectedBlocks={selectedBlocks}
 													onToggleBulkBlock={handleToggleBulkBlock}
 													onShiftClick={handleShiftClick}
+													onDoubleClick={handleDoubleClick}
 												/>
 											</>
 										)}
@@ -563,6 +590,7 @@ export function FullPageScheduler({
 														selectedBlocks={selectedBlocks}
 														onToggleBulkBlock={handleToggleBulkBlock}
 														onShiftClick={handleShiftClick}
+														onDoubleClick={handleDoubleClick}
 													/>
 												</>
 											)}

--- a/apps/client/src/components/shift-schedules/schedule-delta-utils.ts
+++ b/apps/client/src/components/shift-schedules/schedule-delta-utils.ts
@@ -462,3 +462,20 @@ export function applyOptimisticUnregister(
 
 	return applyScheduleDelta(currentData, optimisticEvent, currentUser.id);
 }
+
+/**
+ * Apply optimistic updates for bulk registration.
+ * Applies each registration sequentially so overlap/balancing/max checks
+ * are correctly accumulated.
+ */
+export function applyOptimisticBulkRegister(
+	currentData: SchedulesData,
+	shiftScheduleIds: number[],
+	currentUser: DeltaUser,
+): SchedulesData {
+	let data = currentData;
+	for (const shiftScheduleId of shiftScheduleIds) {
+		data = applyOptimisticRegister(data, shiftScheduleId, currentUser);
+	}
+	return data;
+}

--- a/apps/client/src/components/shift-schedules/scheduler-grid.tsx
+++ b/apps/client/src/components/shift-schedules/scheduler-grid.tsx
@@ -13,6 +13,7 @@ interface SchedulerGridProps {
 	selectedBlocks: Set<string>;
 	onToggleBulkBlock: (dayOfWeek: number, timeBlock: number) => void;
 	onShiftClick: (dayOfWeek: number, timeBlock: number) => void;
+	onDoubleClick?: (dayOfWeek: number, timeBlock: number) => void;
 }
 
 /**
@@ -135,6 +136,7 @@ export function SchedulerGrid({
 	selectedBlocks,
 	onToggleBulkBlock,
 	onShiftClick,
+	onDoubleClick,
 }: SchedulerGridProps) {
 	const isDarkMode = useIsDarkMode();
 
@@ -241,11 +243,18 @@ export function SchedulerGrid({
 										}
 									};
 
+									const handleDoubleClick = () => {
+										if (!bulkMode && onDoubleClick) {
+											onDoubleClick(day.value, blockStart);
+										}
+									};
+
 									return (
 										<td key={key} className="p-1">
 											<button
 												type="button"
 												onClick={handleClick}
+												onDoubleClick={handleDoubleClick}
 												aria-label={
 													bulkMode
 														? isBulkSelected

--- a/apps/client/src/components/shift-schedules/scheduler-grid.tsx
+++ b/apps/client/src/components/shift-schedules/scheduler-grid.tsx
@@ -9,6 +9,10 @@ interface SchedulerGridProps {
 	blocks: Map<string, TimeBlock>;
 	selectedBlock: { dayOfWeek: number; timeBlock: number } | null;
 	onSelectBlock: (dayOfWeek: number, timeBlock: number) => void;
+	bulkMode: boolean;
+	selectedBlocks: Set<string>;
+	onToggleBulkBlock: (dayOfWeek: number, timeBlock: number) => void;
+	onShiftClick: (dayOfWeek: number, timeBlock: number) => void;
 }
 
 /**
@@ -127,6 +131,10 @@ export function SchedulerGrid({
 	blocks,
 	selectedBlock,
 	onSelectBlock,
+	bulkMode,
+	selectedBlocks,
+	onToggleBulkBlock,
+	onShiftClick,
 }: SchedulerGridProps) {
 	const isDarkMode = useIsDarkMode();
 
@@ -194,6 +202,7 @@ export function SchedulerGrid({
 									const isSelected =
 										selectedBlock?.dayOfWeek === day.value &&
 										selectedBlock?.timeBlock === blockStart;
+									const isBulkSelected = selectedBlocks.has(key);
 
 									// Check if all schedules are truly full (no available slots)
 									const isTrulyFull = blockData.schedules.every(
@@ -219,40 +228,75 @@ export function SchedulerGrid({
 												s.hasTimeOverlap,
 										);
 
+									const handleClick = (e: React.MouseEvent) => {
+										if (e.shiftKey && !bulkMode) {
+											// Shift-click activates bulk mode and selects this block
+											onShiftClick(day.value, blockStart);
+											return;
+										}
+										if (bulkMode) {
+											onToggleBulkBlock(day.value, blockStart);
+										} else {
+											onSelectBlock(day.value, blockStart);
+										}
+									};
+
 									return (
 										<td key={key} className="p-1">
 											<button
 												type="button"
-												onClick={() => onSelectBlock(day.value, blockStart)}
+												onClick={handleClick}
 												aria-label={
-													isRegistered
-														? "You are registered for this shift"
-														: hasAvailable
-															? availabilityStyles.ariaLabel
-															: isTrulyFull
-																? "This shift is full"
-																: "This shift is unavailable due to restrictions"
+													bulkMode
+														? isBulkSelected
+															? "Selected for bulk registration. Click to deselect."
+															: "Click to select for bulk registration"
+														: isRegistered
+															? "You are registered for this shift"
+															: hasAvailable
+																? availabilityStyles.ariaLabel
+																: isTrulyFull
+																	? "This shift is full"
+																	: "This shift is unavailable due to restrictions"
 												}
-												aria-pressed={isSelected}
+												aria-pressed={bulkMode ? isBulkSelected : isSelected}
 												className={cn(
 													"w-full h-12 rounded-lg border-2 transition-all flex items-center justify-center gap-2 px-2 active:scale-[0.98]",
-													isSelected && "ring-2 ring-offset-2 ring-primary",
-													isRegistered
+													!bulkMode &&
+														isSelected &&
+														"ring-2 ring-offset-2 ring-primary",
+													bulkMode &&
+														isBulkSelected &&
+														"ring-2 ring-offset-2 ring-primary border-primary bg-primary/15 dark:bg-primary/25",
+													bulkMode &&
+														!isBulkSelected &&
+														"opacity-80 hover:opacity-100",
+													!bulkMode && isRegistered
 														? "border-primary bg-primary text-primary-foreground hover:scale-[1.02]"
-														: hasAvailable
+														: !bulkMode && hasAvailable
 															? availabilityStyles.className
-															: hasRestrictions
+															: !bulkMode && hasRestrictions
 																? "border-amber-500/40 bg-amber-50 dark:bg-amber-950/20 text-amber-700 dark:text-amber-400 hover:scale-[1.02]"
-																: availabilityStyles.className,
+																: !bulkMode
+																	? availabilityStyles.className
+																	: undefined,
 												)}
 												style={
+													!bulkMode &&
 													!isRegistered &&
 													(hasAvailable || (!hasRestrictions && isTrulyFull))
 														? availabilityStyles.style
 														: undefined
 												}
 											>
-												{isRegistered ? (
+												{bulkMode && isBulkSelected ? (
+													<span
+														className="text-lg font-bold text-primary"
+														aria-hidden="true"
+													>
+														✓
+													</span>
+												) : isRegistered && !bulkMode ? (
 													<span
 														className="text-lg font-bold"
 														aria-hidden="true"

--- a/apps/client/src/components/shift-schedules/use-shift-mutations.ts
+++ b/apps/client/src/components/shift-schedules/use-shift-mutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useAuth } from "@/auth/AuthProvider";
 import {
+	applyOptimisticBulkRegister,
 	applyOptimisticRegister,
 	applyOptimisticUnregister,
 	type SchedulesData,
@@ -105,5 +106,38 @@ export function useShiftMutations(periodId: number) {
 		},
 	});
 
-	return { registerMutation, unregisterMutation };
+	const bulkRegisterMutation = useMutation({
+		mutationFn: async (shiftScheduleIds: number[]) => {
+			return trpc.shiftSchedules.bulkRegister.mutate({ shiftScheduleIds });
+		},
+		onMutate: async (shiftScheduleIds) => {
+			await queryClient.cancelQueries({ queryKey });
+
+			const previousData = queryClient.getQueryData<SchedulesData>(queryKey);
+
+			if (previousData && user) {
+				const optimisticData = applyOptimisticBulkRegister(
+					previousData,
+					shiftScheduleIds,
+					{ id: user.id, name: user.name ?? "Unknown" },
+				);
+				queryClient.setQueryData(queryKey, optimisticData);
+			}
+
+			return { previousData };
+		},
+		onError: (error, _shiftScheduleIds, context) => {
+			if (context?.previousData) {
+				queryClient.setQueryData(queryKey, context.previousData);
+			}
+			toast.error(error.message || "Failed to register for shifts");
+		},
+		onSuccess: (_data, shiftScheduleIds) => {
+			toast.success(
+				`Successfully registered for ${shiftScheduleIds.length} shift${shiftScheduleIds.length !== 1 ? "s" : ""}!`,
+			);
+		},
+	});
+
+	return { registerMutation, unregisterMutation, bulkRegisterMutation };
 }

--- a/packages/trpc/server/routers/shiftSchedules/_route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/_route.ts
@@ -5,6 +5,7 @@ import {
 } from "../../trpc";
 import { bulkCreateHandler, ZBulkCreateSchema } from "./bulkCreate.route";
 import { bulkDeleteHandler, ZBulkDeleteSchema } from "./bulkDelete.route";
+import { bulkRegisterHandler, ZBulkRegisterSchema } from "./bulkRegister.route";
 import { createHandler, ZCreateSchema } from "./create.route";
 import { deleteHandler, ZDeleteSchema } from "./delete.route";
 import {
@@ -100,6 +101,9 @@ export const shiftSchedulesRouter = router({
 		.input(ZForceUnregisterSchema)
 		.mutation(forceUnregisterHandler),
 	register: protectedProcedure.input(ZRegisterSchema).mutation(registerHandler),
+	bulkRegister: protectedProcedure
+		.input(ZBulkRegisterSchema)
+		.mutation(bulkRegisterHandler),
 	unregister: protectedProcedure
 		.input(ZUnregisterSchema)
 		.mutation(unregisterHandler),

--- a/packages/trpc/server/routers/shiftSchedules/bulkRegister.route.ts
+++ b/packages/trpc/server/routers/shiftSchedules/bulkRegister.route.ts
@@ -1,0 +1,365 @@
+import {
+	assertCanAccessPeriod,
+	assignUserToScheduleOccurrences,
+	calculateRequirementComparableValue,
+	convertRequirementThresholdToComparable,
+	getAllSchedulesForBalancing,
+	getShiftDurationMinutes,
+	getShiftScheduleForRegistration,
+	getUserRegisteredSchedules,
+	getUserWithRoles,
+	lockShiftSchedule,
+	type ShiftScheduleUser,
+	shiftScheduleEvents,
+	validateBalancingRequirement,
+	validateNoTimeOverlap,
+	validateRoleRequirement,
+} from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import z from "zod";
+import type { TProtectedProcedureContext } from "../../trpc";
+
+export const ZBulkRegisterSchema = z.object({
+	shiftScheduleIds: z
+		.array(z.number().min(1))
+		.min(1, "At least one shift schedule is required")
+		.max(50, "Cannot register for more than 50 shifts at once"),
+});
+
+export type TBulkRegisterSchema = z.infer<typeof ZBulkRegisterSchema>;
+
+export type TBulkRegisterOptions = {
+	ctx: TProtectedProcedureContext;
+	input: TBulkRegisterSchema;
+};
+
+interface BulkRegisterDelta {
+	shiftScheduleId: number;
+	periodId: number;
+	user: ShiftScheduleUser;
+	availableSlots: number;
+	totalSlots: number;
+	users: ShiftScheduleUser[];
+}
+
+export async function bulkRegisterHandler(options: TBulkRegisterOptions) {
+	const { shiftScheduleIds } = options.input;
+	const userId = options.ctx.user.id;
+
+	// Deduplicate IDs
+	const uniqueIds = Array.from(new Set(shiftScheduleIds));
+
+	// Store data needed for event emission after transaction
+	const deltas: BulkRegisterDelta[] = [];
+	const errors: Array<{ shiftScheduleId: number; message: string }> = [];
+
+	await prisma.$transaction(async (tx) => {
+		// Lock all schedules first (in sorted order to prevent deadlocks)
+		const sortedIds = [...uniqueIds].sort((a, b) => a - b);
+		for (const id of sortedIds) {
+			const isLocked = await lockShiftSchedule(tx, id);
+			if (!isLocked) {
+				errors.push({
+					shiftScheduleId: id,
+					message: "Shift schedule not found",
+				});
+			}
+		}
+
+		// If any schedules couldn't be locked, throw
+		if (errors.length > 0) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: `Some shift schedules were not found: ${errors.map((e) => e.shiftScheduleId).join(", ")}`,
+			});
+		}
+
+		// Get user with roles once
+		const user = await getUserWithRoles(tx, userId);
+		if (!user) {
+			throw new TRPCError({
+				code: "UNAUTHORIZED",
+				message: "User not found",
+			});
+		}
+		const userRoleIds = new Set(user.roles.map((r) => r.id));
+
+		// Load all target schedules
+		const targetSchedules = await Promise.all(
+			sortedIds.map((id) => getShiftScheduleForRegistration(tx, id)),
+		);
+
+		// Validate all schedules exist and narrow types
+		const validatedSchedules = targetSchedules.filter(
+			(s): s is NonNullable<typeof s> => {
+				if (!s) return false;
+				return true;
+			},
+		);
+
+		if (validatedSchedules.length !== sortedIds.length) {
+			const missingIds = sortedIds.filter((_id, i) => !targetSchedules[i]);
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: `Shift schedule(s) not found: ${missingIds.join(", ")}`,
+			});
+		}
+
+		// Verify all schedules belong to the same period
+		const periodIds = new Set(
+			validatedSchedules.map((s) => s.shiftType.periodId),
+		);
+		if (periodIds.size > 1) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message:
+					"All shift schedules must belong to the same period for bulk registration",
+			});
+		}
+
+		const firstSchedule = validatedSchedules[0];
+		if (!firstSchedule) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "No valid shift schedules provided",
+			});
+		}
+		const periodId = firstSchedule.shiftType.periodId;
+
+		// Get the period to check time windows
+		const period = await tx.period.findUnique({
+			where: { id: periodId },
+			include: {
+				roles: {
+					select: { id: true },
+				},
+			},
+		});
+
+		if (!period) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "Period not found",
+			});
+		}
+
+		// Check period access
+		assertCanAccessPeriod(period, userRoleIds, {
+			isSystemUser: options.ctx.user.isSystemUser,
+		});
+
+		// Check if we're within the schedule signup window
+		const now = new Date();
+		const nowTime = now.getTime();
+		const isWithinSignupWindow =
+			period.scheduleSignupStart.getTime() <= nowTime &&
+			period.scheduleSignupEnd.getTime() >= nowTime;
+
+		if (!isWithinSignupWindow) {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message:
+					"Shift registration is not currently allowed. Please check the signup window for this period.",
+			});
+		}
+
+		// Get user's current registered schedules (will grow as we register)
+		const userSchedules = await getUserRegisteredSchedules(tx, userId);
+		const userSchedulesInPeriod = userSchedules.filter(
+			(s) => s.shiftType?.periodId === periodId,
+		);
+		const schedulesForOverlap = userSchedules.map(
+			({ shiftType, ...rest }) => rest,
+		);
+
+		// Get all schedules for balancing checks
+		const allSchedulesForBalancing = await getAllSchedulesForBalancing(tx);
+
+		// Calculate current requirement progress
+		let currentComparable = 0;
+		const unit = period.minMaxUnit;
+		const maxThreshold =
+			period.max !== null && period.max !== undefined && unit
+				? convertRequirementThresholdToComparable(period.max, unit)
+				: null;
+
+		if (unit) {
+			currentComparable = calculateRequirementComparableValue(
+				userSchedulesInPeriod,
+				unit,
+			);
+		}
+
+		// Validate and register each schedule sequentially
+		// Order matters because each registration affects overlap/balancing/max checks
+		for (const schedule of validatedSchedules) {
+			// Check if canSelfAssign is allowed
+			if (!schedule.shiftType.canSelfAssign) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: `Self-assignment is not allowed for "${schedule.shiftType.name}". An administrator must assign you.`,
+				});
+			}
+
+			// Check if user already registered
+			if (schedule.users.some((u) => u.id === userId)) {
+				// Skip silently - user is already registered for this schedule
+				continue;
+			}
+
+			// Check if there are available slots
+			if (schedule.users.length >= schedule.slots) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `All slots for "${schedule.shiftType.name}" on ${getDayName(schedule.dayOfWeek)} at ${schedule.startTime} are filled`,
+				});
+			}
+
+			// Validate role requirements
+			try {
+				validateRoleRequirement(schedule.shiftType, userRoleIds);
+			} catch (error) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message:
+						error instanceof Error ? error.message : "Role requirement not met",
+				});
+			}
+
+			// Check balancing restrictions
+			if (
+				schedule.shiftType.isBalancedAcrossPeriod ||
+				schedule.shiftType.isBalancedAcrossDay ||
+				schedule.shiftType.isBalancedAcrossOverlap
+			) {
+				try {
+					validateBalancingRequirement(schedule, allSchedulesForBalancing);
+				} catch (error) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message:
+							error instanceof Error
+								? error.message
+								: "Balancing requirement not met",
+					});
+				}
+			}
+
+			// Validate no time overlap with existing registrations
+			try {
+				validateNoTimeOverlap(schedule, schedulesForOverlap);
+			} catch (error) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message:
+						error instanceof Error ? error.message : "Time overlap detected",
+				});
+			}
+
+			// Enforce period maximum requirement if configured
+			if (maxThreshold !== null && unit) {
+				const addedComparable =
+					unit === "count"
+						? 1
+						: getShiftDurationMinutes(schedule.startTime, schedule.endTime);
+
+				if (currentComparable + addedComparable > maxThreshold) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message:
+							"You would exceed the maximum allowed shift registrations for this period.",
+					});
+				}
+
+				// Update running total for next iteration
+				currentComparable += addedComparable;
+			}
+
+			// Register the user
+			const updatedSchedule = await tx.shiftSchedule.update({
+				where: { id: schedule.id },
+				data: {
+					users: {
+						connect: { id: userId },
+					},
+				},
+				select: {
+					slots: true,
+					users: {
+						select: { id: true, name: true },
+					},
+				},
+			});
+
+			// Assign user to all occurrences
+			await assignUserToScheduleOccurrences(tx, schedule.id, userId);
+
+			// Track this registration for overlap checks in subsequent iterations
+			schedulesForOverlap.push({
+				id: schedule.id,
+				dayOfWeek: schedule.dayOfWeek,
+				startTime: schedule.startTime,
+				endTime: schedule.endTime,
+			});
+
+			// Update balancing data for subsequent iterations
+			const balancingIdx = allSchedulesForBalancing.findIndex(
+				(s) => s.id === schedule.id,
+			);
+			if (balancingIdx !== -1) {
+				allSchedulesForBalancing[balancingIdx] = {
+					...allSchedulesForBalancing[balancingIdx],
+					users: updatedSchedule.users,
+				};
+			}
+
+			// Collect delta for event emission
+			deltas.push({
+				shiftScheduleId: schedule.id,
+				periodId,
+				user: { id: user.id, name: user.name },
+				availableSlots: updatedSchedule.slots - updatedSchedule.users.length,
+				totalSlots: updatedSchedule.slots,
+				users: updatedSchedule.users,
+			});
+		}
+	});
+
+	// Emit events for real-time updates (after transaction commits)
+	for (const delta of deltas) {
+		shiftScheduleEvents.emitUpdate({
+			type: "register",
+			shiftScheduleId: delta.shiftScheduleId,
+			userId,
+			periodId: delta.periodId,
+			timestamp: new Date(),
+			delta: {
+				user: delta.user,
+				availableSlots: delta.availableSlots,
+				totalSlots: delta.totalSlots,
+				users: delta.users,
+			},
+		});
+	}
+
+	return {
+		success: true,
+		registeredCount: deltas.length,
+		registeredIds: deltas.map((d) => d.shiftScheduleId),
+	};
+}
+
+const DAY_NAMES = [
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+];
+
+function getDayName(dayOfWeek: number): string {
+	return DAY_NAMES[dayOfWeek] ?? `Day ${dayOfWeek}`;
+}


### PR DESCRIPTION
This pull request adds support for bulk shift registration.

Bulk registration mode is activated by either selecting "Bulk" from the top right of the shift registration page, or by `shift`+clicking any time slot. Once in bulk mode, any time slot you select is added to the pool. The right sidebar will show all shift types which are open in all of your selected time slots. When you register on the sidebar, you are then registered for the chosen shift type at all selected time slots.

<img width="1512" height="858" alt="Screenshot 2026-02-23 at 16 30 44" src="https://github.com/user-attachments/assets/ae04651d-b35b-4366-8db2-9695cd08174c" />

Bulk mode does not work on mobile. It can be exited by clicking the "X" on the bulk sidebar or by clicking the "Bulk" button on the top right again.

