### PR TITLE
Add trainer page to control points

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,23 +284,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Normalize image names
+      - name: Normalize image owner
+        id: owner
         run: |
-          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
-          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
-          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
-
-      - name: Normalize image names
-        run: |
-          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
-          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
-          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata for server image
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-server
           tags: |
             type=raw,value=${{ needs.create-release.outputs.tag }}-${{ matrix.arch }},priority=900
             type=raw,value=v${{ needs.create-release.outputs.version }}-${{ matrix.arch }},priority=850
@@ -352,23 +345,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Normalize image names
+      - name: Normalize image owner
+        id: owner
         run: |
-          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
-          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
-          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
-
-      - name: Normalize image names
-        run: |
-          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
-          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
-          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata for migrate image
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-migrate
           tags: |
             type=raw,value=${{ needs.create-release.outputs.tag }}-${{ matrix.arch }},priority=900
             type=raw,value=v${{ needs.create-release.outputs.version }}-${{ matrix.arch }},priority=850
@@ -420,11 +406,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize image owner
+        id: owner
+        run: |
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata for web image
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-web
           tags: |
             type=raw,value=${{ needs.create-release.outputs.tag }}-${{ matrix.arch }},priority=900
             type=raw,value=v${{ needs.create-release.outputs.version }}-${{ matrix.arch }},priority=850
@@ -465,6 +456,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize image owner
+        id: owner
+        run: |
+          OWNER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+          echo "REPO_OWNER=$OWNER" >> "$GITHUB_ENV"
+          echo "SERVER_IMAGE_NAME=${{ env.REGISTRY }}/$OWNER/hums-server" >> "$GITHUB_ENV"
+          echo "MIGRATE_IMAGE_NAME=${{ env.REGISTRY }}/$OWNER/hums-migrate" >> "$GITHUB_ENV"
+          echo "WEB_IMAGE_NAME=${{ env.REGISTRY }}/$OWNER/hums-web" >> "$GITHUB_ENV"
+
       - name: Make images public
         run: |
           # Set packages to public visibility using organization packages API
@@ -492,32 +493,32 @@ jobs:
         run: |
           # Create multi-arch manifest for server
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:${TAG} \
-            -t ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:v${VERSION} \
-            -t ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:${TAG}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:${TAG}-arm64
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-server:${TAG} \
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-server:v${VERSION} \
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-server:latest \
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-server:${TAG}-amd64 \
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-server:${TAG}-arm64
 
           # Create multi-arch manifest for migrate
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}:${TAG} \
-            -t ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}:v${VERSION} \
-            -t ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}:${TAG}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}:${TAG}-arm64
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-migrate:${TAG} \
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-migrate:v${VERSION} \
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-migrate:latest \
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-migrate:${TAG}-amd64 \
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-migrate:${TAG}-arm64
 
           # Create multi-arch manifest for web
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:${TAG} \
-            -t ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:v${VERSION} \
-            -t ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:${TAG}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:${TAG}-arm64
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-web:${TAG} \
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-web:v${VERSION} \
+            -t ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-web:latest \
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-web:${TAG}-amd64 \
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-web:${TAG}-arm64
 
           # Capture manifest digests
-          SERVER_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:${TAG} --format '{{.Manifest.Digest}}')
-          MIGRATE_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}:${TAG} --format '{{.Manifest.Digest}}')
-          WEB_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:${TAG} --format '{{.Manifest.Digest}}')
+          SERVER_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-server:${TAG} --format '{{.Manifest.Digest}}')
+          MIGRATE_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-migrate:${TAG} --format '{{.Manifest.Digest}}')
+          WEB_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/hums-web:${TAG} --format '{{.Manifest.Digest}}')
 
           # Validate digests are non-empty
           for img in SERVER MIGRATE WEB; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize image names
+        run: |
+          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
+          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
+          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
+
+      - name: Normalize image names
+        run: |
+          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
+          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
+          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
+
       - name: Extract metadata for server image
         id: meta
         uses: docker/metadata-action@v5
