### PR TITLE
Add item transaction rate limiting

### DIFF
--- a/apps/client/src/components/inventory/columns.tsx
+++ b/apps/client/src/components/inventory/columns.tsx
@@ -1,6 +1,7 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
 import {
+	ClockIcon,
 	CookieIcon,
 	EllipsisIcon,
 	LinkIcon,
@@ -72,6 +73,25 @@ export function generateColumns(): ColumnDef<ItemRow>[] {
 								<TooltipContent>Individual item</TooltipContent>
 							</Tooltip>
 						) : null}
+						{row.transactionRateLimit !== undefined &&
+						row.transactionRateLimit !== null ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button variant="ghost" size="icon" className="h-6 w-6">
+										<ClockIcon className="h-4 w-4 text-amber-500" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent>
+									<div className="text-sm">
+										<div className="font-semibold mb-1">Transaction Limit</div>
+										<div>
+											{row.transactionRateLimit}{" per "}
+											{row.transactionRateLimitPeriod}
+										</div>
+									</div>
+								</TooltipContent>
+							</Tooltip>
+						) : null}
 						{row.approvalRoles && row.approvalRoles.length > 0 ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
@@ -80,7 +100,7 @@ export function generateColumns(): ColumnDef<ItemRow>[] {
 								<TooltipContent>
 									<div className="text-sm">
 										<div className="font-semibold mb-1">Restricted Item</div>
-										<div className="text-muted-foreground">
+										<div>
 											Requires approval from:
 										</div>
 										<ul className="mt-1 list-disc list-inside">

--- a/apps/client/src/components/inventory/create-dialog.tsx
+++ b/apps/client/src/components/inventory/create-dialog.tsx
@@ -81,6 +81,8 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 		link?: string;
 		isActive?: boolean;
 		itemType?: "multiple" | "single" | "consumable";
+		transactionRateLimit?: number;
+		transactionRateLimitPeriod?: "day" | "week" | "month" | "semester";
 		initialQuantity?: number;
 		approvalRoleIds?: number[];
 	};
@@ -105,6 +107,8 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 			link: "",
 			isActive: true,
 			itemType: "multiple",
+			transactionRateLimit: undefined,
+			transactionRateLimitPeriod: undefined,
 			initialQuantity: undefined,
 		},
 		validators: {
@@ -388,6 +392,59 @@ export function CreateDialog({ onUpdate }: CreateDialogProps): JSX.Element {
 							</Field>
 						)}
 					</form.Field>
+
+					<div className="gap-4 display: flex">
+						<form.Field name="transactionRateLimit">
+							{(field) => (
+								<Field>
+									<FieldLabel htmlFor={field.name}>
+										Transaction Rate Limit{" "}
+										<span className="text-muted-foreground">(optional)</span>
+									</FieldLabel>
+									<Input
+										id={field.name}
+										name={field.name}
+										value={field.state.value ?? ""}
+										onChange={(e) => field.handleChange(Number(e.target.value))}
+										onBlur={field.handleBlur}
+										placeholder="Enter transaction rate limit"
+									/>
+									<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+								</Field>
+							)}
+						</form.Field>
+						<form.Field name="transactionRateLimitPeriod">
+							{(field) => (
+								<Field>
+								<FieldLabel htmlFor={field.name}>
+									Per Period{" "}
+									<span className="text-muted-foreground">(optional)</span>
+								</FieldLabel>
+								<Select
+									value={field.state.value}
+									onValueChange={(value) =>
+										field.handleChange(
+											value as "day" | "week" | "month" | "semester"
+										)
+									}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder="Select period" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="day">Per day</SelectItem>
+										<SelectItem value="week">Per week</SelectItem>
+										<SelectItem value="month">Per month</SelectItem>
+										<SelectItem value="semester">
+											Per semester (90 days)
+										</SelectItem>
+									</SelectContent>
+								</Select>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+								</Field>
+							)}
+						</form.Field>
+					</div>
 
 					<Field>
 						<FieldLabel>

--- a/apps/client/src/components/inventory/edit-dialog.tsx
+++ b/apps/client/src/components/inventory/edit-dialog.tsx
@@ -56,6 +56,8 @@ type EditDialogProps = {
 		link?: string | null;
 		isActive: boolean;
 		itemType: "multiple" | "single" | "consumable";
+		transactionRateLimit?: number | null;
+		transactionRateLimitPeriod?: "day" | "week" | "month" | "semester" | null;
 		approvalRoles?: { id: number; name: string }[];
 	};
 	onUpdate?: () => void;
@@ -80,6 +82,8 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 		link?: string;
 		isActive?: boolean;
 		itemType?: "multiple" | "single" | "consumable";
