### PR TITLE
Add inventory item types support

### DIFF
--- a/apps/client/src/components/inventory/columns.tsx
+++ b/apps/client/src/components/inventory/columns.tsx
@@ -1,6 +1,6 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { EllipsisIcon, LinkIcon, LockIcon } from "lucide-react";
+import { CookieIcon, EllipsisIcon, LinkIcon, LockIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -48,12 +48,18 @@ export function generateColumns(): ColumnDef<ItemRow>[] {
 								<TooltipContent>Copy link to clipboard</TooltipContent>
 							</Tooltip>
 						) : null}
+						{row.isConsumable ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<CookieIcon className="h-4 w-4 text-muted-foreground" />
+								</TooltipTrigger>
+								<TooltipContent>Consumable item, no return needed</TooltipContent>
+							</Tooltip>
+						) : null}
 						{row.approvalRoles && row.approvalRoles.length > 0 ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<div className="flex items-center">
-										<LockIcon className="h-4 w-4 text-amber-500" />
-									</div>
+									<LockIcon className="h-4 w-4 text-amber-500" />
 								</TooltipTrigger>
 								<TooltipContent>
 									<div className="text-sm">

--- a/apps/client/src/components/inventory/columns.tsx
+++ b/apps/client/src/components/inventory/columns.tsx
@@ -1,6 +1,12 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { CookieIcon, EllipsisIcon, LinkIcon, LockIcon } from "lucide-react";
+import {
+	CookieIcon,
+	EllipsisIcon,
+	LinkIcon,
+	LockIcon,
+	PackageIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -48,12 +54,22 @@ export function generateColumns(): ColumnDef<ItemRow>[] {
 								<TooltipContent>Copy link to clipboard</TooltipContent>
 							</Tooltip>
 						) : null}
-						{row.isConsumable ? (
+						{row.itemType === "consumable" ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<CookieIcon className="h-4 w-4 text-muted-foreground" />
 								</TooltipTrigger>
-								<TooltipContent>Consumable item, no return needed</TooltipContent>
+								<TooltipContent>
+									Consumable item, no return needed
+								</TooltipContent>
+							</Tooltip>
+						) : null}
+						{row.itemType === "single" ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<PackageIcon className="h-4 w-4 text-muted-foreground" />
+								</TooltipTrigger>
+								<TooltipContent>Individual item</TooltipContent>
 							</Tooltip>
 						) : null}
 						{row.approvalRoles && row.approvalRoles.length > 0 ? (

--- a/apps/client/src/components/inventory/create-dialog.tsx
+++ b/apps/client/src/components/inventory/create-dialog.tsx
@@ -14,6 +14,13 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
 	Sheet,
 	SheetClose,
 	SheetContent,
@@ -34,7 +41,7 @@ const formSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url("Must be a valid URL").optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
-	isConsumable: z.boolean().optional(),
+	itemType: z.enum(["multiple", "single", "consumable"]).optional(),
 	initialQuantity: z.number().int().min(0).optional(),
 });
 
@@ -73,7 +80,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 		minQuantity?: number;
 		link?: string;
 		isActive?: boolean;
-		isConsumable?: boolean;
+		itemType?: "multiple" | "single" | "consumable";
 		initialQuantity?: number;
 		approvalRoleIds?: number[];
 	};
@@ -97,7 +104,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 			minQuantity: undefined,
 			link: "",
 			isActive: true,
-			isConsumable: false,
+			itemType: "multiple",
 			initialQuantity: undefined,
 		},
 		validators: {
@@ -145,9 +152,9 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 					link: "",
 					isActive: true,
 					initialQuantity: undefined,
+					itemType: "multiple",
 				});
 				setApprovalRoles([]);
-				setServerError(null);
 				return;
 			}
 
@@ -350,23 +357,33 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 						)}
 					</form.Field>
 
-					<form.Field name="isConsumable">
+					<form.Field name="itemType">
 						{(field) => (
 							<Field>
-								<div className="flex items-center space-x-2">
-									<Checkbox
-										id={field.name}
-										checked={field.state.value}
-										onCheckedChange={(checked) => field.handleChange(!!checked)}
-										onBlur={field.handleBlur}
-									/>
-									<FieldLabel htmlFor={field.name} className="!mt-0">
-										Consumable
-									</FieldLabel>
-								</div>
-								<p className="text-xs text-muted-foreground">
-									Net balances are not shown for consumable items.
-								</p>
+								<FieldLabel htmlFor={field.name}>Item Type</FieldLabel>
+								<Select
+									value={field.state.value}
+									onValueChange={(value) =>
+										field.handleChange(
+											value as "multiple" | "single" | "consumable",
+										)
+									}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder="Select item type" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="multiple">
+											Multiple (tracked by quantity)
+										</SelectItem>
+										<SelectItem value="single">
+											Single (individual item)
+										</SelectItem>
+										<SelectItem value="consumable">
+											Consumable (no return needed)
+										</SelectItem>
+									</SelectContent>
+								</Select>
 								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
 							</Field>
 						)}

--- a/apps/client/src/components/inventory/create-dialog.tsx
+++ b/apps/client/src/components/inventory/create-dialog.tsx
@@ -34,6 +34,7 @@ const formSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url("Must be a valid URL").optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
+	isConsumable: z.boolean().optional(),
 	initialQuantity: z.number().int().min(0).optional(),
 });
 
@@ -72,6 +73,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 		minQuantity?: number;
 		link?: string;
 		isActive?: boolean;
+		isConsumable?: boolean;
 		initialQuantity?: number;
 		approvalRoleIds?: number[];
 	};
@@ -95,6 +97,7 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 			minQuantity: undefined,
 			link: "",
 			isActive: true,
+			isConsumable: false,
 			initialQuantity: undefined,
 		},
 		validators: {
@@ -341,6 +344,28 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 								</div>
 								<p className="text-xs text-muted-foreground">
 									Inactive items will be hidden by default.
+								</p>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+							</Field>
+						)}
+					</form.Field>
+
+					<form.Field name="isConsumable">
+						{(field) => (
+							<Field>
+								<div className="flex items-center space-x-2">
+									<Checkbox
+										id={field.name}
+										checked={field.state.value}
+										onCheckedChange={(checked) => field.handleChange(!!checked)}
+										onBlur={field.handleBlur}
+									/>
+									<FieldLabel htmlFor={field.name} className="!mt-0">
+										Consumable
+									</FieldLabel>
+								</div>
+								<p className="text-xs text-muted-foreground">
+									Net balances are not shown for consumable items.
 								</p>
 								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
 							</Field>

--- a/apps/client/src/components/inventory/edit-dialog.tsx
+++ b/apps/client/src/components/inventory/edit-dialog.tsx
@@ -15,6 +15,13 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
 	Sheet,
 	SheetClose,
 	SheetContent,
@@ -48,7 +55,7 @@ type EditDialogProps = {
 		minQuantity?: number | null;
 		link?: string | null;
 		isActive: boolean;
-		isConsumable: boolean;
+		itemType: "multiple" | "single" | "consumable";
 		approvalRoles?: { id: number; name: string }[];
 	};
 	onUpdate?: () => void;
@@ -72,7 +79,7 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 		minQuantity?: number;
 		link?: string;
 		isActive?: boolean;
-		isConsumable?: boolean;
+		itemType?: "multiple" | "single" | "consumable";
 		approvalRoleIds?: number[];
 	};
 
@@ -105,7 +112,7 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 			link: item.link ?? "",
 			quantity: undefined,
 			isActive: item.isActive,
-			isConsumable: item.isConsumable,
+			itemType: item.itemType,
 		},
 		validators: {
 			onSubmit: formSchema,
@@ -364,23 +371,33 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 						)}
 					</form.Field>
 
-					<form.Field name="isConsumable">
+					<form.Field name="itemType">
 						{(field) => (
 							<Field>
-								<div className="flex items-center space-x-2">
-									<Checkbox
-										id={field.name}
-										checked={field.state.value}
-										onCheckedChange={(checked) => field.handleChange(!!checked)}
-										onBlur={field.handleBlur}
-									/>
-									<FieldLabel htmlFor={field.name} className="!mt-0">
-										Consumable
-									</FieldLabel>
-								</div>
-								<p className="text-xs text-muted-foreground">
-									Net balances are not shown for consumable items.
-								</p>
+								<FieldLabel htmlFor={field.name}>Item Type</FieldLabel>
+								<Select
+									value={field.state.value}
+									onValueChange={(value) =>
+										field.handleChange(
+											value as "multiple" | "single" | "consumable",
+										)
+									}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder="Select item type" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="multiple">
+											Multiple (tracked by quantity)
+										</SelectItem>
+										<SelectItem value="single">
+											Single (individual item)
+										</SelectItem>
+										<SelectItem value="consumable">
+											Consumable (no return needed)
+										</SelectItem>
+									</SelectContent>
+								</Select>
 								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
 							</Field>
 						)}

