### PR TITLE
Format decimal hour values into hh:mm

### DIFF
--- a/apps/client/src/components/shift-management/user-shift-sections.tsx
+++ b/apps/client/src/components/shift-management/user-shift-sections.tsx
@@ -22,6 +22,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { formatDateInAppTimezone, formatTimeRange } from "@/lib/timezone";
+import { formatDecimalHours } from "@/lib/utils";
 
 const DAYS_OF_WEEK = [
 	"Sunday",
@@ -166,8 +167,8 @@ export function AttendanceStatsSummary({
 	stats: AttendanceStatsSnapshot;
 }) {
 	const coveragePercent = stats.attendanceCoveragePercent;
-	const scheduledHoursLabel = `${stats.totalScheduledHours.toFixed(1)}h`;
-	const actualHoursLabel = `${stats.totalActualHours.toFixed(1)}h`;
+	const scheduledHoursLabel = formatDecimalHours(stats.totalScheduledHours);
+	const actualHoursLabel = formatDecimalHours(stats.totalActualHours);
 
 	return (
 		<div className="space-y-3">
@@ -778,11 +779,11 @@ export function AttendanceSection({
 								const statusLabel = formatStatusLabel(record.status);
 								const scheduledDisplay =
 									typeof record.scheduledHours === "number"
-										? `${record.scheduledHours.toFixed(1)}h`
+										? formatDecimalHours(record.scheduledHours)
 										: "–";
 								const actualDisplay =
 									typeof record.actualHours === "number"
-										? `${record.actualHours.toFixed(1)}h`
+										? formatDecimalHours(record.actualHours)
 										: "–";
 								return (
 									<TableRow key={record.id}>

--- a/apps/client/src/lib/reports/utils.ts
+++ b/apps/client/src/lib/reports/utils.ts
@@ -1,8 +1,12 @@
 /**
- * Format a number as hours with 2 decimal places
+ * Format a decimal hour value into h:mm format.
+ * @param hours - Hours as a decimal number (e.g. 1.25)
+ * @returns Formatted string (e.g. "1:15")
  */
 export function formatHours(hours: number): string {
-	return `${hours.toFixed(2)} hrs`;
+	const h = Math.floor(hours);
+	const m = Math.round((hours - h) * 60);
+	return `${h}:${m.toString().padStart(2, "0")}`;
 }
 
 /**

--- a/apps/client/src/lib/utils.ts
+++ b/apps/client/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
+
+/**
+ * Format a decimal hour value into h:mm format.
+ * @param decimalHours - Hours as a decimal number (e.g. 1.25)
+ * @returns Formatted string (e.g. "1:15")
+ */
+export function formatDecimalHours(decimalHours: number): string {
+	const h = Math.floor(decimalHours);
+	const m = Math.round((decimalHours - h) * 60);
+	return `${h}:${m.toString().padStart(2, "0")}`;
+}

--- a/apps/client/src/routes/app/_app/index.tsx
+++ b/apps/client/src/routes/app/_app/index.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
+import { formatDecimalHours } from "@/lib/utils";
 
 export const Route = createFileRoute("/app/_app/")({
 	component: () =>
@@ -170,7 +171,7 @@ function AppIndexLayout() {
 						</CardHeader>
 						<CardContent>
 							<div className="text-2xl font-bold">
-								{sessionStats?.totalHours ?? 0}
+								{formatDecimalHours(sessionStats?.totalHours ?? 0)}
 							</div>
 							<p className="text-xs text-muted-foreground">hours logged</p>
 						</CardContent>
@@ -185,7 +186,7 @@ function AppIndexLayout() {
 						</CardHeader>
 						<CardContent>
 							<div className="text-2xl font-bold">
-								{sessionStats?.averageSessionHours ?? 0}
+								{formatDecimalHours(sessionStats?.averageSessionHours ?? 0)}
 							</div>
 							<p className="text-xs text-muted-foreground">hours per session</p>
 						</CardContent>

--- a/apps/client/src/routes/app/_app/me/sessions.tsx
+++ b/apps/client/src/routes/app/_app/me/sessions.tsx
@@ -37,6 +37,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { usePaginationInfo } from "@/hooks/use-pagination-info";
 import { useTableState } from "@/hooks/use-table-state";
+import { formatDecimalHours } from "@/lib/utils";
 
 export const Route = createFileRoute("/app/_app/me/sessions")({
 	component: () => RequireAuth({ children: <MySessionsPage /> }),
@@ -149,7 +150,7 @@ function MySessionsPage() {
 						</CardHeader>
 						<CardContent>
 							<div className="text-2xl font-bold">
-								{statsData?.totalHours ?? 0}
+								{formatDecimalHours(statsData?.totalHours ?? 0)}
 							</div>
 							<p className="text-xs text-muted-foreground">hours logged</p>
 						</CardContent>
@@ -164,7 +165,7 @@ function MySessionsPage() {
 						</CardHeader>
 						<CardContent>
 							<div className="text-2xl font-bold">
-								{statsData?.averageSessionHours ?? 0}
+								{formatDecimalHours(statsData?.averageSessionHours ?? 0)}
 							</div>
 							<p className="text-xs text-muted-foreground">hours per session</p>
 						</CardContent>

--- a/apps/client/src/routes/app/shifts/attendance.tsx
+++ b/apps/client/src/routes/app/shifts/attendance.tsx
@@ -30,6 +30,7 @@ import {
 import { usePaginationInfo } from "@/hooks/use-pagination-info";
 import { useTableState } from "@/hooks/use-table-state";
 import type { RequiredPermissions } from "@/lib/permissions";
+import { formatDecimalHours } from "@/lib/utils";
 
 export const Route = createFileRoute("/app/shifts/attendance")({
 	component: () => (
@@ -140,7 +141,7 @@ function AttendancePage() {
 								{statsData?.timeOnShiftPercentage ?? 0}%
 							</div>
 							<p className="text-xs text-muted-foreground">
-								{statsData?.totalHoursWorked ?? 0}h logged
+								{formatDecimalHours(statsData?.totalHoursWorked ?? 0)} logged
 							</p>
 						</CardContent>
 					</Card>

--- a/apps/client/src/routes/app/shifts/period-details.tsx
+++ b/apps/client/src/routes/app/shifts/period-details.tsx
@@ -22,6 +22,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { checkPermissions, type RequiredPermissions } from "@/lib/permissions";
 import { formatInAppTimezone } from "@/lib/timezone";
+import { formatDecimalHours } from "@/lib/utils";
 
 export const Route = createFileRoute("/app/shifts/period-details")({
 	component: () =>
@@ -263,7 +264,9 @@ function PeriodDetail() {
 									</div>
 									<div>
 										{period.min !== null
-											? `${period.min} ${unitLabel}`
+											? period.minMaxUnit === "hours"
+												? `${formatDecimalHours(period.min)} ${unitLabel}`
+												: `${period.min} ${unitLabel}`
 											: "Not set"}
 									</div>
 								</div>
@@ -273,7 +276,9 @@ function PeriodDetail() {
 									</div>
 									<div>
 										{period.max !== null
-											? `${period.max} ${unitLabel}`
+											? period.minMaxUnit === "hours"
+												? `${formatDecimalHours(period.max)} ${unitLabel}`
+												: `${period.max} ${unitLabel}`
 											: "Not set"}
 									</div>
 								</div>

--- a/apps/client/src/routes/app/shifts/scheduling.tsx
+++ b/apps/client/src/routes/app/shifts/scheduling.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/ui/table";
 import type { RequiredPermissions } from "@/lib/permissions";
 import { formatInAppTimezone, formatTimeRange } from "@/lib/timezone";
+import { formatDecimalHours } from "@/lib/utils";
 
 export const Route = createFileRoute("/app/shifts/scheduling")({
 	component: () => (
@@ -270,15 +271,21 @@ function Scheduling() {
 		? requirementUnitLabels[requirementUnit]
 		: null;
 	const requirementFormatter =
-		requirementUnit === null
+		requirementUnit === null || requirementUnit === "hours"
 			? null
 			: new Intl.NumberFormat(undefined, {
-					maximumFractionDigits: requirementUnit === "hours" ? 1 : 0,
+					maximumFractionDigits: 0,
 					minimumFractionDigits: 0,
 				});
 
 	const formatRequirementValue = (value: number | null | undefined) => {
-		if (value === null || value === undefined || !requirementFormatter) {
+		if (value === null || value === undefined) {
+			return null;
+		}
+		if (requirementUnit === "hours") {
+			return formatDecimalHours(value);
+		}
+		if (!requirementFormatter) {
 			return null;
 		}
 		return requirementFormatter.format(value);


### PR DESCRIPTION
This pull request updates various decimal hour values on the client to be rendered as `hh:mm` instead.