+		transactionRateLimit?: number;
+		transactionRateLimitPeriod?: "day" | "week" | "month" | "semester";
 		approvalRoleIds?: number[];
 	};
 
@@ -113,6 +117,8 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 			quantity: undefined,
 			isActive: item.isActive,
 			itemType: item.itemType,
+			transactionRateLimit: item.transactionRateLimit ?? undefined,
+			transactionRateLimitPeriod: item.transactionRateLimitPeriod ?? undefined,
 		},
 		validators: {
 			onSubmit: formSchema,
@@ -402,6 +408,59 @@ export function EditDialog({ item, onUpdate }: EditDialogProps): JSX.Element {
 							</Field>
 						)}
 					</form.Field>
+
+					<div className="gap-4 display: flex">
+						<form.Field name="transactionRateLimit">
+							{(field) => (
+								<Field>
+									<FieldLabel htmlFor={field.name}>
+										Transaction Rate Limit{" "}
+										<span className="text-muted-foreground">(optional)</span>
+									</FieldLabel>
+									<Input
+										id={field.name}
+										name={field.name}
+										value={field.state.value ?? ""}
+										onChange={(e) => field.handleChange(Number(e.target.value))}
+										onBlur={field.handleBlur}
+										placeholder="Enter transaction rate limit"
+									/>
+									<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+								</Field>
+							)}
+						</form.Field>
+						<form.Field name="transactionRateLimitPeriod">
+							{(field) => (
+								<Field>
+								<FieldLabel htmlFor={field.name}>
+									Per Period{" "}
+									<span className="text-muted-foreground">(optional)</span>
+								</FieldLabel>
+								<Select
+									value={field.state.value}
+									onValueChange={(value) =>
+										field.handleChange(
+											value as "day" | "week" | "month" | "semester"
+										)
+									}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder="Select period" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="day">Per day</SelectItem>
+										<SelectItem value="week">Per week</SelectItem>
+										<SelectItem value="month">Per month</SelectItem>
+										<SelectItem value="semester">
+											Per semester (90 days)
+										</SelectItem>
+									</SelectContent>
+								</Select>
+								<FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+								</Field>
+							)}
+						</form.Field>
+					</div>
 
 					<Field>
 						<FieldLabel>