@@ -339,6 +351,18 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize image names
+        run: |
+          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
+          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
+          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
+
+      - name: Normalize image names
+        run: |
+          echo "SERVER_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-server" >> "$GITHUB_ENV"
+          echo "MIGRATE_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-migrate" >> "$GITHUB_ENV"
+          echo "WEB_IMAGE_NAME=${GITHUB_REPOSITORY_OWNER,,}/hums-web" >> "$GITHUB_ENV"
 
       - name: Extract metadata for migrate image
         id: meta

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/client",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/client",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/client",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/client/src/components/control/create-point-dialog.tsx
+++ b/apps/client/src/components/control/create-point-dialog.tsx
@@ -62,6 +62,8 @@ export function CreateControlPointDialog({
 	const [open, setOpen] = useState(false);
 	const [serverError, setServerError] = useState<string | null>(null);
 	const [authorizedRoles, setAuthorizedRoles] = useState<Role[]>([]);
+	const [trainedRole, setTrainedRole] = useState<Role | null>(null);
+	const [trainerRole, setTrainerRole] = useState<Role | null>(null);
 	const queryClient = useQueryClient();
 	const formId = useId();
 
@@ -85,6 +87,8 @@ export function CreateControlPointDialog({
 			providerId: number;
 			providerConfig: Record<string, unknown>;
 			authorizedRoleIds?: number[];
+			trainedRoleId?: number | null;
+			trainerRoleId?: number | null;
 			autoTurnOffEnabled?: boolean;
 			autoTurnOffMinutes?: number | null;
 			isActive: boolean;
@@ -127,6 +131,8 @@ export function CreateControlPointDialog({
 						ipAddress: value.ipAddress,
 					},
 					authorizedRoleIds: authorizedRoles.map((r) => r.id),
+					trainedRoleId: trainedRole?.id,
+					trainerRoleId: trainerRole?.id,
 					autoTurnOffEnabled: value.autoTurnOffEnabled,
 					autoTurnOffMinutes: value.autoTurnOffEnabled
 						? value.autoTurnOffMinutes
@@ -151,6 +157,8 @@ export function CreateControlPointDialog({
 			if (nextOpen) {
 				form.reset();
 				setAuthorizedRoles([]);
+				setTrainedRole(null);
+				setTrainerRole(null);
 				setServerError(null);
 			}
 		},
@@ -332,7 +340,33 @@ export function CreateControlPointDialog({
 							onChange={setAuthorizedRoles}
 						/>
 						<p className="text-xs text-muted-foreground mt-1">
-							Leave empty to allow anyone with operate permission
+							Leave empty to allow anyone to operate
+						</p>
+					</Field>
+
+					<Field>
+						<FieldLabel>Trained Role</FieldLabel>
+						<RoleMultiSelect
+							value={trainedRole}
+							onChange={setTrainedRole}
+							selectionMode="single"
+						/>
+						<p className="text-xs text-muted-foreground mt-1">
+							This role is granted when a user is trained through the control
+							kiosk, and should be included in the authorized roles above
+						</p>
+					</Field>
+
+					<Field>
+						<FieldLabel>Trainer Role</FieldLabel>
+						<RoleMultiSelect
+							value={trainerRole}
+							onChange={setTrainerRole}
+							selectionMode="single"
+						/>
+						<p className="text-xs text-muted-foreground mt-1">
+							Users with this role can train other users (assigning the role
+							above) and mark the control point as active/inactive
 						</p>
 					</Field>
 

--- a/apps/client/src/components/control/edit-point-dialog.tsx
+++ b/apps/client/src/components/control/edit-point-dialog.tsx
@@ -68,6 +68,8 @@ type ControlPoint = {
 		providerType: string;
 	};
 	authorizedRoles: { id: number; name: string }[];
+	trainedRole: { id: number; name: string } | null;
+	trainerRole: { id: number; name: string } | null;
 	authorizedUsers: { id: number; name: string; username: string }[];
 	providerConfig?: {
 		tagName?: string;
@@ -88,6 +90,12 @@ export function EditControlPointDialog({
 	const [serverError, setServerError] = useState<string | null>(null);
 	const [authorizedRoles, setAuthorizedRoles] = useState<Role[]>(
 		point.authorizedRoles ?? [],
+	);
+	const [trainedRole, setTrainedRole] = useState<Role | null>(
+		point.trainedRole ?? null,
+	);
+	const [trainerRole, setTrainerRole] = useState<Role | null>(
+		point.trainerRole ?? null,
 	);
 	const queryClient = useQueryClient();
 	const formId = useId();
@@ -120,6 +128,8 @@ export function EditControlPointDialog({
 			providerId?: number;
 			providerConfig?: Record<string, unknown>;
 			authorizedRoleIds?: number[];
+			trainedRoleId?: number | null;
+			trainerRoleId?: number | null;
 			autoTurnOffEnabled?: boolean;
 			autoTurnOffMinutes?: number | null;
 			isActive?: boolean;
@@ -171,6 +181,8 @@ export function EditControlPointDialog({
 						ipAddress: value.ipAddress,
 					},
 					authorizedRoleIds: authorizedRoles.map((r) => r.id),
+					trainedRoleId: trainedRole?.id ?? null,
+					trainerRoleId: trainerRole?.id ?? null,
 					autoTurnOffEnabled: value.autoTurnOffEnabled,
 					autoTurnOffMinutes: value.autoTurnOffEnabled
 						? value.autoTurnOffMinutes
@@ -224,6 +236,8 @@ export function EditControlPointDialog({
 				setAuthorizedRoles(
 					pointDetails?.authorizedRoles ?? point.authorizedRoles ?? [],
 				);
+				setTrainedRole(pointDetails?.trainedRole ?? point.trainedRole ?? null);
+				setTrainerRole(pointDetails?.trainerRole ?? point.trainerRole ?? null);
 				setServerError(null);
 			}
 		},
@@ -394,8 +408,26 @@ export function EditControlPointDialog({
 							onChange={setAuthorizedRoles}
 						/>
 						<p className="text-xs text-muted-foreground mt-1">
-							Leave empty to allow anyone with operate permission
+							Leave empty to allow anyone to operate
 						</p>
+					</Field>
+
+					<Field>
+						<FieldLabel>Trained Role</FieldLabel>
+						<RoleMultiSelect
+							value={trainedRole}
+							onChange={setTrainedRole}
+							selectionMode="single"
+						/>
+					</Field>
+
+					<Field>
+						<FieldLabel>Trainer Role</FieldLabel>
+						<RoleMultiSelect
+							value={trainerRole}
+							onChange={setTrainerRole}
+							selectionMode="single"
+						/>
 					</Field>
 
 					<form.Field name="canControlOnline">

--- a/apps/client/src/components/roles/role-multiselect.tsx
+++ b/apps/client/src/components/roles/role-multiselect.tsx
@@ -9,21 +9,37 @@ import { useDebounce } from "@/lib/debounce";
 
 export type Role = { id: number; name: string };
 
-type RoleMultiSelectProps = {
+type RoleMultiSelectSingleProps = {
+	value: Role | null;
+	onChange: (role: Role | null) => void;
+	placeholder?: string;
+	onAdd?: (role: Role) => Promise<void> | void;
+	onRemove?: (role: Role) => Promise<void> | void;
+	selectionMode: "single";
+};
+
+type RoleMultiSelectMultipleProps = {
 	value: Role[];
 	onChange: (roles: Role[]) => void;
 	placeholder?: string;
 	onAdd?: (role: Role) => Promise<void> | void;
 	onRemove?: (role: Role) => Promise<void> | void;
+	selectionMode?: "multiple";
 };
 
-export function RoleMultiSelect({
-	value,
-	onChange,
-	placeholder = "Select roles...",
-	onAdd,
-	onRemove,
-}: RoleMultiSelectProps) {
+type RoleMultiSelectProps =
+	| RoleMultiSelectSingleProps
+	| RoleMultiSelectMultipleProps;
+
+export function RoleMultiSelect(props: RoleMultiSelectProps) {
+	const selectionMode = props.selectionMode ?? "multiple";
+	const {
+		placeholder = `Select role${selectionMode === "single" ? "" : "s"}...`,
+		onAdd,
+		onRemove,
+	} = props;
+	const value = props.value;
+	const onChange = props.onChange;
 	const [query, setQuery] = React.useState("");
 	const debounced = useDebounce(query, 250);
 
@@ -49,26 +65,36 @@ export function RoleMultiSelect({
 	);
 
 	// Convert value to MultiSelectOption format
-	const selectedOptions: MultiSelectOption<number>[] = React.useMemo(
-		() =>
-			value.map((r) => ({
-				id: r.id,
-				label: r.name,
-			})),
-		[value],
-	);
+	const selectedOptions: MultiSelectOption<number>[] = React.useMemo(() => {
+		var selectedRoles: Role[];
+		var val: Role[] | Role | null = value ?? [];
+		if (typeof val === "object" && "id" in val) {
+			// Single mode
+			selectedRoles = val ? [val] : [];
+		} else {
+			// Multiple mode
+			selectedRoles = (value as Role[]) || [];
+		}
+		return selectedRoles.map((r) => ({
+			id: r.id,
+			label: r.name,
+		}));
+	}, [value, selectionMode]);
 
 	// Handle selection changes
 	const handleChange = React.useCallback(
 		(newOptions: MultiSelectOption<number>[]) => {
-			onChange(
-				newOptions.map((opt) => ({
-					id: opt.id,
-					name: opt.label,
-				})),
-			);
+			const nextRoles = newOptions.map((opt) => ({
+				id: opt.id,
+				name: opt.label,
+			}));
+			if (selectionMode === "single") {
+				(onChange as (role: Role | null) => void)(nextRoles[0] ?? null);
+				return;
+			}
+			(onChange as (roles: Role[]) => void)(nextRoles);
 		},
-		[onChange],
+		[onChange, selectionMode],
 	);
 
 	// Handle add with optimistic update
@@ -105,6 +131,7 @@ export function RoleMultiSelect({
 			onAdd={onAdd ? handleAdd : undefined}
 			onRemove={onRemove ? handleRemove : undefined}
 			popoverWidth="w-[300px]"
+			selectionMode={selectionMode}
 		/>
 	);
 }

--- a/apps/client/src/components/ui/searchable-multi-select.tsx
+++ b/apps/client/src/components/ui/searchable-multi-select.tsx
@@ -61,6 +61,8 @@ export type SearchableMultiSelectProps<T = string | number> = {
 	showClearAll?: boolean;
 	/** Disable the component */
 	disabled?: boolean;
+	/** Selection mode for the component */
+	selectionMode?: "multiple" | "single";
 };
 
 export function SearchableMultiSelect<T = string | number>({
@@ -80,6 +82,7 @@ export function SearchableMultiSelect<T = string | number>({
 	className,
 	showClearAll = true,
 	disabled = false,
+	selectionMode = "multiple",
 }: SearchableMultiSelectProps<T>) {
 	const [open, setOpen] = React.useState(false);
 	const [internalSearch, setInternalSearch] = React.useState("");
@@ -96,15 +99,22 @@ export function SearchableMultiSelect<T = string | number>({
 	async function addOption(option: MultiSelectOption<T>) {
 		if (selectedIds.has(option.id)) return;
 		const previous = value;
-		onChange([...value, option]);
-		if (onAdd) {
-			try {
+		const nextValue = selectionMode === "single" ? [option] : [...value, option];
+		onChange(nextValue);
+		try {
+			if (onAdd) {
 				await onAdd(option);
-			} catch (err) {
-				// Revert optimistic update on error
-				onChange(previous);
-				throw err;
 			}
+			if (selectionMode === "single" && onRemove) {
+				const removed = previous.filter((item) => item.id !== option.id);
+				for (const removedOption of removed) {
+					await onRemove(removedOption);
+				}
+			}
+		} catch (err) {
+			// Revert optimistic update on error
+			onChange(previous);
+			throw err;
 		}
 	}
 
@@ -215,7 +225,9 @@ export function SearchableMultiSelect<T = string | number>({
 													} else {
 														addOption(option);
 													}
-													// Keep popover open for multi-selection
+													if (selectionMode === "single") {
+														setOpen(false);
+													}
 												}}
 											>
 												<div

--- a/apps/client/src/routes/app/control/points.tsx
+++ b/apps/client/src/routes/app/control/points.tsx
@@ -74,6 +74,8 @@ type ControlPoint = {
 		providerType: string;
 	};
 	authorizedRoles: { id: number; name: string }[];
+	trainedRole: { id: number; name: string } | null;
+	trainerRole: { id: number; name: string } | null;
 	authorizedUsers: { id: number; name: string; username: string }[];
 };
 
@@ -94,7 +96,7 @@ function ControlPointsPage() {
 
 	const [activeFilter, setActiveFilter] = React.useState<
 		"active" | "inactive" | "all"
-	>("active");
+	>("all");
 	const [classFilter, setClassFilter] = React.useState<
 		"SWITCH" | "DOOR" | "all"
 	>("all");
@@ -161,7 +163,7 @@ function ControlPointsPage() {
 			// System users can operate everything
 			if (user?.isSystemUser) return true;
 
-			// If no restrictions, anyone with operate permission can use it
+			// If no restrictions, anyone can operate
 			if (
 				point.authorizedRoles.length === 0 &&
 				point.authorizedUsers.length === 0

--- a/apps/control/package.json
+++ b/apps/control/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/control",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/control/package.json
+++ b/apps/control/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/control",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/control/package.json
+++ b/apps/control/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/control",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/control/src/App.tsx
+++ b/apps/control/src/App.tsx
@@ -49,7 +49,7 @@ function ControlPointStatusCard({
 	const isOn = controlPoint.currentState;
 
 	const getStatusText = () => {
-		if (!isActive) return "Offline";
+		if (!isActive) return "Disabled";
 		if (controlPoint.controlClass === "DOOR") {
 			return isOn ? "Unlocked" : "Locked";
 		}

--- a/apps/control/src/App.tsx
+++ b/apps/control/src/App.tsx
@@ -1,12 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
 	AlertCircle,
+	ArrowLeft,
 	CheckCircle2,
 	Clock,
 	DoorOpen,
 	Loader2,
 	LogOut,
 	RefreshCw,
+	Settings,
 	Usb,
 	Users,
 	Zap,
@@ -157,28 +159,55 @@ function SessionActionCard({
 // Control point button for the authenticated view
 function ControlPointButton({
 	point,
+	onManage,
 	onOperate,
 	isOperating,
+	canManage,
 	disabled,
 	index,
 }: {
 	point: ControlPointWithStatus;
+	onManage: (point: ControlPointWithStatus) => void;
 	onOperate: (point: ControlPointWithStatus) => void;
 	isOperating: boolean;
+	canManage: boolean;
 	disabled: boolean;
 	index: number;
 }) {
 	const Icon = point.controlClass === "DOOR" ? DoorOpen : Zap;
 	const isOn = point.currentState;
-	const actionText =
-		point.controlClass === "DOOR" ? "Unlock" : isOn ? "Turn Off" : "Turn On";
+	const actionText = point.isActive
+		? point.controlClass === "DOOR"
+			? "Unlock"
+			: isOn
+				? "Turn Off"
+				: "Turn On"
+		: "Disabled";
+
+	const handleOperate = () => {
+		if (disabled || !point.isActive) return;
+		onOperate(point);
+	};
+
+	const handleManage = (event: React.MouseEvent<HTMLButtonElement>) => {
+		event.stopPropagation();
+		onManage(point);
+	};
 
 	return (
-		<motion.button
+		<motion.div
 			key={point.id}
-			type="button"
-			disabled={disabled}
-			onClick={() => onOperate(point)}
+			role="button"
+			tabIndex={disabled ? -1 : 0}
+			aria-disabled={disabled || !point.isActive}
+			onClick={handleOperate}
+			onKeyDown={(event) => {
+				if (disabled || !point.isActive) return;
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					handleOperate();
+				}
+			}}
 			className={`relative bg-card text-card-foreground rounded-xl shadow-sm cursor-pointer transition-all p-4 md:p-6 border ${
 				isOn ? "border-green-500/50" : "border-border hover:border-primary/50"
 			} ${disabled ? "opacity-50 cursor-not-allowed" : "hover:scale-[1.02]"} ${isOperating ? "!opacity-100" : ""}`}
@@ -197,6 +226,19 @@ function ControlPointButton({
 						transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
 					/>
 				</div>
+			)}
+			{canManage && (
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					disabled={disabled}
+					aria-label={`Manage ${point.name}`}
+					onClick={handleManage}
+					className="absolute right-2 top-2 h-12 w-12"
+				>
+					<Settings className="size-10" />
+				</Button>
 			)}
 			<div className="flex flex-col items-center gap-2">
 				<div
@@ -225,7 +267,7 @@ function ControlPointButton({
 					</p>
 				)}
 			</div>
-		</motion.button>
+		</motion.div>
 	);
 }
 
@@ -237,12 +279,30 @@ function ControlKioskApp() {
 		state,
 		controlPoints,
 		isLoading: controlPointsLoading,
+		controlLogs,
+		isControlLogsLoading,
 		handleCardScan,
+		handleTrainingCardScan,
 		operateControlPoint,
 		logout,
 		handleSessionAction,
 		cancelConfirmation,
 		confirmAction,
+		selectedControlPoint,
+		startManagingControlPoint,
+		stopManagingControlPoint,
+		toggleControlPointActive,
+		isUpdatingControlPoint,
+		trainingControlPoint,
+		trainingStatusMessage,
+		trainingStatusType,
+		lastTrainedUserName,
+		openTrainingDialog,
+		closeTrainingDialog,
+		isTrainingUser,
+		controlLogsPoint,
+		openControlLogsDialog,
+		closeControlLogsDialog,
 	} = useControlWorkflow({
 		onSuccess: (message) => {
 			logger.info("Control operation success:", message);
@@ -254,7 +314,13 @@ function ControlKioskApp() {
 
 	// Set up card reader
 	const { connectionStatus, connect } = useCardReader({
-		onScan: handleCardScan,
+		onScan: (cardNumber) => {
+			if (trainingControlPoint) {
+				handleTrainingCardScan(cardNumber);
+				return;
+			}
+			handleCardScan(cardNumber);
+		},
 		onFatalError: (message) => {
 			logger.error("Card reader fatal error:", message);
 		},
@@ -401,10 +467,391 @@ function ControlKioskApp() {
 		);
 	}
 
+	if (isAuthenticated && state.authenticatedUser && selectedControlPoint) {
+		const point = selectedControlPoint;
+		const Icon = point.controlClass === "DOOR" ? DoorOpen : Zap;
+		const statusText = !point.isActive
+			? "Disabled"
+			: point.controlClass === "DOOR"
+				? point.currentState
+					? "Unlocked"
+					: "Locked"
+				: point.currentState
+					? "In Use"
+					: "Available";
+		const statusVariant = !point.isActive
+			? "secondary"
+			: point.currentState
+				? "warning"
+				: "success";
+		const trainingStatusText = trainingStatusMessage
+			? trainingStatusMessage
+			: lastTrainedUserName
+				? `Last trained: ${lastTrainedUserName}`
+				: "Waiting for card scan...";
+		const trainingStatusClass =
+			trainingStatusType === "error"
+				? "text-destructive"
+				: "text-muted-foreground";
+		const hasControlLogs = controlLogs.length > 0;
+
+		return (
+			<>
+				<div className="h-svh bg-background flex flex-col overflow-hidden">
+					<AuthenticatedHeader
+						logo={logo}
+						getLogoDataUrl={getLogoDataUrl}
+						userName={state.authenticatedUser.name}
+						onCancel={logout}
+					/>
+
+					<main className="flex-1 overflow-auto p-4 px-8">
+						<div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+							<div>
+								<p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
+									Manage Control Point
+								</p>
+								<h1 className="text-3xl font-bold">{point.name}</h1>
+								{point.location && (
+									<p className="text-sm text-muted-foreground mt-2">
+										{point.location}
+									</p>
+								)}
+							</div>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={stopManagingControlPoint}
+								className="gap-2"
+							>
+								<ArrowLeft className="w-4 h-4" />
+								Back
+							</Button>
+						</div>
+
+						<div className="grid gap-4 lg:grid-cols-[1.4fr_0.8fr]">
+							<Card className="p-6 space-y-6">
+								<div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+									<div className="flex items-center gap-4">
+										<div
+											className={`p-4 rounded-full ${point.currentState ? "bg-green-500/10" : "bg-muted"}`}
+										>
+											<Icon
+												className={`w-6 h-6 ${point.currentState ? "text-green-500" : "text-muted-foreground"}`}
+											/>
+										</div>
+										<div>
+											<p className="text-sm text-muted-foreground">
+												Control type
+											</p>
+											<h2 className="text-xl font-semibold">
+												{point.controlClass === "DOOR" ? "Door" : "Switch"}
+											</h2>
+										</div>
+									</div>
+									<Badge
+										variant={statusVariant}
+										className="uppercase text-lg font-semibold py-2 px-3"
+									>
+										{statusText}
+									</Badge>
+								</div>
+								<div className="grid gap-4 sm:grid-cols-2">
+									<div className="rounded-xl border border-border p-4 bg-background">
+										<p className="text-sm text-muted-foreground">Active</p>
+										<p className="mt-2 font-semibold">
+											{point.isActive ? "Yes" : "No"}
+										</p>
+									</div>
+									<button
+										type="button"
+										onClick={() => openControlLogsDialog(point)}
+										className="rounded-xl border border-border p-4 bg-background text-left transition hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+									>
+										<p className="text-sm text-muted-foreground">Control Logs</p>
+										<p className="mt-2 font-semibold">Tap to view logs</p>
+									</button>
+								</div>
+								<div className="rounded-xl border border-border p-4 bg-background space-y-2">
+									<p className="text-sm text-muted-foreground">Current state</p>
+									<p className="font-semibold">
+										{statusText}
+										{point.isActive &&
+											point.currentUserName &&
+											` by ${point.currentUserName}`}
+									</p>
+								</div>
+								<div className="flex flex-col gap-3 sm:flex-row">
+									<Button
+										onClick={() => toggleControlPointActive(point)}
+										disabled={isUpdatingControlPoint}
+										className="flex-1 text-lg font-semibold"
+										variant={point.isActive ? "destructive" : "success"}
+									>
+										{point.isActive ? "Deactivate" : "Activate"}
+									</Button>
+									<Button
+										variant="outline"
+										onClick={stopManagingControlPoint}
+										className="flex-1 text-lg font-semibold"
+									>
+										Close
+									</Button>
+								</div>
+							</Card>
+							<div className="space-y-4">
+								<Card className="p-6 space-y-4">
+									<h3 className="text-lg font-semibold">Training</h3>
+									{point.trainedRole ? (
+										<div className="space-y-4">
+											<div>
+												<p className="text-sm text-muted-foreground">
+													Trained role
+												</p>
+												<Badge variant="outline" className="text-xs">
+													{point.trainedRole.name}
+												</Badge>
+											</div>
+											<Button
+												className="w-full text-lg font-semibold"
+												onClick={() => openTrainingDialog(point)}
+											>
+												Train Users
+											</Button>
+										</div>
+									) : (
+										<p className="text-sm text-muted-foreground">
+											No trained role is configured for this point.
+										</p>
+									)}
+								</Card>
+								<Card className="p-6 space-y-4">
+									<h3 className="text-lg font-semibold">Authorized access</h3>
+									<div className="space-y-4">
+										<div>
+											<p className="text-sm text-muted-foreground">
+												Authorized roles
+											</p>
+											{point.authorizedRoles.length > 0 ? (
+												<div className="mt-2 flex flex-wrap gap-2">
+													{point.authorizedRoles.map((role) => (
+														<Badge
+															key={role.id}
+															variant="outline"
+															className="text-xs"
+														>
+															{role.name}
+														</Badge>
+													))}
+												</div>
+											) : (
+												<p className="mt-2 text-sm text-muted-foreground">
+													No role restrictions.
+												</p>
+											)}
+										</div>
+										<div>
+											<p className="text-sm text-muted-foreground">
+												Authorized users
+											</p>
+											{point.authorizedUsers.length > 0 ? (
+												<div className="mt-2 space-y-2">
+													{point.authorizedUsers.map((user) => (
+														<p key={user.id} className="text-sm">
+															{user.name}
+														</p>
+													))}
+												</div>
+											) : (
+												<p className="mt-2 text-sm text-muted-foreground">
+													No users are explicitly authorized.
+												</p>
+											)}
+										</div>
+									</div>
+								</Card>
+							</div>
+						</div>
+					</main>
+				</div>
+
+				<AnimatePresence>
+					{trainingControlPoint && (
+						<motion.div
+							className="fixed inset-0 z-[110] flex items-center justify-center bg-black/80 backdrop-blur-md"
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+							exit={{ opacity: 0 }}
+							onClick={closeTrainingDialog}
+						>
+							<motion.div
+								className="w-full max-w-2xl rounded-3xl bg-card p-8 shadow-xl border border-border"
+								initial={{ opacity: 0, scale: 0.95, y: 16 }}
+								animate={{ opacity: 1, scale: 1, y: 0 }}
+								exit={{ opacity: 0, scale: 0.95, y: 16 }}
+								transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+								onClick={(event) => event.stopPropagation()}
+							>
+								<div className="flex flex-col gap-6">
+									<div className="flex items-center justify-between">
+										<div>
+											<p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">
+												Training Mode
+											</p>
+											<h2 className="text-3xl font-bold">
+												Train Users for {trainingControlPoint.name}
+											</h2>
+											{trainingControlPoint.trainedRole && (
+												<div>
+													<p className="text-sm text-muted-foreground mt-2">
+														Granting Role
+													</p>
+													<Badge variant="outline" className="text-xs">
+														{trainingControlPoint.trainedRole.name}
+													</Badge>
+												</div>
+											)}
+										</div>
+										<Button variant="outline" onClick={closeTrainingDialog}>
+											Done
+										</Button>
+									</div>
+
+									<div className="flex items-center gap-4 rounded-2xl border border-border bg-background p-6">
+										<div className="relative flex items-center justify-center">
+											<motion.div
+												className="absolute h-4 w-4 rounded-full bg-primary/20"
+												animate={{ scale: [1, 3], opacity: [0.6, 0.2] }}
+												transition={{
+													duration: 1.6,
+													repeat: Infinity,
+													ease: "easeOut",
+												}}
+											/>
+											<motion.div
+												className="h-4 w-4 rounded-full bg-primary"
+												animate={{ opacity: [0.3, 1, 0.3] }}
+												transition={{ duration: 1.6, repeat: Infinity }}
+											/>
+										</div>
+										<div>
+											<p className="text-lg font-semibold">
+												Scan card to train user
+											</p>
+											<p className="text-sm text-muted-foreground">
+												You can scan multiple cards quickly without closing this
+												dialog.
+											</p>
+										</div>
+									</div>
+
+									<div className="flex items-center justify-between rounded-xl border border-border bg-background px-4 py-3">
+										<div
+											className={`text-sm font-medium ${trainingStatusClass}`}
+										>
+											{trainingStatusText}
+										</div>
+										{isTrainingUser && (
+											<div className="flex items-center gap-2 text-xs text-muted-foreground">
+												<Loader2 className="h-4 w-4 animate-spin" />
+												Saving
+											</div>
+										)}
+									</div>
+								</div>
+							</motion.div>
+						</motion.div>
+					)}
+				</AnimatePresence>
+
+				<AnimatePresence>
+					{controlLogsPoint && (
+						<motion.div
+							className="fixed inset-0 z-[110] flex items-center justify-center bg-black/80 backdrop-blur-md"
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+							exit={{ opacity: 0 }}
+							onClick={closeControlLogsDialog}
+						>
+							<motion.div
+								className="w-full max-w-3xl rounded-3xl bg-card p-8 shadow-xl border border-border"
+								initial={{ opacity: 0, scale: 0.95, y: 16 }}
+								animate={{ opacity: 1, scale: 1, y: 0 }}
+								exit={{ opacity: 0, scale: 0.95, y: 16 }}
+								transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+								onClick={(event) => event.stopPropagation()}
+							>
+								<div className="flex flex-col gap-6">
+									<div className="flex items-center justify-between">
+										<div>
+											<p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">
+												Control Logs
+											</p>
+											<h2 className="text-3xl font-bold">
+												{controlLogsPoint.name}
+											</h2>
+										</div>
+										<Button variant="outline" onClick={closeControlLogsDialog}>
+											Done
+										</Button>
+									</div>
+
+									<div className="rounded-2xl border border-border bg-background p-4">
+										<div className="mb-3 flex items-center justify-between">
+											<p className="text-sm font-semibold">Recent activity</p>
+											{isControlLogsLoading && (
+												<div className="flex items-center gap-2 text-xs text-muted-foreground">
+													<Loader2 className="h-4 w-4 animate-spin" />
+													Loading
+												</div>
+											)}
+										</div>
+										<div className="max-h-[320px] space-y-3 overflow-y-auto pr-2">
+											{hasControlLogs ? (
+												controlLogs.map((log) => (
+													<div
+														key={log.id}
+														className="flex items-center justify-between rounded-xl border border-border bg-card px-4 py-3"
+													>
+														<div>
+															<p className="text-sm font-semibold capitalize">
+																{log.action}
+															</p>
+															<p className="text-xs text-muted-foreground">
+																{log.userName}
+															</p>
+														</div>
+														<p className="text-xs text-muted-foreground">
+															{new Date(log.createdAt).toLocaleString()}
+														</p>
+													</div>
+												))
+											) : (
+												<p className="text-sm text-muted-foreground">
+													No log entries yet.
+												</p>
+											)}
+										</div>
+									</div>
+								</div>
+							</motion.div>
+						</motion.div>
+					)}
+				</AnimatePresence>
+			</>
+		);
+	}
+
 	// Authenticated view - new design with session controls and control points
 	if (isAuthenticated && state.authenticatedUser) {
-		const authorizedPoints = controlPoints.filter((p) =>
-			state.authenticatedUser?.authorizedControlPointIds.includes(p.id),
+		const authorizedPoints = controlPoints.filter(
+			(p) =>
+				(state.authenticatedUser?.authorizedControlPointIds.includes(p.id) &&
+					p.isActive) ||
+				state.authenticatedUser?.managedControlPointIds.includes(p.id),
+		);
+		const managedPoints = controlPoints.filter((p) =>
+			state.authenticatedUser?.managedControlPointIds.includes(p.id),
 		);
 		const isInSession = !!state.authenticatedUser.currentSession;
 		const isStaffing =
@@ -512,7 +959,9 @@ function ControlKioskApp() {
 									<ControlPointButton
 										key={point.id}
 										point={point}
+										onManage={startManagingControlPoint}
 										onOperate={operateControlPoint}
+										canManage={managedPoints.some((p) => p.id === point.id)}
 										isOperating={state.operatingPointId === point.id}
 										disabled={!!state.operatingPointId}
 										index={index}

--- a/apps/control/src/hooks/use-control-workflow.ts
+++ b/apps/control/src/hooks/use-control-workflow.ts
@@ -10,6 +10,7 @@ interface AuthenticatedUser {
 	name: string;
 	cardNumber: string;
 	authorizedControlPointIds: string[];
+	managedControlPointIds: string[];
 	hasStaffingPermission: boolean;
 	currentSession: {
 		id: number;
@@ -39,7 +40,20 @@ interface ControlKioskState {
 	showSessionSelection: boolean;
 	operatingPointId: string | null; // Track which control point is being operated
 	pendingConfirmation: ConfirmationState | null; // Track pending confirmation dialog
+	selectedControlPoint: ControlPointWithStatus | null;
+	trainingControlPoint: ControlPointWithStatus | null;
+	trainingStatusMessage: string | null;
+	trainingStatusType: "success" | "error" | null;
+	lastTrainedUserName: string | null;
+	controlLogsPoint: ControlPointWithStatus | null;
 }
+
+type ControlLogEntry = {
+	id: string;
+	action: "login" | "logout";
+	createdAt: Date;
+	userName: string;
+};
 
 interface UseControlWorkflowOptions {
 	onSuccess?: (message: string) => void;
@@ -57,6 +71,12 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 		showSessionSelection: false,
 		operatingPointId: null,
 		pendingConfirmation: null,
+		selectedControlPoint: null,
+		trainingControlPoint: null,
+		trainingStatusMessage: null,
+		trainingStatusType: null,
+		lastTrainedUserName: null,
+		controlLogsPoint: null,
 	});
 
 	// Get control points available on this device
@@ -66,12 +86,30 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 		refetchInterval: 5000, // Refetch every 5 seconds for status updates
 	});
 
+	const controlLogsQuery = useQuery({
+		queryKey: ["controlKiosk", "controlLogs", state.controlLogsPoint?.id],
+		queryFn: async () => {
+			if (!state.controlLogsPoint) {
+				return { logs: [] };
+			}
+
+			return trpc.controlKiosk.getControlLogs.query({
+				controlPointId: state.controlLogsPoint.id,
+				limit: 50,
+			});
+		},
+		enabled: !!state.controlLogsPoint,
+	});
+
 	// Check user permissions mutation
 	const checkPermissionsMutation = useMutation({
 		mutationFn: (input: { cardNumber: string }) =>
 			trpc.controlKiosk.checkUserPermissions.query(input),
 		onSuccess: (data, variables) => {
-			if (data.authorizedControlPoints.length === 0) {
+			if (
+				data.authorizedControlPoints.length === 0 &&
+				data.managedControlPoints.length === 0
+			) {
 				const errorMsg =
 					"You don't have permission to control any points on this device";
 				setState((prev) => ({
@@ -92,6 +130,7 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 						authorizedControlPointIds: data.authorizedControlPoints.map(
 							(p) => p.id,
 						),
+						managedControlPointIds: data.managedControlPoints.map((p) => p.id),
 						hasStaffingPermission: data.hasStaffingPermission,
 						currentSession: data.currentSession
 							? {
@@ -157,6 +196,70 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 					})),
 				calculateReadingDuration(errorMsg),
 			);
+		},
+	});
+
+	const updatePointMutation = useMutation({
+		mutationFn: (input: {
+			id: string;
+			isActive: boolean;
+			cardNumber: string;
+		}) =>
+			trpc.controlKiosk.updatePoint.mutate({
+				cardNumber: input.cardNumber,
+				controlPointId: input.id,
+				isActive: input.isActive,
+			}),
+		onSuccess: (_data, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: ["controlKiosk", "controlPoints"],
+			});
+			setState((prev) => ({
+				...prev,
+				selectedControlPoint:
+					prev.selectedControlPoint &&
+					prev.selectedControlPoint.id === variables.id
+						? {
+								...prev.selectedControlPoint,
+								isActive: variables.isActive,
+							}
+						: prev.selectedControlPoint,
+			}));
+			onSuccess?.("Control point updated successfully");
+		},
+		onError: (error: Error) => {
+			logger.error("Failed to update control point:", error);
+			const errorMsg = error.message || "Failed to update control point";
+			setState((prev) => ({ ...prev, error: errorMsg }));
+			onError?.(errorMsg);
+			setTimeout(
+				() => setState((prev) => ({ ...prev, error: null })),
+				calculateReadingDuration(errorMsg),
+			);
+		},
+	});
+
+	const trainUserMutation = useMutation({
+		mutationFn: (input: {
+			controlPointId: string;
+			trainerCardNumber: string;
+			traineeCardNumber: string;
+		}) => trpc.controlKiosk.trainUser.mutate(input),
+		onSuccess: (data) => {
+			setState((prev) => ({
+				...prev,
+				lastTrainedUserName: data.userName,
+				trainingStatusMessage: null,
+				trainingStatusType: "success",
+			}));
+		},
+		onError: (error: Error) => {
+			const errorMsg = error.message || "Failed to train user";
+			setState((prev) => ({
+				...prev,
+				trainingStatusMessage: errorMsg,
+				trainingStatusType: "error",
+			}));
 		},
 	});
 
@@ -253,14 +356,21 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 			logger.info("Card scanned for control access");
 
 			// Authenticate the user
-			setState({
+			setState((prev) => ({
+				...prev,
 				mode: "processing",
 				authenticatedUser: null,
 				error: null,
 				showSessionSelection: false,
 				operatingPointId: null,
 				pendingConfirmation: null,
-			});
+				selectedControlPoint: null,
+				trainingControlPoint: null,
+				trainingStatusMessage: null,
+				trainingStatusType: null,
+				lastTrainedUserName: null,
+				controlLogsPoint: null,
+			}));
 
 			checkPermissionsMutation.mutate({ cardNumber });
 		},
@@ -304,20 +414,122 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 	);
 
 	const resetToIdle = useCallback(() => {
-		setState({
+		setState((prev) => ({
+			...prev,
 			mode: "idle",
 			authenticatedUser: null,
 			error: null,
 			showSessionSelection: false,
 			operatingPointId: null,
 			pendingConfirmation: null,
-		});
+			selectedControlPoint: null,
+			trainingControlPoint: null,
+			trainingStatusMessage: null,
+			trainingStatusType: null,
+			lastTrainedUserName: null,
+			controlLogsPoint: null,
+		}));
 	}, []);
 
 	const logout = useCallback(() => {
 		logger.info("User logged out from control kiosk");
 		resetToIdle();
 	}, [resetToIdle]);
+
+	const startManagingControlPoint = useCallback(
+		(controlPoint: ControlPointWithStatus) => {
+			setState((prev) => ({ ...prev, selectedControlPoint: controlPoint }));
+		},
+		[],
+	);
+
+	const stopManagingControlPoint = useCallback(() => {
+		setState((prev) => ({
+			...prev,
+			selectedControlPoint: null,
+			trainingControlPoint: null,
+			trainingStatusMessage: null,
+			trainingStatusType: null,
+			lastTrainedUserName: null,
+			controlLogsPoint: null,
+		}));
+	}, []);
+
+	const openControlLogsDialog = useCallback(
+		(controlPoint: ControlPointWithStatus) => {
+			setState((prev) => ({
+				...prev,
+				controlLogsPoint: controlPoint,
+			}));
+		},
+		[],
+	);
+
+	const closeControlLogsDialog = useCallback(() => {
+		setState((prev) => ({
+			...prev,
+			controlLogsPoint: null,
+		}));
+	}, []);
+
+	const openTrainingDialog = useCallback(
+		(controlPoint: ControlPointWithStatus) => {
+			setState((prev) => ({
+				...prev,
+				trainingControlPoint: controlPoint,
+				trainingStatusMessage: null,
+				trainingStatusType: null,
+				lastTrainedUserName: null,
+			}));
+		},
+		[],
+	);
+
+	const closeTrainingDialog = useCallback(() => {
+		setState((prev) => ({
+			...prev,
+			trainingControlPoint: null,
+			trainingStatusMessage: null,
+			trainingStatusType: null,
+			lastTrainedUserName: null,
+		}));
+	}, []);
+
+	const handleTrainingCardScan = useCallback(
+		(cardNumber: string) => {
+			if (!state.authenticatedUser || !state.trainingControlPoint) {
+				return;
+			}
+
+			setState((prev) => ({
+				...prev,
+				trainingStatusMessage: null,
+				trainingStatusType: null,
+			}));
+
+			trainUserMutation.mutate({
+				controlPointId: state.trainingControlPoint.id,
+				trainerCardNumber: state.authenticatedUser.cardNumber,
+				traineeCardNumber: cardNumber,
+			});
+		},
+		[state.authenticatedUser, state.trainingControlPoint, trainUserMutation],
+	);
+
+	const toggleControlPointActive = useCallback(
+		(controlPoint: ControlPointWithStatus) => {
+			if (state.mode !== "authenticated" || !state.authenticatedUser) {
+				return;
+			}
+
+			updatePointMutation.mutate({
+				id: controlPoint.id,
+				isActive: !controlPoint.isActive,
+				cardNumber: state.authenticatedUser.cardNumber,
+			});
+		},
+		[state.mode, state.authenticatedUser, updatePointMutation],
+	);
 
 	const showSessionSelection = useCallback(() => {
 		setState((prev) => ({ ...prev, showSessionSelection: true }));
@@ -471,12 +683,15 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 		state,
 		controlPoints: (controlPointsQuery.data?.controlPoints ??
 			[]) as ControlPointWithStatus[],
+		controlLogs: (controlLogsQuery.data?.logs ?? []) as ControlLogEntry[],
 		isLoading: controlPointsQuery.isLoading,
+		isControlLogsLoading: controlLogsQuery.isLoading,
 		isProcessing:
 			checkPermissionsMutation.isPending ||
 			operateMutation.isPending ||
 			tapInOutMutation.isPending,
 		handleCardScan,
+		handleTrainingCardScan,
 		operateControlPoint,
 		logout,
 		resetToIdle,
@@ -490,5 +705,20 @@ export function useControlWorkflow(options: UseControlWorkflowOptions = {}) {
 			queryClient.invalidateQueries({
 				queryKey: ["controlKiosk", "controlPoints"],
 			}),
+		selectedControlPoint: state.selectedControlPoint,
+		startManagingControlPoint,
+		stopManagingControlPoint,
+		toggleControlPointActive,
+		isUpdatingControlPoint: updatePointMutation.isPending,
+		trainingControlPoint: state.trainingControlPoint,
+		trainingStatusMessage: state.trainingStatusMessage,
+		trainingStatusType: state.trainingStatusType,
+		lastTrainedUserName: state.lastTrainedUserName,
+		openTrainingDialog,
+		closeTrainingDialog,
+		isTrainingUser: trainUserMutation.isPending,
+		controlLogsPoint: state.controlLogsPoint,
+		openControlLogsDialog,
+		closeControlLogsDialog,
 	};
 }

--- a/apps/control/src/types/index.ts
+++ b/apps/control/src/types/index.ts
@@ -147,6 +147,7 @@ export type AuthenticatedUser = {
 	name: string;
 	cardNumber: string;
 	authorizedControlPointIds: string[];
+	managedControlPointIds: string[];
 };
 
 export type ControlKioskState = {

--- a/apps/control/src/types/index.ts
+++ b/apps/control/src/types/index.ts
@@ -136,6 +136,8 @@ export type ControlPointWithStatus = {
 	isActive: boolean;
 	canControlOnline: boolean;
 	authorizedRoles: { id: number; name: string }[];
+	trainedRole: { id: number; name: string } | null;
+	trainerRole: { id: number; name: string } | null;
 	authorizedUsers: { id: number; name: string }[];
 	currentUserName: string | null;
 };

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/inventory",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/inventory",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/inventory",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/kiosk/package.json
+++ b/apps/kiosk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/kiosk",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/kiosk/package.json
+++ b/apps/kiosk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/kiosk",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/kiosk/package.json
+++ b/apps/kiosk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/kiosk",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/overview/package.json
+++ b/apps/overview/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/overview",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/overview/package.json
+++ b/apps/overview/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/overview",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/overview/package.json
+++ b/apps/overview/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/overview",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/server",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"scripts": {
 		"start": "bun ./src/index.ts",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/server",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"scripts": {
 		"start": "bun ./src/index.ts",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/server",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"scripts": {
 		"start": "bun ./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/hums",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"workspaces": [
 		"apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/hums",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"workspaces": [
 		"apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/hums",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"workspaces": [
 		"apps/*",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/auth",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/auth",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/auth",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/card-scanner/package.json
+++ b/packages/card-scanner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/card-scanner",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",

--- a/packages/card-scanner/package.json
+++ b/packages/card-scanner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/card-scanner",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",

--- a/packages/card-scanner/package.json
+++ b/packages/card-scanner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/card-scanner",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/config",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"types": "./types/index.d.ts",
 	"files": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/config",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"types": "./types/index.d.ts",
 	"files": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/config",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"types": "./types/index.d.ts",
 	"files": [

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/email",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/email",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/email",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/env",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/env",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/env",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/features",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/features",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/features",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/features/src/control/create-control-point.ts
+++ b/packages/features/src/control/create-control-point.ts
@@ -17,6 +17,8 @@ export interface CreateControlPointInput {
 	providerId: number;
 	providerConfig: Record<string, unknown>;
 	authorizedRoleIds?: number[];
+	trainedRoleId?: number;
+	trainerRoleId?: number;
 	authorizedUserIds?: number[];
 	autoTurnOffEnabled?: boolean;
 	autoTurnOffMinutes?: number | null;
@@ -67,6 +69,8 @@ export async function createControlPoint(input: CreateControlPointInput) {
 			authorizedRoles: input.authorizedRoleIds?.length
 				? { connect: input.authorizedRoleIds.map((id) => ({ id })) }
 				: undefined,
+			trainedRoleId: input.trainedRoleId ?? undefined,
+			trainerRoleId: input.trainerRoleId ?? undefined,
 			authorizedUsers: input.authorizedUserIds?.length
 				? { connect: input.authorizedUserIds.map((id) => ({ id })) }
 				: undefined,
@@ -80,6 +84,12 @@ export async function createControlPoint(input: CreateControlPointInput) {
 				},
 			},
 			authorizedRoles: {
+				select: { id: true, name: true },
+			},
+			trainedRole: {
+				select: { id: true, name: true },
+			},
+			trainerRole: {
 				select: { id: true, name: true },
 			},
 			authorizedUsers: {

--- a/packages/features/src/control/get-control-point.ts
+++ b/packages/features/src/control/get-control-point.ts
@@ -18,6 +18,12 @@ export async function getControlPoint(id: string) {
 			authorizedRoles: {
 				select: { id: true, name: true },
 			},
+			trainedRole: {
+				select: { id: true, name: true },
+			},
+			trainerRole: {
+				select: { id: true, name: true },
+			},
 			authorizedUsers: {
 				select: { id: true, name: true, username: true, email: true },
 			},
@@ -47,6 +53,12 @@ export async function findControlPoint(id: string) {
 				},
 			},
 			authorizedRoles: {
+				select: { id: true, name: true },
+			},
+			trainedRole: {
+				select: { id: true, name: true },
+			},
+			trainerRole: {
 				select: { id: true, name: true },
 			},
 			authorizedUsers: {

--- a/packages/features/src/control/invoke-control-gateway.ts
+++ b/packages/features/src/control/invoke-control-gateway.ts
@@ -54,6 +54,8 @@ export async function invokeControlGateway(
 						include: {
 							provider: true,
 							authorizedRoles: { select: { id: true } },
+							trainedRole: { select: { id: true, name: true } },
+							trainerRole: { select: { id: true, name: true } },
 							authorizedUsers: { select: { id: true } },
 						},
 					},

--- a/packages/features/src/control/list-control-points.ts
+++ b/packages/features/src/control/list-control-points.ts
@@ -74,6 +74,12 @@ export async function listControlPoints(
 				authorizedRoles: {
 					select: { id: true, name: true },
 				},
+				trainedRole: {
+					select: { id: true, name: true },
+				},
+				trainerRole: {
+					select: { id: true, name: true },
+				},
 				authorizedUsers: {
 					select: { id: true, name: true, username: true },
 				},

--- a/packages/features/src/control/operate-control-points.ts
+++ b/packages/features/src/control/operate-control-points.ts
@@ -86,6 +86,8 @@ export async function operateControlPoint(
 		include: {
 			provider: true,
 			authorizedRoles: { select: { id: true } },
+			trainedRole: { select: { id: true, name: true } },
+			trainerRole: { select: { id: true, name: true } },
 			authorizedUsers: { select: { id: true } },
 		},
 	});
@@ -217,6 +219,8 @@ export async function operateControlPointByUserId(
 		include: {
 			provider: true,
 			authorizedRoles: { select: { id: true } },
+			trainedRole: { select: { id: true, name: true } },
+			trainerRole: { select: { id: true, name: true } },
 			authorizedUsers: { select: { id: true } },
 		},
 	});

--- a/packages/features/src/control/update-control-point.ts
+++ b/packages/features/src/control/update-control-point.ts
@@ -18,6 +18,8 @@ export interface UpdateControlPointInput {
 	providerId?: number;
 	providerConfig?: Record<string, unknown>;
 	authorizedRoleIds?: number[];
+	trainedRoleId?: number | null;
+	trainerRoleId?: number | null;
 	authorizedUserIds?: number[];
 	autoTurnOffEnabled?: boolean;
 	autoTurnOffMinutes?: number | null;
@@ -93,6 +95,14 @@ export async function updateControlPoint(input: UpdateControlPointInput) {
 		};
 	}
 
+	// Handle trained/trainer role updates
+	if (input.trainedRoleId !== undefined) {
+		updateData.trainedRoleId = input.trainedRoleId;
+	}
+	if (input.trainerRoleId !== undefined) {
+		updateData.trainerRoleId = input.trainerRoleId;
+	}
+
 	// Handle user connections
 	if (input.authorizedUserIds !== undefined) {
 		updateData.authorizedUsers = {
@@ -112,6 +122,12 @@ export async function updateControlPoint(input: UpdateControlPointInput) {
 				},
 			},
 			authorizedRoles: {
+				select: { id: true, name: true },
+			},
+			trainedRole: {
+				select: { id: true, name: true },
+			},
+			trainerRole: {
 				select: { id: true, name: true },
 			},
 			authorizedUsers: {

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/ldap",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/ldap",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/ldap",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/logger",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"exports": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/logger",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"exports": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/logger",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"exports": {

--- a/packages/prisma/migrations/20260504171404_add_controlpoint_training_roles/migration.sql
+++ b/packages/prisma/migrations/20260504171404_add_controlpoint_training_roles/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "ControlPoint" ADD COLUMN     "trainedRoleId" INTEGER,
+ADD COLUMN     "trainerRoleId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "ControlPoint" ADD CONSTRAINT "ControlPoint_trainedRoleId_fkey" FOREIGN KEY ("trainedRoleId") REFERENCES "Role"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ControlPoint" ADD CONSTRAINT "ControlPoint_trainerRoleId_fkey" FOREIGN KEY ("trainerRoleId") REFERENCES "Role"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/migrations/20260504175704_add_universal_trainer_permission/migration.sql
+++ b/packages/prisma/migrations/20260504175704_add_universal_trainer_permission/migration.sql
@@ -1,0 +1,4 @@
+-- Add credentials permissions
+INSERT INTO "Permission" (name) VALUES
+    ('control.points.universalTrainer')
+ON CONFLICT (name) DO NOTHING;

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/prisma",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/prisma",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/prisma",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -49,6 +49,8 @@ model Role {
   shiftTypes              ShiftType[]    @relation("RoleToShiftType")
   users                   User[]         @relation("RoleToUser")
   authorizedControlPoints ControlPoint[] @relation("ControlPointRoles")
+  trainedControlPoints    ControlPoint[] @relation("ControlPointTrainedRole")
+  trainerControlPoints    ControlPoint[] @relation("ControlPointTrainerRole")
 }
 
 model Permission {
@@ -476,6 +478,10 @@ model ControlPoint {
   providerId         Int
   provider           ControlProvider        @relation(fields: [providerId], references: [id], onDelete: Restrict)
   authorizedRoles    Role[]                 @relation("ControlPointRoles")
+  trainedRoleId      Int?
+  trainedRole        Role?                  @relation("ControlPointTrainedRole", fields: [trainedRoleId], references: [id])
+  trainerRoleId      Int?
+  trainerRole        Role?                  @relation("ControlPointTrainerRole", fields: [trainerRoleId], references: [id])
   authorizedUsers    User[]                 @relation("ControlPointUsers")
   controlLogs        ControlLog[]
   devices            Device[]               @relation("DeviceControlPoints")

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/rest",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/rest",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/rest",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/rest/src/routes/control-points.ts
+++ b/packages/rest/src/routes/control-points.ts
@@ -65,6 +65,8 @@ function serializeControlPoint(point: {
 		isActive?: boolean;
 	};
 	authorizedRoles: Array<{ id: number; name: string }>;
+	trainedRole: { id: number; name: string } | null;
+	trainerRole: { id: number; name: string } | null;
 	authorizedUsers: Array<{
 		id: number;
 		name: string;
@@ -93,6 +95,18 @@ function serializeControlPoint(point: {
 			id: r.id,
 			name: r.name,
 		})),
+		trainedRole: point.trainedRole
+			? {
+					id: point.trainedRole.id,
+					name: point.trainedRole.name,
+				}
+			: null,
+		trainerRole: point.trainerRole
+			? {
+					id: point.trainerRole.id,
+					name: point.trainerRole.name,
+				}
+			: null,
 		authorizedUsers: point.authorizedUsers.map((u) => ({
 			id: u.id,
 			name: u.name,

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/trpc",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"exports": {
 		"./client": "./client/index.ts",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/trpc",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"exports": {
 		"./client": "./client/index.ts",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/trpc",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"exports": {
 		"./client": "./client/index.ts",

--- a/packages/trpc/server/routers/control/points/create.route.ts
+++ b/packages/trpc/server/routers/control/points/create.route.ts
@@ -15,6 +15,8 @@ export const ZCreatePointSchema = z.object({
 	providerId: z.number().int(),
 	providerConfig: z.record(z.string(), z.unknown()),
 	authorizedRoleIds: z.array(z.number().int()).optional(),
+	trainedRoleId: z.number().int().optional(),
+	trainerRoleId: z.number().int().optional(),
 	authorizedUserIds: z.array(z.number().int()).optional(),
 	autoTurnOffEnabled: z.boolean().optional(),
 	autoTurnOffMinutes: z.number().int().min(1).optional().nullable(),

--- a/packages/trpc/server/routers/control/points/update.route.ts
+++ b/packages/trpc/server/routers/control/points/update.route.ts
@@ -16,6 +16,8 @@ export const ZUpdatePointSchema = z.object({
 	providerId: z.number().int().optional(),
 	providerConfig: z.record(z.string(), z.unknown()).optional(),
 	authorizedRoleIds: z.array(z.number().int()).optional(),
+	trainedRoleId: z.number().int().optional().nullable(),
+	trainerRoleId: z.number().int().optional().nullable(),
 	authorizedUserIds: z.array(z.number().int()).optional(),
 	autoTurnOffEnabled: z.boolean().optional(),
 	autoTurnOffMinutes: z.number().int().min(1).optional().nullable(),

--- a/packages/trpc/server/routers/controlKiosk/_route.ts
+++ b/packages/trpc/server/routers/controlKiosk/_route.ts
@@ -11,6 +11,10 @@ import {
 	ZCheckUserPermissionsSchema,
 } from "./checkUserPermissions.route";
 import {
+	getControlLogsHandler,
+	ZGetControlLogsSchema,
+} from "./getControlLogs.route";
+import {
 	getControlPointsHandler,
 	ZGetControlPointsSchema,
 } from "./getControlPoints.route";
@@ -19,12 +23,19 @@ import {
 	controlTapInOutHandler,
 	ZControlTapInOutSchema,
 } from "./tapInOut.route";
+import { trainUserHandler, ZTrainUserSchema } from "./trainUser.route";
+import { updatePointHandler, ZUpdatePointSchema } from "./updatePoint.route";
 
 export const controlKioskRouter = router({
 	// Get control points available on this device
 	getControlPoints: controlProtectedProcedure
 		.input(ZGetControlPointsSchema)
 		.query(getControlPointsHandler),
+
+	// Get control logs for a control point
+	getControlLogs: controlProtectedProcedure
+		.input(ZGetControlLogsSchema)
+		.query(getControlLogsHandler),
 
 	// Check what control points a user can operate
 	checkUserPermissions: controlProtectedProcedure
@@ -35,6 +46,16 @@ export const controlKioskRouter = router({
 	operate: controlProtectedProcedure
 		.input(ZKioskOperateSchema)
 		.mutation(kioskOperateHandler),
+
+	// Enable or disable a control point from the kiosk when the scanned user may manage it
+	updatePoint: controlProtectedProcedure
+		.input(ZUpdatePointSchema)
+		.mutation(updatePointHandler),
+
+	// Train additional users for a control point
+	trainUser: controlProtectedProcedure
+		.input(ZTrainUserSchema)
+		.mutation(trainUserHandler),
 
 	// Tap in/out for session management
 	tapInOut: controlProtectedProcedure

--- a/packages/trpc/server/routers/controlKiosk/checkUserPermissions.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/checkUserPermissions.route.ts
@@ -55,6 +55,8 @@ export async function checkUserPermissionsHandler({
 			controlClass: true,
 			currentState: true,
 			authorizedRoles: { select: { id: true } },
+			trainedRole: { select: { id: true, name: true } },
+			trainerRole: { select: { id: true, name: true } },
 			authorizedUsers: { select: { id: true } },
 		},
 	});

--- a/packages/trpc/server/routers/controlKiosk/checkUserPermissions.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/checkUserPermissions.route.ts
@@ -45,7 +45,6 @@ export async function checkUserPermissionsHandler({
 	const deviceControlPoints = await prisma.controlPoint.findMany({
 		where: {
 			id: { in: deviceControlPointIds },
-			isActive: true,
 		},
 		select: {
 			id: true,
@@ -58,6 +57,7 @@ export async function checkUserPermissionsHandler({
 			trainedRole: { select: { id: true, name: true } },
 			trainerRole: { select: { id: true, name: true } },
 			authorizedUsers: { select: { id: true } },
+			isActive: true,
 		},
 	});
 
@@ -90,6 +90,33 @@ export async function checkUserPermissionsHandler({
 		return false;
 	});
 
+	// Check if the user has universalTrainer permission on any assigned role
+	const hasUniversalTrainerPermission =
+		(await prisma.role.count({
+			where: {
+				id: { in: userRoleIds },
+				permissions: { some: { name: "control.points.universalTrainer" } },
+			},
+		})) > 0;
+
+	// Check which control points the user can manage (activate/deactivate and train other users)
+	const managedControlPoints = deviceControlPoints.filter((point) => {
+		// System users can manage everything
+		if (isSystemUser) return true;
+
+		// Check if user has trainer role for this control point
+		if (point.trainerRole && userRoleIds.includes(point.trainerRole.id)) {
+			return true;
+		}
+
+		// Check if user has universalTrainer permission
+		if (hasUniversalTrainerPermission) {
+			return true;
+		}
+
+		return false;
+	});
+
 	return {
 		user: {
 			id: user.id,
@@ -97,6 +124,14 @@ export async function checkUserPermissionsHandler({
 			username: user.username,
 		},
 		authorizedControlPoints: authorizedControlPoints.map((cp) => ({
+			id: cp.id,
+			name: cp.name,
+			description: cp.description,
+			location: cp.location,
+			controlClass: cp.controlClass,
+			currentState: cp.currentState,
+		})),
+		managedControlPoints: managedControlPoints.map((cp) => ({
 			id: cp.id,
 			name: cp.name,
 			description: cp.description,

--- a/packages/trpc/server/routers/controlKiosk/getControlLogs.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/getControlLogs.route.ts
@@ -1,0 +1,62 @@
+/**
+ * Control Kiosk Routes - Get Control Logs
+ *
+ * Returns recent control logs for a control point on the kiosk device.
+ */
+
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import type { TControlProtectedProcedureContext } from "../../trpc";
+
+export const ZGetControlLogsSchema = z.object({
+	controlPointId: z.string().uuid(),
+	limit: z.number().int().min(1).max(200).default(50),
+});
+
+type GetControlLogsOptions = {
+	ctx: TControlProtectedProcedureContext;
+	input: z.infer<typeof ZGetControlLogsSchema>;
+};
+
+export async function getControlLogsHandler({
+	ctx,
+	input,
+}: GetControlLogsOptions) {
+	const { controlPointId, limit } = input;
+
+	const deviceControlPoint = ctx.device.controlPoints.find(
+		(cp) => cp.id === controlPointId,
+	);
+
+	if (!deviceControlPoint) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "This control point is not available on this device.",
+		});
+	}
+
+	const logs = await prisma.controlLog.findMany({
+		where: {
+			controlPointId,
+			action: { in: ["TURN_ON", "TURN_OFF", "UNLOCK"] },
+		},
+		orderBy: { createdAt: "desc" },
+		take: limit,
+		select: {
+			id: true,
+			action: true,
+			createdAt: true,
+			user: { select: { name: true } },
+		},
+	});
+
+	return {
+		logs: logs.map((log) => ({
+			id: log.id,
+			action: log.action === "TURN_OFF" ? "logout" : "login",
+			createdAt: log.createdAt,
+			userName: log.user?.name ?? "Unknown User",
+		})),
+	};
+}

--- a/packages/trpc/server/routers/controlKiosk/getControlPoints.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/getControlPoints.route.ts
@@ -36,6 +36,8 @@ export async function getControlPointsHandler({
 			isActive: true,
 			canControlOnline: true,
 			authorizedRoles: { select: { id: true, name: true } },
+			trainedRole: { select: { id: true, name: true } },
+			trainerRole: { select: { id: true, name: true } },
 			authorizedUsers: { select: { id: true, name: true } },
 		},
 		orderBy: { name: "asc" },

--- a/packages/trpc/server/routers/controlKiosk/getControlPoints.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/getControlPoints.route.ts
@@ -25,7 +25,6 @@ export async function getControlPointsHandler({
 	const controlPoints = await prisma.controlPoint.findMany({
 		where: {
 			id: { in: controlPointIds },
-			isActive: true,
 		},
 		select: {
 			id: true,

--- a/packages/trpc/server/routers/controlKiosk/operate.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/operate.route.ts
@@ -60,6 +60,8 @@ export async function kioskOperateHandler({ ctx, input }: KioskOperateOptions) {
 		include: {
 			provider: true,
 			authorizedRoles: { select: { id: true } },
+			trainedRole: { select: { id: true, name: true } },
+			trainerRole: { select: { id: true, name: true } },
 			authorizedUsers: { select: { id: true } },
 		},
 	});

--- a/packages/trpc/server/routers/controlKiosk/trainUser.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/trainUser.route.ts
@@ -1,0 +1,149 @@
+/**
+ * Control Kiosk Routes - Train User
+ *
+ * Grants the trained role for a control point when a trainer scans a user's card.
+ */
+
+import { createAuditLogEntry, findUserByCard } from "@ecehive/features";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import type { TControlProtectedProcedureContext } from "../../trpc";
+
+export const ZTrainUserSchema = z.object({
+	trainerCardNumber: z.string().regex(/^\d+$/),
+	traineeCardNumber: z.string().regex(/^\d+$/),
+	controlPointId: z.string().uuid(),
+});
+
+type TrainUserOptions = {
+	ctx: TControlProtectedProcedureContext;
+	input: z.infer<typeof ZTrainUserSchema>;
+};
+
+export async function trainUserHandler({ ctx, input }: TrainUserOptions) {
+	const { trainerCardNumber, traineeCardNumber, controlPointId } = input;
+
+	const trainer = await findUserByCard(trainerCardNumber);
+	const trainee = await findUserByCard(traineeCardNumber);
+
+	if (trainer.id === trainee.id) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "You cannot train yourself.",
+		});
+	}
+
+	const trainerWithRoles = await prisma.user.findUniqueOrThrow({
+		where: { id: trainer.id },
+		include: {
+			roles: { select: { id: true } },
+		},
+	});
+
+	const deviceControlPoint = ctx.device.controlPoints.find(
+		(cp) => cp.id === controlPointId,
+	);
+
+	if (!deviceControlPoint) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "This control point is not available on this device.",
+		});
+	}
+
+	const point = await prisma.controlPoint.findUnique({
+		where: { id: controlPointId },
+		include: {
+			trainerRole: { select: { id: true, name: true } },
+			trainedRole: { select: { id: true, name: true } },
+		},
+	});
+
+	if (!point) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Control point not found",
+		});
+	}
+
+	if (!point.trainedRole) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "No trained role is configured for this control point.",
+		});
+	}
+
+	const userRoleIds = trainerWithRoles.roles.map((role) => role.id);
+	const isSystemUser = trainerWithRoles.isSystemUser;
+
+	if (!isSystemUser) {
+		const hasTrainerRole =
+			point.trainerRole !== null && userRoleIds.includes(point.trainerRole.id);
+		const hasUniversalTrainerPermission =
+			(await prisma.role.count({
+				where: {
+					id: { in: userRoleIds },
+					permissions: { some: { name: "control.points.universalTrainer" } },
+				},
+			})) > 0;
+
+		if (!hasTrainerRole && !hasUniversalTrainerPermission) {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message:
+					"You are not authorized to train users for this control point.",
+			});
+		}
+	}
+
+	const traineeWithRoles = await prisma.user.findUniqueOrThrow({
+		where: { id: trainee.id },
+		include: {
+			roles: { select: { id: true } },
+		},
+	});
+
+	const alreadyTrained = traineeWithRoles.roles.some(
+		(role) => role.id === point.trainedRole?.id,
+	);
+
+	if (alreadyTrained) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "User is already trained for this control point.",
+		});
+	}
+
+	await prisma.user.update({
+		where: { id: trainee.id },
+		data: {
+			roles: {
+				connect: {
+					id: point.trainedRole.id,
+				},
+			},
+		},
+	});
+
+	await createAuditLogEntry({
+		userId: trainer.id,
+		source: "trpc",
+		action: "controlKiosk.trainUser",
+		metadata: {
+			controlPointId: controlPointId,
+			controlPointName: point.name,
+			trainerId: trainer.id,
+			trainerName: trainer.name,
+			traineeId: trainee.id,
+			traineeName: trainee.name,
+			trainedRoleId: point.trainedRole.id,
+			trainedRoleName: point.trainedRole.name,
+		},
+	});
+
+	return {
+		userId: trainee.id,
+		userName: trainee.name,
+	};
+}

--- a/packages/trpc/server/routers/controlKiosk/updatePoint.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/updatePoint.route.ts
@@ -1,0 +1,180 @@
+/**
+ * Control Kiosk Routes - Update Control Point
+ *
+ * This route allows kiosk users to enable or disable a control point on the
+ * current kiosk device when they are authorized to manage that point.
+ */
+
+import { createAuditLogEntry, findUserByCard } from "@ecehive/features";
+import type { ControlProviderType } from "@ecehive/prisma";
+import { prisma } from "@ecehive/prisma";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import type { TControlProtectedProcedureContext } from "../../trpc";
+import { getControlProvider } from "../control/providers";
+
+export const ZUpdatePointSchema = z.object({
+	cardNumber: z.string().regex(/^\d+$/),
+	controlPointId: z.string().uuid(),
+	isActive: z.boolean(),
+});
+
+type UpdatePointOptions = {
+	ctx: TControlProtectedProcedureContext;
+	input: z.infer<typeof ZUpdatePointSchema>;
+};
+
+export async function updatePointHandler({ ctx, input }: UpdatePointOptions) {
+	const { cardNumber, controlPointId, isActive } = input;
+
+	const user = await findUserByCard(cardNumber);
+
+	const userWithRoles = await prisma.user.findUniqueOrThrow({
+		where: { id: user.id },
+		include: {
+			roles: { select: { id: true } },
+		},
+	});
+
+	const deviceControlPoint = ctx.device.controlPoints.find(
+		(cp) => cp.id === controlPointId,
+	);
+
+	if (!deviceControlPoint) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "This control point is not available on this device.",
+		});
+	}
+
+	const point = await prisma.controlPoint.findUnique({
+		where: { id: controlPointId },
+		include: {
+			provider: true,
+			trainerRole: { select: { id: true } },
+		},
+	});
+
+	if (!point) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Control point not found",
+		});
+	}
+
+	const userRoleIds = userWithRoles.roles.map((role) => role.id);
+	const isSystemUser = userWithRoles.isSystemUser;
+
+	if (!isSystemUser) {
+		const hasTrainerRole =
+			point.trainerRole !== null && userRoleIds.includes(point.trainerRole.id);
+		const hasUniversalTrainerPermission =
+			(await prisma.role.count({
+				where: {
+					id: { in: userRoleIds },
+					permissions: { some: { name: "control.points.universalTrainer" } },
+				},
+			})) > 0;
+
+		if (!hasTrainerRole && !hasUniversalTrainerPermission) {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message: "You are not authorized to manage this control point",
+			});
+		}
+	}
+
+	if (!isActive && point.controlClass === "SWITCH" && point.currentState) {
+		const lastTurnOnLog = await prisma.controlLog.findFirst({
+			where: {
+				controlPointId: point.id,
+				action: "TURN_ON",
+				success: true,
+			},
+			orderBy: { createdAt: "desc" },
+			include: {
+				user: {
+					select: {
+						id: true,
+						username: true,
+					},
+				},
+			},
+		});
+
+		const systemUser = await prisma.user.findFirst({
+			where: { isSystemUser: true },
+			select: { id: true, username: true },
+		});
+
+		const effectiveUser = lastTurnOnLog?.user ?? systemUser;
+
+		if (!effectiveUser) {
+			throw new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: "Unable to locate a user for tool logout logging",
+			});
+		}
+
+		const provider = getControlProvider(
+			point.provider.providerType as ControlProviderType,
+		);
+
+		const operationResult = await provider.writeState(
+			point.provider.config,
+			point.providerConfig,
+			false,
+			effectiveUser.username,
+		);
+
+		await prisma.controlLog.create({
+			data: {
+				controlPointId: point.id,
+				userId: effectiveUser.id,
+				action: "TURN_OFF",
+				previousState: point.currentState,
+				newState: operationResult.success ? false : null,
+				success: operationResult.success,
+				errorMessage: operationResult.success
+					? "Auto logout before deactivation"
+					: operationResult.errorMessage,
+			},
+		});
+
+		if (!operationResult.success) {
+			throw new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message:
+					operationResult.errorMessage ??
+					"Failed to turn off control point before deactivation",
+			});
+		}
+
+		await prisma.controlPoint.update({
+			where: { id: point.id },
+			data: { currentState: false },
+		});
+	}
+
+	const updatedPoint = await prisma.controlPoint.update({
+		where: { id: controlPointId },
+		data: { isActive },
+		select: {
+			id: true,
+			isActive: true,
+		},
+	});
+
+	await createAuditLogEntry({
+		userId: user.id,
+		source: "trpc",
+		action: "controlKiosk.updatePoint",
+		metadata: {
+			controlPointId,
+			controlPointName: point.name,
+			isActive,
+		},
+	});
+
+	return updatedPoint;
+}

--- a/packages/trpc/server/routers/devices/checkStatus.route.ts
+++ b/packages/trpc/server/routers/devices/checkStatus.route.ts
@@ -35,6 +35,8 @@ export async function checkStatusHandler(options: TCheckStatusOptions) {
 					isActive: true,
 					canControlOnline: true,
 					authorizedRoles: { select: { id: true } },
+					trainedRole: { select: { id: true, name: true } },
+					trainerRole: { select: { id: true, name: true } },
 					authorizedUsers: { select: { id: true } },
 				},
 			},

--- a/packages/trpc/server/trpc.ts
+++ b/packages/trpc/server/trpc.ts
@@ -223,7 +223,6 @@ export type TKioskProtectedProcedureContext =
  */
 const deviceWithControlPointsInclude = {
 	controlPoints: {
-		where: { isActive: true },
 		select: {
 			id: true,
 			name: true,

--- a/packages/trpc/server/trpc.ts
+++ b/packages/trpc/server/trpc.ts
@@ -245,6 +245,8 @@ const deviceWithControlPointsInclude = {
 				},
 			},
 			authorizedRoles: { select: { id: true } },
+			trainedRole: { select: { id: true, name: true } },
+			trainerRole: { select: { id: true, name: true } },
 			authorizedUsers: { select: { id: true } },
 		},
 	},

--- a/packages/user-data/package.json
+++ b/packages/user-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/user-data",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/user-data/package.json
+++ b/packages/user-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/user-data",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/user-data/package.json
+++ b/packages/user-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/user-data",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/workers",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/workers",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecehive/workers",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {


### PR DESCRIPTION
This PR adds a trainer page to control points with the following functionality:
- Mark control points as active/inactive
- Train other users on that control point (assigning the trained role defined for that point)
- View the past 50 control logs for that point (the complete history can be seen on the HUMS website)
- All actions are properly logged in the audit log

Accessing this page requires a user to either have the trainer role for that point, the `control.points.universalTrainer` permission, or be a system user.

To allow trainers to mark control points as active/inactive, inactive control points are now displayed in the idle kiosk view, and to those with trainer access (so that they can mark them back up from the kiosk itself).