--- a/apps/client/src/components/inventory/edit-dialog.tsx
+++ b/apps/client/src/components/inventory/edit-dialog.tsx
@@ -48,6 +48,7 @@ type EditDialogProps = {
 		minQuantity?: number | null;
 		link?: string | null;
 		isActive: boolean;
+		isConsumable: boolean;
 		approvalRoles?: { id: number; name: string }[];
 	};
 	onUpdate?: () => void;
@@ -71,6 +72,7 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 		minQuantity?: number;
 		link?: string;
 		isActive?: boolean;
+		isConsumable?: boolean;
 		approvalRoleIds?: number[];
 	};
 
@@ -103,6 +105,7 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 			link: item.link ?? "",
 			quantity: undefined,
 			isActive: item.isActive,
+			isConsumable: item.isConsumable,
 		},
 		validators: {
 			onSubmit: formSchema,
@@ -355,6 +358,28 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 								</div>
 								<p className="text-xs text-muted-foreground">
 									Inactive items will be hidden by default.
+								</p>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+							</Field>
+						)}
+					</form.Field>
+
+					<form.Field name="isConsumable">
+						{(field) => (
+							<Field>
+								<div className="flex items-center space-x-2">
+									<Checkbox
+										id={field.name}
+										checked={field.state.value}
+										onCheckedChange={(checked) => field.handleChange(!!checked)}
+										onBlur={field.handleBlur}
+									/>
+									<FieldLabel htmlFor={field.name} className="!mt-0">
+										Consumable
+									</FieldLabel>
+								</div>
+								<p className="text-xs text-muted-foreground">
+									Net balances are not shown for consumable items.
 								</p>
 								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
 							</Field>

--- a/apps/client/src/components/inventory/transaction-columns.tsx
+++ b/apps/client/src/components/inventory/transaction-columns.tsx
@@ -129,6 +129,12 @@ export function generateColumns(): ColumnDef<Transaction>[] {
 			cell: ({ row }) => {
 				const quantity = row.original.quantity;
 				const action = row.original.action;
+				const isSingle = row.original.item.itemType === "single";
+
+				if (isSingle) {
+					return <span className="text-muted-foreground">—</span>;
+				}
+
 				const displayQuantity =
 					action === "CHECK_IN" ? `+${quantity}` : `-${Math.abs(quantity)}`;
 				return (
@@ -235,6 +241,12 @@ export function generateMyTransactionColumns(): ColumnDef<MyTransaction>[] {
 			cell: ({ row }) => {
 				const quantity = row.original.quantity;
 				const action = row.original.action;
+				const isSingle = row.original.item.itemType === "single";
+
+				if (isSingle) {
+					return <span className="text-muted-foreground">—</span>;
+				}
+
 				const displayQuantity =
 					action === "CHECK_IN" ? `+${quantity}` : `-${Math.abs(quantity)}`;
 				return (

--- a/apps/client/src/components/inventory/transaction-columns.tsx
+++ b/apps/client/src/components/inventory/transaction-columns.tsx
@@ -1,6 +1,13 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
+import { CookieIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { formatInAppTimezone } from "@/lib/timezone";
 
 type Transaction = {
@@ -15,6 +22,7 @@ type Transaction = {
 		id: string;
 		name: string;
 		sku: string | null;
+		isConsumable: boolean;
 	};
 	user: {
 		id: number;
@@ -35,6 +43,7 @@ type MyTransaction = {
 		id: string;
 		name: string;
 		sku: string | null;
+		isConsumable: boolean;
 	};
 };
 
@@ -87,7 +96,17 @@ export function generateColumns(): ColumnDef<Transaction>[] {
 				const item = row.original.item;
 				return (
 					<div className="flex flex-col">
-						<span>{item.name}</span>
+						<span className="flex items-center gap-2">
+							{item.name}
+							{item.isConsumable && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<CookieIcon className="h-4 w-4 text-muted-foreground" />
+									</TooltipTrigger>
+									<TooltipContent>Consumable item, no return needed</TooltipContent>
+								</Tooltip>
+							)}
+						</span>
 						{item.sku && (
 							<span className="text-xs text-muted-foreground">{item.sku}</span>
 						)}
@@ -173,7 +192,17 @@ export function generateMyTransactionColumns(): ColumnDef<MyTransaction>[] {
 				const item = row.original.item;
 				return (
 					<div className="flex flex-col">
-						<span>{item.name}</span>
+						<span className="flex items-center gap-2">
+							{item.name}
+							{item.isConsumable && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<CookieIcon className="h-4 w-4 text-muted-foreground" />
+									</TooltipTrigger>
+									<TooltipContent>Consumable item, no return needed</TooltipContent>
+								</Tooltip>
+							)}
+						</span>
 						{item.sku && (
 							<span className="text-xs text-muted-foreground">{item.sku}</span>
 						)}

--- a/apps/client/src/components/inventory/transaction-columns.tsx
+++ b/apps/client/src/components/inventory/transaction-columns.tsx
@@ -1,8 +1,7 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { CookieIcon } from "lucide-react";
+import { CookieIcon, PackageIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
 	TooltipContent,
@@ -22,7 +21,7 @@ type Transaction = {
 		id: string;
 		name: string;
 		sku: string | null;
-		isConsumable: boolean;
+		itemType: "multiple" | "single" | "consumable";
 	};
 	user: {
 		id: number;
@@ -43,7 +42,7 @@ type MyTransaction = {
 		id: string;
 		name: string;
 		sku: string | null;
-		isConsumable: boolean;
+		itemType: "multiple" | "single" | "consumable";
 	};
 };
 
@@ -98,12 +97,22 @@ export function generateColumns(): ColumnDef<Transaction>[] {
 					<div className="flex flex-col">
 						<span className="flex items-center gap-2">
 							{item.name}
-							{item.isConsumable && (
+							{item.itemType === "consumable" && (
 								<Tooltip>
 									<TooltipTrigger asChild>
 										<CookieIcon className="h-4 w-4 text-muted-foreground" />
 									</TooltipTrigger>
-									<TooltipContent>Consumable item, no return needed</TooltipContent>
+									<TooltipContent>
+										Consumable item, no return needed
+									</TooltipContent>
+								</Tooltip>
+							)}
+							{item.itemType === "single" && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<PackageIcon className="h-4 w-4 text-muted-foreground" />
+									</TooltipTrigger>
+									<TooltipContent>Individual item</TooltipContent>
 								</Tooltip>
 							)}
 						</span>
@@ -194,12 +203,22 @@ export function generateMyTransactionColumns(): ColumnDef<MyTransaction>[] {
 					<div className="flex flex-col">
 						<span className="flex items-center gap-2">
 							{item.name}
-							{item.isConsumable && (
+							{item.itemType === "consumable" && (
 								<Tooltip>
 									<TooltipTrigger asChild>
 										<CookieIcon className="h-4 w-4 text-muted-foreground" />
 									</TooltipTrigger>
-									<TooltipContent>Consumable item, no return needed</TooltipContent>
+									<TooltipContent>
+										Consumable item, no return needed
+									</TooltipContent>
+								</Tooltip>
+							)}
+							{item.itemType === "single" && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<PackageIcon className="h-4 w-4 text-muted-foreground" />
+									</TooltipTrigger>
+									<TooltipContent>Individual item</TooltipContent>
 								</Tooltip>
 							)}
 						</span>

--- a/apps/client/src/components/inventory/transaction-summary-columns.tsx
+++ b/apps/client/src/components/inventory/transaction-summary-columns.tsx
@@ -57,6 +57,25 @@ export function generateSummaryColumns(): ColumnDef<TransactionSummary>[] {
 			header: "Net Balance",
 			cell: ({ row }) => {
 				const quantity = row.original.netQuantity;
+				const isSingle = row.original.itemType === "single";
+
+				if (isSingle) {
+					return (
+						<div className="flex items-center gap-2">
+							<Badge
+								variant={quantity < 0 ? "default" : "secondary"}
+								className={
+									quantity < 0
+										? "bg-blue-600 hover:bg-blue-700 text-foreground"
+										: "bg-green-600 hover:bg-green-700 text-foreground"
+								}
+							>
+								{quantity < 0 ? "Checked Out" : "Available"}
+							</Badge>
+						</div>
+					);
+				}
+
 				return (
 					<div className="flex items-center gap-2">
 						<span
@@ -121,6 +140,25 @@ export function generateMySummaryColumns(): ColumnDef<MyTransactionSummary>[] {
 			header: "Net Balance",
 			cell: ({ row }) => {
 				const quantity = row.original.netQuantity;
+				const isSingle = row.original.itemType === "single";
+
+				if (isSingle) {
+					return (
+						<div className="flex items-center gap-2">
+							<Badge
+								variant={quantity < 0 ? "default" : "secondary"}
+								className={
+									quantity < 0
+										? "bg-blue-600 hover:bg-blue-700 text-foreground"
+										: "bg-green-600 hover:bg-green-700 text-foreground"
+								}
+							>
+								{quantity < 0 ? "Checked Out" : "In Possession"}
+							</Badge>
+						</div>
+					);
+				}
+
 				return (
 					<div className="flex items-center gap-2">
 						<span

--- a/apps/client/src/components/inventory/transaction-summary-columns.tsx
+++ b/apps/client/src/components/inventory/transaction-summary-columns.tsx
@@ -1,10 +1,17 @@
 import type { ColumnDef } from "@tanstack/react-table";
+import { PackageIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type TransactionSummary = {
 	itemId: string;
 	itemName: string;
 	itemSku: string | null;
+	itemType: string;
 	netQuantity: number;
 };
 
@@ -12,6 +19,7 @@ type MyTransactionSummary = {
 	itemId: string;
 	itemName: string;
 	itemSku: string | null;
+	itemType: string;
 	netQuantity: number;
 };
 
@@ -24,7 +32,17 @@ export function generateSummaryColumns(): ColumnDef<TransactionSummary>[] {
 				const item = row.original;
 				return (
 					<div className="flex flex-col">
-						<span className="font-medium">{item.itemName}</span>
+						<span className="flex items-center gap-2 font-medium">
+							{item.itemName}
+							{item.itemType === "single" && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<PackageIcon className="h-4 w-4 text-muted-foreground" />
+									</TooltipTrigger>
+									<TooltipContent>Individual item</TooltipContent>
+								</Tooltip>
+							)}
+						</span>
 						{item.itemSku && (
 							<span className="text-xs text-muted-foreground">
 								{item.itemSku}
@@ -78,7 +96,17 @@ export function generateMySummaryColumns(): ColumnDef<MyTransactionSummary>[] {
 				const item = row.original;
 				return (
 					<div className="flex flex-col">
-						<span className="font-medium">{item.itemName}</span>
+						<span className="flex items-center gap-2 font-medium">
+							{item.itemName}
+							{item.itemType === "single" && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<PackageIcon className="h-4 w-4 text-muted-foreground" />
+									</TooltipTrigger>
+									<TooltipContent>Individual item</TooltipContent>
+								</Tooltip>
+							)}
+						</span>
 						{item.itemSku && (
 							<span className="text-xs text-muted-foreground">
 								{item.itemSku}

--- a/apps/client/src/components/inventory/types.ts
+++ b/apps/client/src/components/inventory/types.ts
@@ -7,6 +7,7 @@ export type ItemRow = {
 	minQuantity?: number | null;
 	link?: string | null;
 	isActive: boolean;
+	isConsumable: boolean;
 	snapshot?: { quantity: number } | null;
 	currentQuantity?: number | null;
 	createdAt?: string | null;

--- a/apps/client/src/components/inventory/types.ts
+++ b/apps/client/src/components/inventory/types.ts
@@ -7,7 +7,7 @@ export type ItemRow = {
 	minQuantity?: number | null;
 	link?: string | null;
 	isActive: boolean;
-	isConsumable: boolean;
+	itemType: "multiple" | "single" | "consumable";
 	snapshot?: { quantity: number } | null;
 	currentQuantity?: number | null;
 	createdAt?: string | null;

--- a/apps/client/src/routes/app/inventory/my-transactions.tsx
+++ b/apps/client/src/routes/app/inventory/my-transactions.tsx
@@ -155,9 +155,7 @@ function MyTransactions() {
 										</Label>
 										<Select
 											value={itemTypeFilter}
-											onValueChange={(
-												value: "all" | "multiple" | "single",
-											) => {
+											onValueChange={(value: "all" | "multiple" | "single") => {
 												setItemTypeFilter(value);
 											}}
 										>

--- a/apps/client/src/routes/app/inventory/my-transactions.tsx
+++ b/apps/client/src/routes/app/inventory/my-transactions.tsx
@@ -19,6 +19,14 @@ import {
 } from "@/components/layout";
 import { SearchInput, TablePaginationFooter } from "@/components/shared";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { usePaginationInfo } from "@/hooks/use-pagination-info";
 import { useTableState } from "@/hooks/use-table-state";
@@ -39,6 +47,10 @@ function MyTransactions() {
 		debouncedSearch,
 		resetToFirstPage,
 	} = useTableState();
+
+	const [itemTypeFilter, setItemTypeFilter] = React.useState<
+		"all" | "multiple" | "single"
+	>("all");
 
 	const queryParams = React.useMemo(() => {
 		return {
@@ -61,13 +73,17 @@ function MyTransactions() {
 		retry: false,
 	});
 
-	// Fetch net balance data separately
+	// Fetch net balance data (excludes consumables, optionally filtered by type)
 	const summaryQueryParams = React.useMemo(() => {
 		return {
 			search:
 				debouncedSearch.trim() === "" ? undefined : debouncedSearch.trim(),
+			itemType:
+				itemTypeFilter === "all"
+					? undefined
+					: (itemTypeFilter as "multiple" | "single"),
 		};
-	}, [debouncedSearch]);
+	}, [debouncedSearch, itemTypeFilter]);
 
 	const { data: summaryData = [] } = useQuery({
 		queryKey: ["inventory", "transactions", "myNetBalance", summaryQueryParams],
@@ -129,6 +145,36 @@ function MyTransactions() {
 										}}
 									/>
 								</TableSearchInput>
+								<div className="flex items-center gap-4">
+									<div className="flex items-center gap-2">
+										<Label
+											htmlFor="item-type-filter"
+											className="text-sm font-medium"
+										>
+											Type:
+										</Label>
+										<Select
+											value={itemTypeFilter}
+											onValueChange={(
+												value: "all" | "multiple" | "single",
+											) => {
+												setItemTypeFilter(value);
+											}}
+										>
+											<SelectTrigger
+												id="item-type-filter"
+												className="w-[180px]"
+											>
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												<SelectItem value="all">All items</SelectItem>
+												<SelectItem value="multiple">Multiple only</SelectItem>
+												<SelectItem value="single">Single only</SelectItem>
+											</SelectContent>
+										</Select>
+									</div>
+								</div>
 							</TableToolbar>
 
 							<TransactionSummaryDataTable

--- a/apps/client/src/routes/app/inventory/transactions.tsx
+++ b/apps/client/src/routes/app/inventory/transactions.tsx
@@ -161,9 +161,7 @@ function Transactions() {
 										</Label>
 										<Select
 											value={itemTypeFilter}
-											onValueChange={(
-												value: "all" | "multiple" | "single",
-											) => {
+											onValueChange={(value: "all" | "multiple" | "single") => {
 												setItemTypeFilter(value);
 											}}
 										>

--- a/apps/client/src/routes/app/inventory/transactions.tsx
+++ b/apps/client/src/routes/app/inventory/transactions.tsx
@@ -21,6 +21,14 @@ import {
 } from "@/components/layout";
 import { SearchInput, TablePaginationFooter } from "@/components/shared";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { usePaginationInfo } from "@/hooks/use-pagination-info";
 import { useTableState } from "@/hooks/use-table-state";
@@ -52,6 +60,10 @@ function Transactions() {
 		resetToFirstPage,
 	} = useTableState();
 
+	const [itemTypeFilter, setItemTypeFilter] = React.useState<
+		"all" | "multiple" | "single"
+	>("all");
+
 	const queryParams = React.useMemo(() => {
 		return {
 			search:
@@ -73,13 +85,17 @@ function Transactions() {
 		retry: false,
 	});
 
-	// Fetch net balance data separately
+	// Fetch net balance data (excludes consumables, optionally filtered by type)
 	const summaryQueryParams = React.useMemo(() => {
 		return {
 			search:
 				debouncedSearch.trim() === "" ? undefined : debouncedSearch.trim(),
+			itemType:
+				itemTypeFilter === "all"
+					? undefined
+					: (itemTypeFilter as "multiple" | "single"),
 		};
-	}, [debouncedSearch]);
+	}, [debouncedSearch, itemTypeFilter]);
 
 	const { data: summaryData = [] } = useQuery({
 		queryKey: ["inventory", "transactions", "netBalance", summaryQueryParams],
@@ -135,6 +151,36 @@ function Transactions() {
 										}}
 									/>
 								</TableSearchInput>
+								<div className="flex items-center gap-4">
+									<div className="flex items-center gap-2">
+										<Label
+											htmlFor="item-type-filter"
+											className="text-sm font-medium"
+										>
+											Type:
+										</Label>
+										<Select
+											value={itemTypeFilter}
+											onValueChange={(
+												value: "all" | "multiple" | "single",
+											) => {
+												setItemTypeFilter(value);
+											}}
+										>
+											<SelectTrigger
+												id="item-type-filter"
+												className="w-[180px]"
+											>
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												<SelectItem value="all">All items</SelectItem>
+												<SelectItem value="multiple">Multiple only</SelectItem>
+												<SelectItem value="single">Single only</SelectItem>
+											</SelectContent>
+										</Select>
+									</div>
+								</div>
 							</TableToolbar>
 
 							<TransactionSummaryDataTable
@@ -149,7 +195,7 @@ function Transactions() {
 								}
 							/>
 						</TableContainer>
-					</TabsContent>{" "}
+					</TabsContent>
 					<TabsContent value="history" className="mt-0">
 						<TableContainer>
 							<TableToolbar>

--- a/apps/inventory/src/components/inventory-transaction-view.tsx
+++ b/apps/inventory/src/components/inventory-transaction-view.tsx
@@ -20,6 +20,7 @@ type TransactionItem = {
 	name: string;
 	sku: string;
 	quantity: number;
+	itemType: "multiple" | "single" | "consumable";
 };
 
 export function InventoryTransactionView({
@@ -82,6 +83,10 @@ export function InventoryTransactionView({
 		setItems((prevItems) => {
 			const existingItem = prevItems.find((item) => item.sku === sku);
 			if (existingItem) {
+				// Single items cannot have quantity incremented
+				if (existingItem.itemType === "single") {
+					return prevItems;
+				}
 				// Item exists, increment quantity
 				return prevItems.map((item) =>
 					item.sku === sku ? { ...item, quantity: item.quantity + 1 } : item,
@@ -109,11 +114,31 @@ export function InventoryTransactionView({
 						onError("Cannot add inactive item");
 						return;
 					}
+					// For single items during checkout, check if already checked out
+					if (item.itemType === "single" && mode === "checkout") {
+						if (item.isCheckedOut) {
+							onError(
+								`"${item.name}" is currently checked out and must be returned before it can be checked out again`,
+							);
+							return;
+						}
+					}
+					// For single items during return, check if it's actually checked out
+					if (item.itemType === "single" && mode === "return") {
+						if (!item.isCheckedOut) {
+							onError(`"${item.name}" is not currently checked out`);
+							return;
+						}
+					}
 					if (item.name) {
 						// Use functional update to avoid stale closure
 						setItems((prevItems) => {
 							// Double-check the item wasn't added while we were fetching
 							if (prevItems.some((i) => i.sku === sku)) {
+								// For single items, don't increment quantity
+								if (item.itemType === "single") {
+									return prevItems;
+								}
 								return prevItems.map((i) =>
 									i.sku === sku ? { ...i, quantity: i.quantity + 1 } : i,
 								);
@@ -125,6 +150,7 @@ export function InventoryTransactionView({
 									name: item.name,
 									sku,
 									quantity: 1,
+									itemType: item.itemType,
 								},
 							];
 						});
@@ -298,25 +324,33 @@ export function InventoryTransactionView({
 															{item.name}
 														</p>
 													</div>
-													<div className="flex items-center gap-2">
-														<Button
-															size="icon"
-															variant="outline"
-															onClick={() => handleUpdateQuantity(item.id, -1)}
-														>
-															<Minus className="h-4 w-4" />
-														</Button>
-														<span className="text-2xl font-bold w-12 text-center">
-															{item.quantity}
+													{item.itemType === "single" ? (
+														<span className="text-lg text-muted-foreground">
+															Individual item
 														</span>
-														<Button
-															size="icon"
-															variant="outline"
-															onClick={() => handleUpdateQuantity(item.id, 1)}
-														>
-															<Plus className="h-4 w-4" />
-														</Button>
-													</div>
+													) : (
+														<div className="flex items-center gap-2">
+															<Button
+																size="icon"
+																variant="outline"
+																onClick={() =>
+																	handleUpdateQuantity(item.id, -1)
+																}
+															>
+																<Minus className="h-4 w-4" />
+															</Button>
+															<span className="text-2xl font-bold w-12 text-center">
+																{item.quantity}
+															</span>
+															<Button
+																size="icon"
+																variant="outline"
+																onClick={() => handleUpdateQuantity(item.id, 1)}
+															>
+																<Plus className="h-4 w-4" />
+															</Button>
+														</div>
+													)}
 													<Button
 														size="icon"
 														variant="ghost"

--- a/apps/inventory/src/hooks/use-inventory-workflow.ts
+++ b/apps/inventory/src/hooks/use-inventory-workflow.ts
@@ -336,11 +336,13 @@ export function useInventoryWorkflow() {
 					await trpc.inventory.transactions.checkOut.mutate({
 						userId,
 						items,
+						approverId: result.user.id,
 					});
 				} else {
 					await trpc.inventory.transactions.checkIn.mutate({
 						userId,
 						items,
+						approverId: result.user.id,
 					});
 				}
 

--- a/packages/prisma/migrations/20260220120000_add_item_consumable_property/migration.sql
+++ b/packages/prisma/migrations/20260220120000_add_item_consumable_property/migration.sql
@@ -1,0 +1,4 @@
+-- Create a new migration to add isConsumable field to Item
+-- This migration corresponds to the update made in schema.prisma
+
+ALTER TABLE "Item" ADD COLUMN "isConsumable" boolean NOT NULL DEFAULT false;

--- a/packages/prisma/migrations/20260220120000_add_item_consumable_property/migration.sql
+++ b/packages/prisma/migrations/20260220120000_add_item_consumable_property/migration.sql
@@ -1,4 +1,0 @@
--- Create a new migration to add isConsumable field to Item
--- This migration corresponds to the update made in schema.prisma
-
-ALTER TABLE "Item" ADD COLUMN "isConsumable" boolean NOT NULL DEFAULT false;

--- a/packages/prisma/migrations/20260220130000_remove_unused_inventory_permissions/migration.sql
+++ b/packages/prisma/migrations/20260220130000_remove_unused_inventory_permissions/migration.sql
@@ -1,0 +1,15 @@
+-- Remove unused inventory transaction permissions
+
+-- Clean up any role associations first
+DELETE FROM "_PermissionToRole" WHERE "A" IN (
+    SELECT "id" FROM "Permission" WHERE "name" IN (
+        'inventory.transactions.checkIn',
+        'inventory.transactions.checkOut'
+    )
+);
+
+-- Delete the permissions themselves
+DELETE FROM "Permission" WHERE "name" IN (
+    'inventory.transactions.checkIn',
+    'inventory.transactions.checkOut'
+);

--- a/packages/prisma/migrations/20260226120744_add_item_types/migration.sql
+++ b/packages/prisma/migrations/20260226120744_add_item_types/migration.sql
@@ -1,0 +1,8 @@
+-- Create a new migration to add the ItemType enum and itemType column on Item
+-- This migration corresponds to the schema updates in packages/prisma/schema.prisma
+
+-- create the enum type
+CREATE TYPE "ItemType" AS ENUM ('multiple','single','consumable');
+
+-- add the new column to the Item table with a default value
+ALTER TABLE "Item" ADD COLUMN "itemType" "ItemType" NOT NULL DEFAULT 'multiple';

--- a/packages/prisma/migrations/20260226220000_remove_item_is_consumable/migration.sql
+++ b/packages/prisma/migrations/20260226220000_remove_item_is_consumable/migration.sql
@@ -1,0 +1,4 @@
+-- Remove the old isConsumable column from the Item table now that itemType handles consumable state.
+-- This corresponds to the schema change that dropped the field from Item.
+
+ALTER TABLE "Item" DROP COLUMN "isConsumable";

--- a/packages/prisma/migrations/20260226220000_remove_item_is_consumable/migration.sql
+++ b/packages/prisma/migrations/20260226220000_remove_item_is_consumable/migration.sql
@@ -1,4 +1,0 @@
--- Remove the old isConsumable column from the Item table now that itemType handles consumable state.
--- This corresponds to the schema change that dropped the field from Item.
-
-ALTER TABLE "Item" DROP COLUMN "isConsumable";

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -9,46 +9,46 @@ datasource db {
 }
 
 model User {
-  id                       Int                    @id @default(autoincrement())
-  username                 String                 @unique
-  name                     String
-  email                    String                 @unique
-  isSystemUser             Boolean                @default(false)
-  createdAt                DateTime               @default(now())
-  updatedAt                DateTime               @default(now()) @updatedAt
-  slackUsername            String?                @unique
-  apiTokens                ApiToken[]
-  impersonatedAuditLogs    AuditLog[]             @relation("AuditLogImpersonators")
-  auditLogs                AuditLog[]
-  inventoryTransactions    InventoryTransaction[]
-  sessions                 Session[]
-  reviewedAttendances      ShiftAttendance[]      @relation("ShiftAttendanceReviewedBy")
-  attendances              ShiftAttendance[]
-  createdSuspensions       Suspension[]           @relation("SuspensionCreatedBy")
-  suspensions              Suspension[]
-  handledTickets           Ticket[]               @relation("TicketHandler")
-  submittedTickets         Ticket[]               @relation("TicketSubmitter")
-  ticketStatusChanges      TicketStatusHistory[]  @relation("TicketStatusChangedBy")
-  userAgreements           UserAgreement[]
-  roles                    Role[]                 @relation("RoleToUser")
-  shiftOccurrences         ShiftOccurrence[]      @relation("ShiftOccurrenceToUser")
-  shiftSchedules           ShiftSchedule[]        @relation("ShiftScheduleToUser")
-  authorizedControlPoints  ControlPoint[]         @relation("ControlPointUsers")
-  controlLogs              ControlLog[]
-  credentials              Credential[]
+  id                      Int                    @id @default(autoincrement())
+  username                String                 @unique
+  name                    String
+  email                   String                 @unique
+  isSystemUser            Boolean                @default(false)
+  createdAt               DateTime               @default(now())
+  updatedAt               DateTime               @default(now()) @updatedAt
+  slackUsername           String?                @unique
+  apiTokens               ApiToken[]
+  impersonatedAuditLogs   AuditLog[]             @relation("AuditLogImpersonators")
+  auditLogs               AuditLog[]
+  inventoryTransactions   InventoryTransaction[]
+  sessions                Session[]
+  reviewedAttendances     ShiftAttendance[]      @relation("ShiftAttendanceReviewedBy")
+  attendances             ShiftAttendance[]
+  createdSuspensions      Suspension[]           @relation("SuspensionCreatedBy")
+  suspensions             Suspension[]
+  handledTickets          Ticket[]               @relation("TicketHandler")
+  submittedTickets        Ticket[]               @relation("TicketSubmitter")
+  ticketStatusChanges     TicketStatusHistory[]  @relation("TicketStatusChangedBy")
+  userAgreements          UserAgreement[]
+  roles                   Role[]                 @relation("RoleToUser")
+  shiftOccurrences        ShiftOccurrence[]      @relation("ShiftOccurrenceToUser")
+  shiftSchedules          ShiftSchedule[]        @relation("ShiftScheduleToUser")
+  authorizedControlPoints ControlPoint[]         @relation("ControlPointUsers")
+  controlLogs             ControlLog[]
+  credentials             Credential[]
 }
 
 model Role {
-  id                       Int            @id @default(autoincrement())
-  name                     String         @unique
-  createdAt                DateTime       @default(now())
-  updatedAt                DateTime       @default(now()) @updatedAt
-  approvalItems            Item[]         @relation("ItemApprovalRoles")
-  periods                  Period[]       @relation("PeriodRoles")
-  permissions              Permission[]   @relation("PermissionToRole")
-  shiftTypes               ShiftType[]    @relation("RoleToShiftType")
-  users                    User[]         @relation("RoleToUser")
-  authorizedControlPoints  ControlPoint[] @relation("ControlPointRoles")
+  id                      Int            @id @default(autoincrement())
+  name                    String         @unique
+  createdAt               DateTime       @default(now())
+  updatedAt               DateTime       @default(now()) @updatedAt
+  approvalItems           Item[]         @relation("ItemApprovalRoles")
+  periods                 Period[]       @relation("PeriodRoles")
+  permissions             Permission[]   @relation("PermissionToRole")
+  shiftTypes              ShiftType[]    @relation("RoleToShiftType")
+  users                   User[]         @relation("RoleToUser")
+  authorizedControlPoints ControlPoint[] @relation("ControlPointRoles")
 }
 
 model Permission {
@@ -179,17 +179,17 @@ model Session {
 }
 
 model Device {
-  id                 Int                @id @default(autoincrement())
+  id                 Int            @id @default(autoincrement())
   name               String
-  ipAddress          String             @unique
-  isActive           Boolean            @default(true)
-  createdAt          DateTime           @default(now())
-  updatedAt          DateTime           @default(now()) @updatedAt
-  hasDashboardAccess Boolean            @default(false)
-  hasKioskAccess     Boolean            @default(true)
-  hasInventoryAccess Boolean            @default(false)
-  hasControlAccess   Boolean            @default(false)
-  controlPoints      ControlPoint[]     @relation("DeviceControlPoints")
+  ipAddress          String         @unique
+  isActive           Boolean        @default(true)
+  createdAt          DateTime       @default(now())
+  updatedAt          DateTime       @default(now()) @updatedAt
+  hasDashboardAccess Boolean        @default(false)
+  hasKioskAccess     Boolean        @default(true)
+  hasInventoryAccess Boolean        @default(false)
+  hasControlAccess   Boolean        @default(false)
+  controlPoints      ControlPoint[] @relation("DeviceControlPoints")
 }
 
 model Agreement {
@@ -299,6 +299,7 @@ model Item {
   location      String?
   minQuantity   Int?
   isActive      Boolean                @default(true)
+  isConsumable  Boolean                @default(false)
   createdAt     DateTime               @default(now())
   updatedAt     DateTime               @default(now()) @updatedAt
   link          String?
@@ -432,54 +433,54 @@ enum TicketStatus {
 // ===== Equipment Control System =====
 
 model ControlProvider {
-  id            Int            @id @default(autoincrement())
-  name          String         @unique
+  id            Int                 @id @default(autoincrement())
+  name          String              @unique
   providerType  ControlProviderType
-  config        Json           @default("{}")
-  isActive      Boolean        @default(true)
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @default(now()) @updatedAt
+  config        Json                @default("{}")
+  isActive      Boolean             @default(true)
+  createdAt     DateTime            @default(now())
+  updatedAt     DateTime            @default(now()) @updatedAt
   controlPoints ControlPoint[]
 }
 
 model ControlPoint {
-  id                  String            @id @default(uuid())
-  name                String
-  description         String?
-  location            String?
-  controlClass        ControlClass
-  canControlOnline    Boolean           @default(true)
-  canControlWithCode  Boolean           @default(false)
-  providerConfig      Json              @default("{}")
-  currentState        Boolean           @default(false)
-  autoTurnOffEnabled  Boolean           @default(false)
-  autoTurnOffMinutes  Int?
-  isActive            Boolean           @default(true)
-  createdAt           DateTime          @default(now())
-  updatedAt           DateTime          @default(now()) @updatedAt
-  providerId          Int
-  provider            ControlProvider   @relation(fields: [providerId], references: [id], onDelete: Restrict)
-  authorizedRoles     Role[]            @relation("ControlPointRoles")
-  authorizedUsers     User[]            @relation("ControlPointUsers")
-  controlLogs         ControlLog[]
-  devices             Device[]          @relation("DeviceControlPoints")
-  gatewayActions      ControlGatewayAction[]
+  id                 String                 @id @default(uuid())
+  name               String
+  description        String?
+  location           String?
+  controlClass       ControlClass
+  canControlOnline   Boolean                @default(true)
+  canControlWithCode Boolean                @default(false)
+  providerConfig     Json                   @default("{}")
+  currentState       Boolean                @default(false)
+  autoTurnOffEnabled Boolean                @default(false)
+  autoTurnOffMinutes Int?
+  isActive           Boolean                @default(true)
+  createdAt          DateTime               @default(now())
+  updatedAt          DateTime               @default(now()) @updatedAt
+  providerId         Int
+  provider           ControlProvider        @relation(fields: [providerId], references: [id], onDelete: Restrict)
+  authorizedRoles    Role[]                 @relation("ControlPointRoles")
+  authorizedUsers    User[]                 @relation("ControlPointUsers")
+  controlLogs        ControlLog[]
+  devices            Device[]               @relation("DeviceControlPoints")
+  gatewayActions     ControlGatewayAction[]
 
   @@index([providerId])
 }
 
 model ControlLog {
-  id             String       @id @default(uuid())
+  id             String        @id @default(uuid())
   controlPointId String
   userId         Int
   action         ControlAction
   previousState  Boolean?
   newState       Boolean?
-  success        Boolean      @default(true)
+  success        Boolean       @default(true)
   errorMessage   String?
-  createdAt      DateTime     @default(now())
-  controlPoint   ControlPoint @relation(fields: [controlPointId], references: [id], onDelete: Cascade)
-  user           User         @relation(fields: [userId], references: [id])
+  createdAt      DateTime      @default(now())
+  controlPoint   ControlPoint  @relation(fields: [controlPointId], references: [id], onDelete: Cascade)
+  user           User          @relation(fields: [userId], references: [id])
 
   @@index([controlPointId, createdAt])
   @@index([userId, createdAt])
@@ -490,8 +491,8 @@ enum ControlProviderType {
 }
 
 enum ControlClass {
-  SWITCH  // On/off toggle with persistent state
-  DOOR    // Momentary unlock, no persistent state
+  SWITCH // On/off toggle with persistent state
+  DOOR // Momentary unlock, no persistent state
 }
 
 enum ControlAction {
@@ -517,14 +518,14 @@ model ControlGateway {
 }
 
 model ControlGatewayAction {
-  id             Int              @id @default(autoincrement())
+  id             Int            @id @default(autoincrement())
   gatewayId      Int
   controlPointId String
   action         ControlAction
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @default(now()) @updatedAt
-  gateway        ControlGateway   @relation(fields: [gatewayId], references: [id], onDelete: Cascade)
-  controlPoint   ControlPoint     @relation(fields: [controlPointId], references: [id], onDelete: Cascade)
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @default(now()) @updatedAt
+  gateway        ControlGateway @relation(fields: [gatewayId], references: [id], onDelete: Cascade)
+  controlPoint   ControlPoint   @relation(fields: [controlPointId], references: [id], onDelete: Cascade)
 
   @@unique([gatewayId, controlPointId, action])
   @@index([gatewayId])

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -291,6 +291,12 @@ model Suspension {
   @@index([emailSentAt, startDate])
 }
 
+enum ItemType {
+  multiple
+  single
+  consumable
+}
+
 model Item {
   id            String                 @id @default(uuid())
   name          String
@@ -299,7 +305,7 @@ model Item {
   location      String?
   minQuantity   Int?
   isActive      Boolean                @default(true)
-  isConsumable  Boolean                @default(false)
+  itemType      ItemType               @default(multiple)
   createdAt     DateTime               @default(now())
   updatedAt     DateTime               @default(now()) @updatedAt
   link          String?

--- a/packages/trpc/server/routers/inventory/items/create.route.ts
+++ b/packages/trpc/server/routers/inventory/items/create.route.ts
@@ -10,7 +10,9 @@ export const ZCreateItemSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
-	isConsumable: z.boolean().optional(),
+	itemType: z
+		.enum(["multiple", "single", "consumable"])
+		.optional(),
 	initialQuantity: z.number().int().min(0).optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });
@@ -29,6 +31,7 @@ export async function createItemHandler(options: TCreateItemOptions) {
 		const newItem = await tx.item.create({
 			data: {
 				...itemData,
+				// prisma default will apply if itemType is undefined
 				approvalRoles: approvalRoleIds?.length
 					? { connect: approvalRoleIds.map((id) => ({ id })) }
 					: undefined,

--- a/packages/trpc/server/routers/inventory/items/create.route.ts
+++ b/packages/trpc/server/routers/inventory/items/create.route.ts
@@ -10,6 +10,7 @@ export const ZCreateItemSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
+	isConsumable: z.boolean().optional(),
 	initialQuantity: z.number().int().min(0).optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });

--- a/packages/trpc/server/routers/inventory/items/create.route.ts
+++ b/packages/trpc/server/routers/inventory/items/create.route.ts
@@ -10,9 +10,7 @@ export const ZCreateItemSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
-	itemType: z
-		.enum(["multiple", "single", "consumable"])
-		.optional(),
+	itemType: z.enum(["multiple", "single", "consumable"]).optional(),
 	initialQuantity: z.number().int().min(0).optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });

--- a/packages/trpc/server/routers/inventory/items/getBySku.route.ts
+++ b/packages/trpc/server/routers/inventory/items/getBySku.route.ts
@@ -37,5 +37,18 @@ export async function getBySkuItemHandler(options: TGetBySkuItemOptions) {
 		});
 	}
 
-	return item;
+	// For single items, include whether the item is currently checked out
+	if (item.itemType === "single") {
+		const balanceResult = await prisma.$queryRaw<
+			Array<{ netQuantity: bigint }>
+		>`
+			SELECT COALESCE(SUM(quantity), 0)::bigint as "netQuantity"
+			FROM "InventoryTransaction"
+			WHERE "itemId" = ${item.id}
+		`;
+		const netQuantity = Number(balanceResult[0]?.netQuantity ?? 0);
+		return { ...item, isCheckedOut: netQuantity < 0 };
+	}
+
+	return { ...item, isCheckedOut: false };
 }

--- a/packages/trpc/server/routers/inventory/items/update.route.ts
+++ b/packages/trpc/server/routers/inventory/items/update.route.ts
@@ -12,9 +12,7 @@ export const ZUpdateItemSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
-	itemType: z
-		.enum(["multiple", "single", "consumable"])
-		.optional(),
+	itemType: z.enum(["multiple", "single", "consumable"]).optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });
 

--- a/packages/trpc/server/routers/inventory/items/update.route.ts
+++ b/packages/trpc/server/routers/inventory/items/update.route.ts
@@ -12,7 +12,9 @@ export const ZUpdateItemSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
-	isConsumable: z.boolean().optional(),
+	itemType: z
+		.enum(["multiple", "single", "consumable"])
+		.optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });
 

--- a/packages/trpc/server/routers/inventory/items/update.route.ts
+++ b/packages/trpc/server/routers/inventory/items/update.route.ts
@@ -12,6 +12,7 @@ export const ZUpdateItemSchema = z.object({
 	minQuantity: z.number().int().min(0).optional(),
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
+	isConsumable: z.boolean().optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });
 

--- a/packages/trpc/server/routers/inventory/transactions/checkIn.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/checkIn.route.ts
@@ -72,44 +72,90 @@ export async function checkInHandler(options: TCheckInOptions) {
 		});
 	}
 
-	// Validate that the user has enough items checked out to return
-	// Get the user's current balance for the requested items
-	const userBalances = await prisma.$queryRaw<
-		Array<{ itemId: string; netQuantity: bigint }>
-	>`
-		SELECT "itemId", SUM(quantity)::bigint as "netQuantity"
-		FROM "InventoryTransaction"
-		WHERE "userId" = ${userId} AND "itemId" IN (${Prisma.join(itemIds)})
-		GROUP BY "itemId"
-	`;
+	// For single items, override the userId with the person who actually has it checked out
+	// This allows anyone to return a single item on behalf of the original borrower
+	const singleItems = foundItems.filter((i) => i.itemType === "single");
+	const userIdOverrides = new Map<string, number>();
 
-	// Create a map of itemId to net quantity (negative means checked out)
-	const balanceMap = new Map<string, number>(
-		userBalances.map((b) => [b.itemId, Number(b.netQuantity)]),
-	);
-
-	// Check each item to ensure the user has enough checked out to return
-	for (const requested of items) {
-		const currentBalance = balanceMap.get(requested.itemId) ?? 0;
-		// currentBalance is negative when items are checked out (e.g., -5 means 5 items checked out)
-		// The user can return at most Math.abs(currentBalance) items
-		const checkedOutQuantity = Math.abs(Math.min(0, currentBalance));
-
-		if (requested.quantity > checkedOutQuantity) {
-			const item = foundItems.find((i) => i.id === requested.itemId);
-			const itemName = item?.name ?? requested.itemId;
-
-			if (checkedOutQuantity === 0) {
+	if (singleItems.length > 0) {
+		// Enforce quantity of 1 for single items
+		for (const singleItem of singleItems) {
+			const requested = items.find((i) => i.itemId === singleItem.id);
+			if (requested && requested.quantity !== 1) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
-					message: `You do not have any "${itemName}" checked out to return`,
+					message: `"${singleItem.name}" is an individual item and can only be returned with a quantity of 1`,
+				});
+			}
+		}
+
+		// Find who has each single item checked out
+		for (const singleItem of singleItems) {
+			const borrower = await prisma.$queryRaw<
+				Array<{ userId: number; netQuantity: bigint }>
+			>`
+				SELECT "userId", SUM(quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction"
+				WHERE "itemId" = ${singleItem.id}
+				GROUP BY "userId"
+				HAVING SUM(quantity) < 0
+			`;
+
+			if (borrower.length === 0) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `"${singleItem.name}" is not currently checked out`,
 				});
 			}
 
-			throw new TRPCError({
-				code: "BAD_REQUEST",
-				message: `Cannot return ${requested.quantity} of "${itemName}" — you only have ${checkedOutQuantity} checked out`,
-			});
+			// Use the borrower's userId for the return transaction
+			userIdOverrides.set(singleItem.id, borrower[0].userId);
+		}
+	}
+
+	// Validate that the user has enough items checked out to return
+	// Get the user's current balance for the requested items (only for non-single items)
+	const nonSingleItems = items.filter((i) => !userIdOverrides.has(i.itemId));
+	const nonSingleItemIds = nonSingleItems.map((i) => i.itemId);
+
+	if (nonSingleItemIds.length > 0) {
+		const userBalances = await prisma.$queryRaw<
+			Array<{ itemId: string; netQuantity: bigint }>
+		>`
+			SELECT "itemId", SUM(quantity)::bigint as "netQuantity"
+			FROM "InventoryTransaction"
+			WHERE "userId" = ${userId} AND "itemId" IN (${Prisma.join(nonSingleItemIds)})
+			GROUP BY "itemId"
+		`;
+
+		// Create a map of itemId to net quantity (negative means checked out)
+		const balanceMap = new Map<string, number>(
+			userBalances.map((b) => [b.itemId, Number(b.netQuantity)]),
+		);
+
+		// Check each non-single item to ensure the user has enough checked out to return
+		for (const requested of nonSingleItems) {
+			const currentBalance = balanceMap.get(requested.itemId) ?? 0;
+			// currentBalance is negative when items are checked out (e.g., -5 means 5 items checked out)
+			// The user can return at most Math.abs(currentBalance) items
+			const checkedOutQuantity = Math.abs(Math.min(0, currentBalance));
+
+			if (requested.quantity > checkedOutQuantity) {
+				const item = foundItems.find((i) => i.id === requested.itemId);
+				const itemName = item?.name ?? requested.itemId;
+
+				if (checkedOutQuantity === 0) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: `You do not have any "${itemName}" checked out to return`,
+					});
+				}
+
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Cannot return ${requested.quantity} of "${itemName}" — you only have ${checkedOutQuantity} checked out`,
+				});
+			}
 		}
 	}
 
@@ -161,12 +207,13 @@ export async function checkInHandler(options: TCheckInOptions) {
 	}
 
 	// Create transactions in a single DB transaction
+	// For single items, use the overridden userId (the original borrower)
 	const created = await prisma.$transaction(
 		items.map((it) =>
 			prisma.inventoryTransaction.create({
 				data: {
 					itemId: it.itemId,
-					userId,
+					userId: userIdOverrides.get(it.itemId) ?? userId,
 					action: "CHECK_IN",
 					quantity: it.quantity,
 					notes: it.notes,

--- a/packages/trpc/server/routers/inventory/transactions/checkOut.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/checkOut.route.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@ecehive/prisma";
+import { Prisma, prisma } from "@ecehive/prisma";
 import { TRPCError } from "@trpc/server";
 import z from "zod";
 import type { TInventoryProtectedProcedureContext } from "../../../trpc";
@@ -70,6 +70,46 @@ export async function checkOutHandler(options: TCheckOutOptions) {
 			code: "BAD_REQUEST",
 			message: `Cannot check out from inactive item: ${inactive.id}`,
 		});
+	}
+
+	// Validate single items: quantity must be 1 and the item must not already be checked out
+	const singleItems = foundItems.filter((i) => i.itemType === "single");
+	if (singleItems.length > 0) {
+		// Enforce quantity of 1 for single items
+		for (const singleItem of singleItems) {
+			const requested = items.find((i) => i.itemId === singleItem.id);
+			if (requested && requested.quantity !== 1) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `"${singleItem.name}" is an individual item and can only be checked out with a quantity of 1`,
+				});
+			}
+		}
+
+		// Check if any single items are already checked out (net balance < 0)
+		const singleItemIds = singleItems.map((i) => i.id);
+		const balances = await prisma.$queryRaw<
+			Array<{ itemId: string; netQuantity: bigint }>
+		>`
+			SELECT "itemId", SUM(quantity)::bigint as "netQuantity"
+			FROM "InventoryTransaction"
+			WHERE "itemId" IN (${Prisma.join(singleItemIds)})
+			GROUP BY "itemId"
+		`;
+
+		const balanceMap = new Map<string, number>(
+			balances.map((b) => [b.itemId, Number(b.netQuantity)]),
+		);
+
+		for (const singleItem of singleItems) {
+			const balance = balanceMap.get(singleItem.id) ?? 0;
+			if (balance < 0) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `"${singleItem.name}" is currently checked out and must be returned before it can be checked out again`,
+				});
+			}
+		}
 	}
 
 	// Check for items that require approval

--- a/packages/trpc/server/routers/inventory/transactions/checkUserBalance.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/checkUserBalance.route.ts
@@ -22,17 +22,22 @@ export async function checkUserBalanceHandler(
 ) {
 	const { userId } = options.input;
 
-	// Use aggregate query to efficiently check if any item has negative balance
-	// This lets the DB do the work instead of loading all transactions into memory
+	// Use aggregate query to efficiently check if any (non-consumable) item has
+	// negative balance.
+	//
+	// This lets the DB do the work instead of loading all transactions into
+	// memory.
 	const result = await prisma.$queryRaw<Array<{ has_checked_out: boolean }>>`
 		SELECT EXISTS (
 			SELECT 1
 			FROM (
-				SELECT "itemId", SUM(quantity) as net_quantity
-				FROM "InventoryTransaction"
-				WHERE "userId" = ${userId}
-				GROUP BY "itemId"
-				HAVING SUM(quantity) < 0
+				SELECT it."itemId", SUM(it.quantity) as net_quantity
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE it."userId" = ${userId}
+				  AND i."isConsumable" = FALSE
+				GROUP BY it."itemId"
+				HAVING SUM(it.quantity) < 0
 			) AS items_with_negative_balance
 		) AS has_checked_out
 	`;

--- a/packages/trpc/server/routers/inventory/transactions/checkUserBalance.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/checkUserBalance.route.ts
@@ -35,7 +35,7 @@ export async function checkUserBalanceHandler(
 				FROM "InventoryTransaction" it
 				INNER JOIN "Item" i ON it."itemId" = i.id
 				WHERE it."userId" = ${userId}
-				  AND i."isConsumable" = FALSE
+			  AND i."itemType" <> 'consumable'
 				GROUP BY it."itemId"
 				HAVING SUM(it.quantity) < 0
 			) AS items_with_negative_balance

--- a/packages/trpc/server/routers/inventory/transactions/getMyNetBalance.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/getMyNetBalance.route.ts
@@ -28,33 +28,34 @@ export async function getMyNetBalanceHandler(options: TGetMyNetBalanceOptions) {
 	if (search) {
 		const searchPattern = `%${search}%`;
 		result = await prisma.$queryRaw`
-      SELECT 
-        it."itemId",
-        i.name as "itemName",
-        i.sku as "itemSku",
-        SUM(it.quantity)::bigint as "netQuantity"
-      FROM "InventoryTransaction" it
-      INNER JOIN "Item" i ON it."itemId" = i.id
-      WHERE it."userId" = ${userId}
-        AND (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
-      GROUP BY it."itemId", i.name, i.sku
-      HAVING SUM(it.quantity) != 0
-      ORDER BY i.name ASC
-    `;
+			SELECT 
+				it."itemId",
+				i.name as "itemName",
+				i.sku as "itemSku",
+				SUM(it.quantity)::bigint as "netQuantity"
+			FROM "InventoryTransaction" it
+			INNER JOIN "Item" i ON it."itemId" = i.id
+			WHERE it."userId" = ${userId}
+				AND (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
+			GROUP BY it."itemId", i.name, i.sku
+			HAVING SUM(it.quantity) != 0
+			ORDER BY i.name ASC
+		`;
 	} else {
 		result = await prisma.$queryRaw`
-      SELECT 
-        it."itemId",
-        i.name as "itemName",
-        i.sku as "itemSku",
-        SUM(it.quantity)::bigint as "netQuantity"
-      FROM "InventoryTransaction" it
-      INNER JOIN "Item" i ON it."itemId" = i.id
-      WHERE it."userId" = ${userId}
-      GROUP BY it."itemId", i.name, i.sku
-      HAVING SUM(it.quantity) != 0
-      ORDER BY i.name ASC
-    `;
+			SELECT
+				it."itemId",
+				i.name as "itemName",
+				i.sku as "itemSku",
+				SUM(it.quantity)::bigint as "netQuantity"
+			FROM "InventoryTransaction" it
+			INNER JOIN "Item" i ON it."itemId" = i.id
+			WHERE it."userId" = ${userId}
+				AND i."isConsumable" = FALSE
+			GROUP BY it."itemId", i.name, i.sku
+			HAVING SUM(it.quantity) != 0
+			ORDER BY i.name ASC
+    	`;
 	}
 
 	// Convert bigint to number

--- a/packages/trpc/server/routers/inventory/transactions/getMyNetBalance.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/getMyNetBalance.route.ts
@@ -4,6 +4,7 @@ import type { TProtectedProcedureContext } from "../../../trpc";
 
 export const ZGetMyNetBalanceSchema = z.object({
 	search: z.string().min(1).max(100).optional(),
+	itemType: z.enum(["multiple", "single"]).optional(),
 });
 
 export type TGetMyNetBalanceSchema = z.infer<typeof ZGetMyNetBalanceSchema>;
@@ -14,7 +15,7 @@ export type TGetMyNetBalanceOptions = {
 };
 
 export async function getMyNetBalanceHandler(options: TGetMyNetBalanceOptions) {
-	const { search } = options.input;
+	const { search, itemType } = options.input;
 	const userId = options.ctx.user.id;
 
 	// Use raw SQL for efficient aggregation
@@ -22,40 +23,81 @@ export async function getMyNetBalanceHandler(options: TGetMyNetBalanceOptions) {
 		itemId: string;
 		itemName: string;
 		itemSku: string | null;
+		itemType: string;
 		netQuantity: bigint;
 	}>;
 
 	if (search) {
 		const searchPattern = `%${search}%`;
-		result = await prisma.$queryRaw`
-			SELECT 
-				it."itemId",
-				i.name as "itemName",
-				i.sku as "itemSku",
-				SUM(it.quantity)::bigint as "netQuantity"
-			FROM "InventoryTransaction" it
-			INNER JOIN "Item" i ON it."itemId" = i.id
-			WHERE it."userId" = ${userId}
-				AND (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
-			GROUP BY it."itemId", i.name, i.sku
-			HAVING SUM(it.quantity) != 0
-			ORDER BY i.name ASC
-		`;
+		if (itemType) {
+			result = await prisma.$queryRaw`
+				SELECT 
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE it."userId" = ${userId}
+					AND (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
+					AND i."itemType" = ${itemType}::"ItemType"
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		} else {
+			result = await prisma.$queryRaw`
+				SELECT 
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE it."userId" = ${userId}
+					AND (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
+					AND i."itemType" <> 'consumable'
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		}
 	} else {
-		result = await prisma.$queryRaw`
-			SELECT
-				it."itemId",
-				i.name as "itemName",
-				i.sku as "itemSku",
-				SUM(it.quantity)::bigint as "netQuantity"
-			FROM "InventoryTransaction" it
-			INNER JOIN "Item" i ON it."itemId" = i.id
-			WHERE it."userId" = ${userId}
-				AND i."isConsumable" = FALSE
-			GROUP BY it."itemId", i.name, i.sku
-			HAVING SUM(it.quantity) != 0
-			ORDER BY i.name ASC
-    	`;
+		if (itemType) {
+			result = await prisma.$queryRaw`
+				SELECT
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE it."userId" = ${userId}
+					AND i."itemType" = ${itemType}::"ItemType"
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		} else {
+			result = await prisma.$queryRaw`
+				SELECT
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE it."userId" = ${userId}
+					AND i."itemType" <> 'consumable'
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		}
 	}
 
 	// Convert bigint to number
@@ -63,6 +105,7 @@ export async function getMyNetBalanceHandler(options: TGetMyNetBalanceOptions) {
 		itemId: item.itemId,
 		itemName: item.itemName,
 		itemSku: item.itemSku,
+		itemType: item.itemType,
 		netQuantity: Number(item.netQuantity),
 	}));
 }

--- a/packages/trpc/server/routers/inventory/transactions/getNetBalance.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/getNetBalance.route.ts
@@ -27,31 +27,33 @@ export async function getNetBalanceHandler(options: TGetNetBalanceOptions) {
 	if (search) {
 		const searchPattern = `%${search}%`;
 		result = await prisma.$queryRaw`
-      SELECT 
-        it."itemId",
-        i.name as "itemName",
-        i.sku as "itemSku",
-        SUM(it.quantity)::bigint as "netQuantity"
-      FROM "InventoryTransaction" it
-      INNER JOIN "Item" i ON it."itemId" = i.id
-      WHERE i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern}
-      GROUP BY it."itemId", i.name, i.sku
-      HAVING SUM(it.quantity) != 0
-      ORDER BY i.name ASC
-    `;
+			SELECT 
+				it."itemId",
+				i.name as "itemName",
+				i.sku as "itemSku",
+				SUM(it.quantity)::bigint as "netQuantity"
+			FROM "InventoryTransaction" it
+			INNER JOIN "Item" i ON it."itemId" = i.id
+			WHERE (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
+				AND i."isConsumable" = FALSE
+			GROUP BY it."itemId", i.name, i.sku
+			HAVING SUM(it.quantity) != 0
+			ORDER BY i.name ASC
+		`;
 	} else {
 		result = await prisma.$queryRaw`
-      SELECT 
-        it."itemId",
-        i.name as "itemName",
-        i.sku as "itemSku",
-        SUM(it.quantity)::bigint as "netQuantity"
-      FROM "InventoryTransaction" it
-      INNER JOIN "Item" i ON it."itemId" = i.id
-      GROUP BY it."itemId", i.name, i.sku
-      HAVING SUM(it.quantity) != 0
-      ORDER BY i.name ASC
-    `;
+			SELECT 
+				it."itemId",
+				i.name as "itemName",
+				i.sku as "itemSku",
+				SUM(it.quantity)::bigint as "netQuantity"
+			FROM "InventoryTransaction" it
+			INNER JOIN "Item" i ON it."itemId" = i.id
+			WHERE i."isConsumable" = FALSE
+			GROUP BY it."itemId", i.name, i.sku
+			HAVING SUM(it.quantity) != 0
+			ORDER BY i.name ASC
+		`;
 	}
 
 	// Convert bigint to number

--- a/packages/trpc/server/routers/inventory/transactions/getNetBalance.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/getNetBalance.route.ts
@@ -4,6 +4,7 @@ import type { TPermissionProtectedProcedureContext } from "../../../trpc";
 
 export const ZGetNetBalanceSchema = z.object({
 	search: z.string().min(1).max(100).optional(),
+	itemType: z.enum(["multiple", "single"]).optional(),
 });
 
 export type TGetNetBalanceSchema = z.infer<typeof ZGetNetBalanceSchema>;
@@ -14,46 +15,84 @@ export type TGetNetBalanceOptions = {
 };
 
 export async function getNetBalanceHandler(options: TGetNetBalanceOptions) {
-	const { search } = options.input;
+	const { search, itemType } = options.input;
 
 	// Use raw SQL for efficient aggregation
 	let result: Array<{
 		itemId: string;
 		itemName: string;
 		itemSku: string | null;
+		itemType: string;
 		netQuantity: bigint;
 	}>;
 
 	if (search) {
 		const searchPattern = `%${search}%`;
-		result = await prisma.$queryRaw`
-			SELECT 
-				it."itemId",
-				i.name as "itemName",
-				i.sku as "itemSku",
-				SUM(it.quantity)::bigint as "netQuantity"
-			FROM "InventoryTransaction" it
-			INNER JOIN "Item" i ON it."itemId" = i.id
-			WHERE (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
-				AND i."isConsumable" = FALSE
-			GROUP BY it."itemId", i.name, i.sku
-			HAVING SUM(it.quantity) != 0
-			ORDER BY i.name ASC
-		`;
+		if (itemType) {
+			result = await prisma.$queryRaw`
+				SELECT 
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
+					AND i."itemType" = ${itemType}::"ItemType"
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		} else {
+			result = await prisma.$queryRaw`
+				SELECT 
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE (i.name ILIKE ${searchPattern} OR i.sku ILIKE ${searchPattern})
+					AND i."itemType" <> 'consumable'
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		}
 	} else {
-		result = await prisma.$queryRaw`
-			SELECT 
-				it."itemId",
-				i.name as "itemName",
-				i.sku as "itemSku",
-				SUM(it.quantity)::bigint as "netQuantity"
-			FROM "InventoryTransaction" it
-			INNER JOIN "Item" i ON it."itemId" = i.id
-			WHERE i."isConsumable" = FALSE
-			GROUP BY it."itemId", i.name, i.sku
-			HAVING SUM(it.quantity) != 0
-			ORDER BY i.name ASC
-		`;
+		if (itemType) {
+			result = await prisma.$queryRaw`
+				SELECT 
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE i."itemType" = ${itemType}::"ItemType"
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		} else {
+			result = await prisma.$queryRaw`
+				SELECT 
+					it."itemId",
+					i.name as "itemName",
+					i.sku as "itemSku",
+					i."itemType" as "itemType",
+					SUM(it.quantity)::bigint as "netQuantity"
+				FROM "InventoryTransaction" it
+				INNER JOIN "Item" i ON it."itemId" = i.id
+				WHERE i."itemType" <> 'consumable'
+				GROUP BY it."itemId", i.name, i.sku, i."itemType"
+				HAVING SUM(it.quantity) != 0
+				ORDER BY i.name ASC
+			`;
+		}
 	}
 
 	// Convert bigint to number
@@ -61,6 +100,7 @@ export async function getNetBalanceHandler(options: TGetNetBalanceOptions) {
 		itemId: item.itemId,
 		itemName: item.itemName,
 		itemSku: item.itemSku,
+		itemType: item.itemType,
 		netQuantity: Number(item.netQuantity),
 	}));
 }

--- a/packages/trpc/server/routers/inventory/transactions/list.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/list.route.ts
@@ -42,7 +42,7 @@ export async function listHandler(options: TListOptions) {
 			take: limit,
 			include: {
 				item: {
-					select: { id: true, name: true, sku: true },
+					select: { id: true, name: true, sku: true, isConsumable: true },
 				},
 				user: {
 					select: { id: true, name: true, username: true },

--- a/packages/trpc/server/routers/inventory/transactions/list.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/list.route.ts
@@ -42,7 +42,7 @@ export async function listHandler(options: TListOptions) {
 			take: limit,
 			include: {
 				item: {
-					select: { id: true, name: true, sku: true, isConsumable: true },
+					select: { id: true, name: true, sku: true, itemType: true },
 				},
 				user: {
 					select: { id: true, name: true, username: true },

--- a/packages/trpc/server/routers/inventory/transactions/listMy.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/listMy.route.ts
@@ -37,7 +37,9 @@ export async function listMyHandler(options: TListMyOptions) {
 			skip: offset,
 			take: limit,
 			include: {
-				item: { select: { id: true, name: true, sku: true } },
+				item: {
+					select: { id: true, name: true, sku: true, isConsumable: true },
+				},
 			},
 		}),
 		prisma.inventoryTransaction.count({ where }),

--- a/packages/trpc/server/routers/inventory/transactions/listMy.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/listMy.route.ts
@@ -38,7 +38,7 @@ export async function listMyHandler(options: TListMyOptions) {
 			take: limit,
 			include: {
 				item: {
-					select: { id: true, name: true, sku: true, isConsumable: true },
+					select: { id: true, name: true, sku: true, itemType: true },
 				},
 			},
 		}),


### PR DESCRIPTION
This PR adds `multiple`, `single`, and `consumable` item types to the inventory system. These types are all handled differently. It also fixes an approval role bug preventing authorized users from approving transactions.

`Multiple`
- Default item type, same behavior as items in previous versions
- Tracks net balance

`Single`
- Meant for an SKU that corresponds to only one item (like a key)
- Not tracked in net balance
- Can only have one checked out at a time
- Cannot be returned if not checked out
- Can be returned by anyone and will give return credit to the original person who checked it out

`Consumable`
- Meant for items that are not expected to be returned
- Not tracked in net balance
- Possible to return if desired