### PR TITLE
Add filtering to makeup shift table

### DIFF
--- a/apps/client/src/components/shared/date-range-selector.tsx
+++ b/apps/client/src/components/shared/date-range-selector.tsx
@@ -44,7 +44,7 @@ const DateRangeSelector: React.FC<DateRangeSelectorProps> = ({
 	useEffect(() => {
 		setRange(value ?? [undefined, undefined]);
 		// Extract time from dates if they exist
-		if (value?.[0]) {
+		if (typeof value?.[0] === "object" && value[0] instanceof Date) {
 			setStartTime(
 				`${value[0].getHours().toString().padStart(2, "0")}:${value[0]
 					.getMinutes()
@@ -52,7 +52,7 @@ const DateRangeSelector: React.FC<DateRangeSelectorProps> = ({
 					.padStart(2, "0")}`,
 			);
 		}
-		if (value?.[1]) {
+		if (typeof value?.[1] === "object" && value[1] instanceof Date) {
 			setEndTime(
 				`${value[1].getHours().toString().padStart(2, "0")}:${value[1]
 					.getMinutes()

--- a/apps/client/src/routes/app/shifts/my-shifts.tsx
+++ b/apps/client/src/routes/app/shifts/my-shifts.tsx
@@ -19,7 +19,12 @@ import {
 } from "@/components/my-shifts/columns";
 import { usePeriod } from "@/components/providers/period-provider";
 import { DataTable, TablePaginationFooter } from "@/components/shared";
+import DateRangeSelector from "@/components/shared/date-range-selector";
 import { TablePagination } from "@/components/shared/table-pagination";
+import {
+	type ShiftType,
+	ShiftTypeSelector,
+} from "@/components/shift-types/shift-type-selector";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -32,6 +37,13 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import {
 	Sheet,
 	SheetContent,
@@ -51,8 +63,13 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { CalendarSyncButton } from "@/components/user/calendar-sync-button";
+import { usePersistedTableState } from "@/hooks/use-persisted-table-state";
 import type { RequiredPermissions } from "@/lib/permissions";
-import { formatDateInAppTimezone, formatTimeRange } from "@/lib/timezone";
+import {
+	formatDateInAppTimezone,
+	formatTimeRange,
+	toUtcDateFromLocalInput,
+} from "@/lib/timezone";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/app/shifts/my-shifts")({
@@ -85,6 +102,27 @@ function getErrorMessage(error: unknown) {
 	return "Something went wrong";
 }
 
+function formatHourOption(hour: number) {
+	const normalizedHour = ((hour % 24) + 24) % 24;
+	const period = normalizedHour >= 12 ? "PM" : "AM";
+	const displayHour = normalizedHour % 12 || 12;
+	return `${displayHour}:00 ${period}`;
+}
+
+type MakeupFilters = {
+	shiftType: ShiftType | null;
+	dateRange: [Date | undefined, Date | undefined];
+	startHour: number | null;
+	restrictToSameType: boolean;
+};
+
+const DEFAULT_MAKEUP_FILTERS: MakeupFilters = {
+	shiftType: null,
+	dateRange: [undefined, undefined],
+	startHour: null,
+	restrictToSameType: true,
+};
+
 function MyShifts() {
 	const { period: selectedPeriodId } = usePeriod();
 	const [page, setPage] = React.useState(1);
@@ -103,13 +141,27 @@ function MyShifts() {
 		React.useState<number | null>(null);
 	const [dropNotes, setDropNotes] = React.useState("");
 	const [dropMakeupNotes, setDropMakeupNotes] = React.useState("");
-	const [restrictToSameType, setRestrictToSameType] = React.useState(true);
-	const [makeupPage, setMakeupPage] = React.useState(1);
+	const {
+		page: makeupPage,
+		setPage: setMakeupPage,
+		pageSize: makeupPageSize,
+		offset: makeupOffset,
+		filters: makeupFilters,
+		setFilters: setMakeupFilters,
+		resetToFirstPage: resetMakeupToFirstPage,
+	} = usePersistedTableState<MakeupFilters>({
+		pageKey: "my-shifts-makeup-options",
+		defaultFilters: DEFAULT_MAKEUP_FILTERS,
+		initialPageSize: 5,
+	});
 
 	const limit = pageSize;
 	const offset = (page - 1) * limit;
-	const makeupLimit = 5;
-	const makeupOffset = (makeupPage - 1) * makeupLimit;
+	const makeupLimit = makeupPageSize;
+	const restrictToSameType = makeupFilters?.restrictToSameType ?? true;
+	const selectedMakeupShiftType = makeupFilters?.shiftType ?? null;
+	const makeupDateRange = makeupFilters?.dateRange ?? [undefined, undefined];
+	const makeupStartHour = makeupFilters?.startHour ?? null;
 
 	const canDropPermission = true;
 	const canMakeupPermission = true;
@@ -130,11 +182,30 @@ function MyShifts() {
 			}
 			setDropMakeupNotes("");
 			setMakeupTarget(occurrence);
-			setRestrictToSameType(true);
+			setMakeupFilters((current) => {
+				const nextFilters = current ?? DEFAULT_MAKEUP_FILTERS;
+				const shouldResetShiftType =
+					nextFilters.restrictToSameType || nextFilters.shiftType === null;
+
+				return {
+					...nextFilters,
+					shiftType: shouldResetShiftType
+						? {
+								id: occurrence.shiftTypeId,
+								name: occurrence.shiftTypeName,
+								location: occurrence.shiftTypeLocation ?? "",
+							}
+						: nextFilters.shiftType,
+					restrictToSameType:
+						nextFilters.shiftType === null
+							? true
+							: nextFilters.restrictToSameType,
+				};
+			});
 			setSelectedMakeupOccurrenceId(null);
-			setMakeupPage(1);
+			resetMakeupToFirstPage();
 		},
-		[canMakeupPermission],
+		[canMakeupPermission, resetMakeupToFirstPage, setMakeupFilters],
 	);
 
 	const tableColumns = React.useMemo(
@@ -177,22 +248,38 @@ function MyShifts() {
 
 	const isMakeupSheetOpen = Boolean(makeupTarget);
 	const makeupQueryEnabled = Boolean(selectedPeriodId && makeupTarget);
+	const makeupDateFrom = React.useMemo(
+		() => toUtcDateFromLocalInput(makeupDateRange[0]),
+		[makeupDateRange],
+	);
+	const makeupDateTo = React.useMemo(() => {
+		const end = makeupDateRange[1];
+		if (!end) return null;
+		const inclusiveEnd = new Date(end);
+		inclusiveEnd.setHours(23, 59, 59, 999);
+		return toUtcDateFromLocalInput(inclusiveEnd);
+	}, [makeupDateRange]);
 	const { data: makeupOptionsData, isLoading: makeupOptionsLoading } = useQuery(
 		{
 			queryKey: [
 				"makeupOptions",
 				selectedPeriodId,
 				makeupTarget?.id,
-				restrictToSameType,
+				selectedMakeupShiftType?.id,
+				makeupDateFrom?.toISOString() ?? null,
+				makeupDateTo?.toISOString() ?? null,
+				makeupStartHour,
 				makeupPage,
 			],
 			queryFn: async () => {
 				if (!selectedPeriodId || !makeupTarget) return null;
 				return trpc.shiftOccurrences.listMakeupOptions.query({
 					periodId: selectedPeriodId,
-					shiftTypeId: restrictToSameType
-						? makeupTarget.shiftTypeId
-						: undefined,
+					shiftTypeId: selectedMakeupShiftType?.id,
+					dateFrom: makeupDateFrom ?? undefined,
+					dateTo: makeupDateTo ?? undefined,
+					startHourFrom: makeupStartHour ?? undefined,
+					collapseSlots: true,
 					limit: makeupLimit,
 					offset: makeupOffset,
 				});
@@ -200,10 +287,36 @@ function MyShifts() {
 			enabled: makeupQueryEnabled,
 		},
 	);
+	const { data: makeupStartHoursData } = useQuery({
+		queryKey: [
+			"makeupStartHours",
+			selectedPeriodId,
+			selectedMakeupShiftType?.id ?? null,
+		],
+		queryFn: async () => {
+			if (!selectedPeriodId) return null;
+			return trpc.shiftOccurrences.listMakeupStartHours.query({
+				periodId: selectedPeriodId,
+				shiftTypeId: selectedMakeupShiftType?.id,
+			});
+		},
+		enabled: Boolean(selectedPeriodId),
+	});
+	const makeupHourOptions = React.useMemo(
+		() =>
+			(makeupStartHoursData?.startHours ?? []).map((hour) => ({
+				value: hour,
+				label: formatHourOption(hour),
+			})),
+		[makeupStartHoursData],
+	);
 
 	const makeupOccurrences = makeupOptionsData?.occurrences ?? [];
 	const makeupTotal = makeupOptionsData?.total ?? 0;
 	const makeupTotalPages = Math.max(1, Math.ceil(makeupTotal / makeupLimit));
+	const hasSelectedHourOption =
+		makeupStartHour === null ||
+		makeupHourOptions.some((option) => option.value === makeupStartHour);
 	const modificationWindow = makeupOptionsData?.modificationWindow;
 	const dropDialogOpen = Boolean(dropTarget);
 	const dropSummary = dropTarget ? formatShiftSummary(dropTarget) : "";
@@ -218,6 +331,24 @@ function MyShifts() {
 			dropMakeupNotes.trim(),
 	);
 
+	React.useEffect(() => {
+		if (hasSelectedHourOption) {
+			return;
+		}
+
+		setMakeupFilters((current) => ({
+			...(current ?? DEFAULT_MAKEUP_FILTERS),
+			startHour: null,
+		}));
+		resetMakeupToFirstPage();
+		setSelectedMakeupOccurrenceId(null);
+	}, [
+		hasSelectedHourOption,
+		resetMakeupToFirstPage,
+		setMakeupFilters,
+		setSelectedMakeupOccurrenceId,
+	]);
+
 	const closeDropDialog = React.useCallback(() => {
 		setDropTarget(null);
 		setDropNotes("");
@@ -228,7 +359,7 @@ function MyShifts() {
 		setSelectedMakeupOccurrenceId(null);
 		setMakeupPage(1);
 		setDropMakeupNotes("");
-	}, []);
+	}, [setMakeupPage]);
 
 	const handleDropDialogOpenChange = React.useCallback(
 		(open: boolean) => {
@@ -294,11 +425,62 @@ function MyShifts() {
 	const handleRestrictToggle = React.useCallback(
 		(checked: boolean | "indeterminate") => {
 			const next = checked === true;
-			setRestrictToSameType(next);
-			setMakeupPage(1);
+			setMakeupFilters((current) => ({
+				...(current ?? DEFAULT_MAKEUP_FILTERS),
+				restrictToSameType: next,
+				shiftType:
+					next && makeupTarget
+						? {
+								id: makeupTarget.shiftTypeId,
+								name: makeupTarget.shiftTypeName,
+								location: makeupTarget.shiftTypeLocation ?? "",
+							}
+						: null,
+			}));
+			resetMakeupToFirstPage();
 			setSelectedMakeupOccurrenceId(null);
 		},
-		[],
+		[makeupTarget, resetMakeupToFirstPage, setMakeupFilters],
+	);
+
+	const handleMakeupShiftTypeChange = React.useCallback(
+		(shiftType: ShiftType | null) => {
+			setMakeupFilters((current) => ({
+				...(current ?? DEFAULT_MAKEUP_FILTERS),
+				shiftType,
+				restrictToSameType: Boolean(
+					makeupTarget && shiftType?.id === makeupTarget.shiftTypeId,
+				),
+			}));
+			resetMakeupToFirstPage();
+			setSelectedMakeupOccurrenceId(null);
+		},
+		[makeupTarget, resetMakeupToFirstPage, setMakeupFilters],
+	);
+
+	const handleMakeupDateRangeChange = React.useCallback(
+		(range: [Date | undefined, Date | undefined]) => {
+			setMakeupFilters((current) => ({
+				...(current ?? DEFAULT_MAKEUP_FILTERS),
+				dateRange: range,
+			}));
+			resetMakeupToFirstPage();
+			setSelectedMakeupOccurrenceId(null);
+		},
+		[resetMakeupToFirstPage, setMakeupFilters],
+	);
+
+	const handleMakeupStartHourChange = React.useCallback(
+		(value: string) => {
+			const parsed = value === "all" ? null : Number(value);
+			setMakeupFilters((current) => ({
+				...(current ?? DEFAULT_MAKEUP_FILTERS),
+				startHour: Number.isNaN(parsed) ? null : parsed,
+			}));
+			resetMakeupToFirstPage();
+			setSelectedMakeupOccurrenceId(null);
+		},
+		[resetMakeupToFirstPage, setMakeupFilters],
 	);
 
 	if (selectedPeriodId === null) {
@@ -444,6 +626,50 @@ function MyShifts() {
 										<Label htmlFor={restrictCheckboxId} className="text-sm">
 											Show only {makeupTarget.shiftTypeName} shifts
 										</Label>
+									</div>
+									<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+										<div className="space-y-2">
+											<Label className="text-sm">Shift type</Label>
+											<ShiftTypeSelector
+												value={selectedMakeupShiftType}
+												onChange={handleMakeupShiftTypeChange}
+												periodId={selectedPeriodId}
+												placeholder="All shift types"
+											/>
+										</div>
+										<div className="space-y-2">
+											<Label className="text-sm">Date</Label>
+											<DateRangeSelector
+												value={makeupDateRange}
+												onChange={handleMakeupDateRangeChange}
+											/>
+										</div>
+										<div className="space-y-2">
+											<Label className="text-sm">Starting hour</Label>
+											<Select
+												value={
+													makeupStartHour === null
+														? "all"
+														: String(makeupStartHour)
+												}
+												onValueChange={handleMakeupStartHourChange}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="All start hours" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="all">All start hours</SelectItem>
+													{makeupHourOptions.map((option) => (
+														<SelectItem
+															key={option.value}
+															value={String(option.value)}
+														>
+															{option.label}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</div>
 									</div>
 								</div>
 							) : null}

--- a/packages/trpc/server/routers/shiftOccurrences/_route.ts
+++ b/packages/trpc/server/routers/shiftOccurrences/_route.ts
@@ -10,7 +10,9 @@ import { listHandler, ZListSchema } from "./list.route";
 import { listForUserHandler, ZListForUserSchema } from "./listForUser.route";
 import {
 	listMakeupOptionsHandler,
+	listMakeupStartHoursHandler,
 	ZListMakeupOptionsSchema,
+	ZListMakeupStartHoursSchema,
 } from "./listMakeupOptions.route";
 import { listMyHandler, ZListMySchema } from "./listMy.route";
 import { listMyPastHandler, ZListMyPastSchema } from "./listMyPast.route";
@@ -38,4 +40,7 @@ export const shiftOccurrencesRouter = router({
 	listMakeupOptions: protectedProcedure
 		.input(ZListMakeupOptionsSchema)
 		.query(listMakeupOptionsHandler),
+	listMakeupStartHours: protectedProcedure
+		.input(ZListMakeupStartHoursSchema)
+		.query(listMakeupStartHoursHandler),
 });

--- a/packages/trpc/server/routers/shiftOccurrences/listMakeupOptions.route.ts
+++ b/packages/trpc/server/routers/shiftOccurrences/listMakeupOptions.route.ts
@@ -12,20 +12,39 @@ import { isWithinModifyWindow } from "./utils";
 export const ZListMakeupOptionsSchema = z.object({
 	periodId: z.number().min(1),
 	shiftTypeId: z.number().min(1).optional(),
+	dateFrom: z.coerce.date().optional(),
+	dateTo: z.coerce.date().optional(),
+	startHourFrom: z.number().int().min(0).max(23).optional(),
+	collapseSlots: z.boolean().optional(),
 	limit: z.number().min(1).max(50).optional(),
 	offset: z.number().min(0).optional(),
 });
 
+export const ZListMakeupStartHoursSchema = z.object({
+	periodId: z.number().min(1),
+	shiftTypeId: z.number().min(1).optional(),
+});
+
 export type TListMakeupOptionsSchema = z.infer<typeof ZListMakeupOptionsSchema>;
+export type TListMakeupStartHoursSchema = z.infer<
+	typeof ZListMakeupStartHoursSchema
+>;
 
 export type TListMakeupOptions = {
 	ctx: TProtectedProcedureContext;
 	input: TListMakeupOptionsSchema;
 };
 
-export async function listMakeupOptionsHandler(options: TListMakeupOptions) {
-	const { periodId, shiftTypeId, limit = 10, offset = 0 } = options.input;
-	const userId = options.ctx.user.id;
+export type TListMakeupStartHours = {
+	ctx: TProtectedProcedureContext;
+	input: TListMakeupStartHoursSchema;
+};
+
+async function getAccessiblePeriod(
+	ctx: TProtectedProcedureContext,
+	periodId: number,
+) {
+	const userId = ctx.user.id;
 
 	const [period, user] = await Promise.all([
 		prisma.period.findUnique({
@@ -62,8 +81,64 @@ export async function listMakeupOptionsHandler(options: TListMakeupOptions) {
 		roles: period.roles,
 	};
 	assertCanAccessPeriod(periodForAccess, userRoleIds, {
-		isSystemUser: options.ctx.user.isSystemUser,
+		isSystemUser: ctx.user.isSystemUser,
 	});
+
+	return period;
+}
+
+function getHourFromTimeString(time: string) {
+	const [hourValue] = time.split(":");
+	const parsedHour = Number.parseInt(hourValue ?? "", 10);
+	return Number.isNaN(parsedHour) ? null : parsedHour;
+}
+
+export async function listMakeupStartHoursHandler(
+	options: TListMakeupStartHours,
+) {
+	const { periodId, shiftTypeId } = options.input;
+
+	await getAccessiblePeriod(options.ctx, periodId);
+
+	const schedules = await prisma.shiftSchedule.findMany({
+		where: {
+			shiftType: {
+				periodId,
+				canSelfAssign: true,
+				...(shiftTypeId ? { id: shiftTypeId } : {}),
+			},
+		},
+		select: {
+			startTime: true,
+		},
+		distinct: ["startTime"],
+		orderBy: {
+			startTime: "asc",
+		},
+	});
+
+	const startHours = schedules
+		.map((schedule) => getHourFromTimeString(schedule.startTime))
+		.filter((hour): hour is number => hour !== null)
+		.filter((hour, index, array) => array.indexOf(hour) === index)
+		.sort((a, b) => a - b);
+
+	return { startHours };
+}
+
+export async function listMakeupOptionsHandler(options: TListMakeupOptions) {
+	const {
+		periodId,
+		shiftTypeId,
+		dateFrom,
+		dateTo,
+		startHourFrom,
+		collapseSlots = false,
+		limit = 10,
+		offset = 0,
+	} = options.input;
+	const userId = options.ctx.user.id;
+	const period = await getAccessiblePeriod(options.ctx, periodId);
 
 	const now = new Date();
 
@@ -84,14 +159,27 @@ export async function listMakeupOptionsHandler(options: TListMakeupOptions) {
 		(occurrence) => occurrence.timestamp,
 	);
 
+	const startTimeFilter =
+		typeof startHourFrom === "number"
+			? {
+					gte: `${startHourFrom.toString().padStart(2, "0")}:00`,
+					lt: `${Math.min(startHourFrom + 1, 24)
+						.toString()
+						.padStart(2, "0")}:00`,
+				}
+			: undefined;
+
 	const where: Prisma.ShiftOccurrenceWhereInput = {
 		timestamp: {
 			gt: now,
+			...(dateFrom ? { gte: dateFrom > now ? dateFrom : now } : {}),
+			...(dateTo ? { lte: dateTo } : {}),
 		},
 		users: {
 			none: {},
 		},
 		shiftSchedule: {
+			...(startTimeFilter ? { startTime: startTimeFilter } : {}),
 			shiftType: {
 				periodId,
 				canSelfAssign: true,
@@ -108,24 +196,48 @@ export async function listMakeupOptionsHandler(options: TListMakeupOptions) {
 		};
 	}
 
-	const [occurrences, total] = await Promise.all([
-		prisma.shiftOccurrence.findMany({
-			where,
-			orderBy: { timestamp: "asc" },
-			skip: offset,
-			take: limit,
-			include: {
-				shiftSchedule: {
-					include: {
-						shiftType: true,
-					},
+	const allOccurrences = await prisma.shiftOccurrence.findMany({
+		where,
+		orderBy: [{ timestamp: "asc" }, { slot: "asc" }],
+		include: {
+			shiftSchedule: {
+				include: {
+					shiftType: true,
 				},
 			},
-		}),
-		prisma.shiftOccurrence.count({ where }),
-	]);
+		},
+	});
 
-	const occurrencesForClient = occurrences.map((occurrence) => ({
+	const normalizedOccurrences = collapseSlots
+		? Array.from(
+				allOccurrences
+					.reduce((map, occurrence) => {
+						const key = [
+							occurrence.shiftScheduleId,
+							occurrence.shiftSchedule.shiftType.id,
+							occurrence.timestamp.toISOString(),
+							occurrence.shiftSchedule.startTime,
+							occurrence.shiftSchedule.endTime,
+						].join(":");
+
+						const existing = map.get(key);
+						if (!existing || occurrence.slot < existing.slot) {
+							map.set(key, occurrence);
+						}
+
+						return map;
+					}, new Map<number | string, (typeof allOccurrences)[number]>())
+					.values(),
+			)
+		: allOccurrences;
+
+	const total = normalizedOccurrences.length;
+	const paginatedOccurrences = normalizedOccurrences.slice(
+		offset,
+		offset + limit,
+	);
+
+	const occurrencesForClient = paginatedOccurrences.map((occurrence) => ({
 		id: occurrence.id,
 		timestamp: occurrence.timestamp,
 		slot: occurrence.slot,


### PR DESCRIPTION
This PR adds the following filtering options to the makeup shift table:
- Shift type (defaulting to same time as the shift being made up)
- Date range (with single day support)
- Starting hour (based on available shifts)