--- a/apps/client/src/components/inventory/types.ts
+++ b/apps/client/src/components/inventory/types.ts
@@ -8,6 +8,8 @@ export type ItemRow = {
 	link?: string | null;
 	isActive: boolean;
 	itemType: "multiple" | "single" | "consumable";
+	transactionRateLimit?: number | null;
+	transactionRateLimitPeriod?: "day" | "week" | "month" | "semester" | null;
 	snapshot?: { quantity: number } | null;
 	currentQuantity?: number | null;
 	createdAt?: string | null;

--- a/apps/client/src/routes/app/inventory/index.tsx
+++ b/apps/client/src/routes/app/inventory/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { HistoryIcon, LaptopMinimalCheckIcon } from "lucide-react";
+import { HistoryIcon, PackageSearchIcon } from "lucide-react";
 import { useCurrentUser } from "@/auth/AuthProvider";
 import { Page, PageContent, PageHeader, PageTitle } from "@/components/layout";
 import { Button } from "@/components/ui/button";
@@ -31,7 +31,7 @@ function InventoryIndex() {
 					<CardContent className="flex flex-col gap-2">
 						<Link to="/app/inventory/items">
 							<Button variant="outline" className="w-full justify-start">
-								<LaptopMinimalCheckIcon className="mr-2 h-4 w-4" />
+								<PackageSearchIcon className="mr-2 h-4 w-4" />
 								View Items
 							</Button>
 						</Link>

--- a/packages/prisma/migrations/20260407191251_item_transaction_rate_limits/migration.sql
+++ b/packages/prisma/migrations/20260407191251_item_transaction_rate_limits/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "transactionRateLimit" DOUBLE PRECISION;

--- a/packages/prisma/migrations/20260407221012_transaction_rate_limit_periods/migration.sql
+++ b/packages/prisma/migrations/20260407221012_transaction_rate_limit_periods/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "TransactionRateLimitPeriod" AS ENUM ('day', 'week', 'month', 'semester');
+
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "transactionRateLimitPeriod" "TransactionRateLimitPeriod";

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -297,21 +297,30 @@ enum ItemType {
   consumable
 }
 
+enum TransactionRateLimitPeriod {
+  day
+  week
+  month
+  semester
+}
+
 model Item {
-  id            String                 @id @default(uuid())
-  name          String
-  description   String?
-  sku           String?                @unique
-  location      String?
-  minQuantity   Int?
-  isActive      Boolean                @default(true)
-  itemType      ItemType               @default(multiple)
-  createdAt     DateTime               @default(now())
-  updatedAt     DateTime               @default(now()) @updatedAt
-  link          String?
-  snapshot      InventorySnapshot?
-  transactions  InventoryTransaction[]
-  approvalRoles Role[]                 @relation("ItemApprovalRoles")
+  id                          String                      @id @default(uuid())
+  name                        String
+  description                 String?
+  sku                         String?                     @unique
+  location                    String?
+  minQuantity                 Int?
+  isActive                    Boolean                     @default(true)
+  itemType                    ItemType                    @default(multiple)
+  transactionRateLimit        Float?                      // Max transactions per period, null for no limit
+  transactionRateLimitPeriod  TransactionRateLimitPeriod? // day, week, month, semester
+  createdAt                   DateTime                    @default(now())
+  updatedAt                   DateTime                    @default(now()) @updatedAt
+  link                        String?
+  snapshot                    InventorySnapshot?
+  transactions                InventoryTransaction[]
+  approvalRoles               Role[]                      @relation("ItemApprovalRoles")
 }
 
 model InventoryTransaction {

--- a/packages/trpc/server/routers/inventory/items/create.route.ts
+++ b/packages/trpc/server/routers/inventory/items/create.route.ts
@@ -11,6 +11,8 @@ export const ZCreateItemSchema = z.object({
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
 	itemType: z.enum(["multiple", "single", "consumable"]).optional(),
+	transactionRateLimit: z.number().optional(),
+	transactionRateLimitPeriod: z.enum(["day", "week", "month", "semester"]).optional(),
 	initialQuantity: z.number().int().min(0).optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });

--- a/packages/trpc/server/routers/inventory/items/update.route.ts
+++ b/packages/trpc/server/routers/inventory/items/update.route.ts
@@ -13,6 +13,8 @@ export const ZUpdateItemSchema = z.object({
 	link: z.string().url().optional().or(z.literal("")),
 	isActive: z.boolean().optional(),
 	itemType: z.enum(["multiple", "single", "consumable"]).optional(),
+	transactionRateLimit: z.number().optional(),
+	transactionRateLimitPeriod: z.enum(["day", "week", "month", "semester"]).optional(),
 	approvalRoleIds: z.array(z.number().int()).optional(),
 });
 

--- a/packages/trpc/server/routers/inventory/transactions/checkOut.route.ts
+++ b/packages/trpc/server/routers/inventory/transactions/checkOut.route.ts
@@ -72,6 +72,62 @@ export async function checkOutHandler(options: TCheckOutOptions) {
 		});
 	}
 
+	// Check transaction rate limit for each item
+	// Fetch existing transactions for the user within the rate limit period
+	for (const item of foundItems) {
+		if (item.transactionRateLimit) {
+			const rateLimitPeriod = item.transactionRateLimitPeriod || "day";
+			const now = new Date();
+			const startDate = new Date(now);
+			switch (rateLimitPeriod) {
+				case "day":
+					startDate.setDate(now.getDate() - 1);
+					break;
+				case "week":
+					startDate.setDate(now.getDate() - 7);
+					break;
+				case "month":
+					startDate.setMonth(now.getDate() - 30);
+					break;
+				case "semester":
+					startDate.setMonth(now.getDate() - 90);
+					break;
+			}
+
+			const existingTransactions = await prisma.inventoryTransaction.findMany({
+				where: {
+					userId,
+					itemId: item.id,
+					createdAt: {
+						gte: startDate,
+						lte: now,
+					},
+				},
+			});
+
+			const totalCheckedOut = existingTransactions.reduce(
+				(sum, tx) => sum + Math.abs(tx.quantity),
+				0
+			);
+
+			const quantity = items.find((i) => i.itemId === item.id)?.quantity;
+
+			if (!quantity) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Quantity not provided for item: ${item.name}`,
+				});
+			}
+
+			if (totalCheckedOut + quantity > item.transactionRateLimit) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: `Transaction rate limit exceeded for ${item.name}. Limit: ${item.transactionRateLimit} per ${item.transactionRateLimitPeriod}.`,
+				});
+			}
+		}
+	}
+
 	// Validate single items: quantity must be 1 and the item must not already be checked out
 	const singleItems = foundItems.filter((i) => i.itemType === "single");
 	if (singleItems.length > 0) {


### PR DESCRIPTION
This PR adds item transaction rate limiting.

Changes
- Add `transactionRateLimit` and `transactionRateLimitPeriod` to `Item` schema
- Periods can be day, week, month (30 days), or semester (90 days)
- Check out tRPC route returns an error to the kiosk if the transaction rate limit is exceeded
- Unrelated: changed the outdated icon in the inventory quick actions page to match the current items page icon