### PR TITLE
Add department support

### DIFF
--- a/apps/client/src/components/users/columns.tsx
+++ b/apps/client/src/components/users/columns.tsx
@@ -17,6 +17,7 @@ type User = {
 	isSystemUser: boolean;
 	createdAt: Date;
 	updatedAt: Date;
+	department: string | null;
 	roles: {
 		id: number;
 		name: string;
@@ -42,6 +43,14 @@ export function generateColumns(user: AuthUser | null): ColumnDef<User>[] {
 		{
 			accessorKey: "email",
 			header: "Email",
+		},
+		{
+			accessorKey: "department",
+			header: "Department",
+			cell: ({ row }) =>
+				row.original.department ?? (
+					<span className="text-muted-foreground">—</span>
+				),
 		},
 		{
 			accessorKey: "slackUsername",

--- a/apps/client/src/lib/reports/global-configs.ts
+++ b/apps/client/src/lib/reports/global-configs.ts
@@ -28,6 +28,7 @@ export interface GlobalUsersReport {
 	slackUsername: string | null;
 	isSystemUser: boolean;
 	createdAt: Date;
+	department: string | null;
 	roles: string;
 	roleCount: number;
 	totalSessions: number;
@@ -106,6 +107,11 @@ export const globalUsersReportConfig: ReportConfig<GlobalUsersReport> = {
 			accessorKey: "email",
 			header: "Email",
 			cell: ({ row }) => row.original.email,
+		},
+		{
+			accessorKey: "department",
+			header: "Department",
+			cell: ({ row }) => row.original.department || "—",
 		},
 		{
 			accessorKey: "roles",

--- a/apps/control/src/App.tsx
+++ b/apps/control/src/App.tsx
@@ -568,7 +568,9 @@ function ControlKioskApp() {
 										onClick={() => openControlLogsDialog(point)}
 										className="rounded-xl border border-border p-4 bg-background text-left transition hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
 									>
-										<p className="text-sm text-muted-foreground">Control Logs</p>
+										<p className="text-sm text-muted-foreground">
+											Control Logs
+										</p>
 										<p className="mt-2 font-semibold">Tap to view logs</p>
 									</button>
 								</div>

--- a/packages/features/src/users/create-user.ts
+++ b/packages/features/src/users/create-user.ts
@@ -18,6 +18,7 @@ export type CreateUserData = {
 	slackUsername?: string | null;
 	isSystemUser?: boolean;
 	roleIds?: number[];
+	department?: string | null;
 };
 
 export type CreateUserOptions = {
@@ -65,11 +66,14 @@ export async function createUser(
 		// Attempt to fetch user information from the configured provider
 		// This enriches the user data with info from external systems (LDAP, BuzzAPI, etc.)
 		// Skipped when the caller already supplied provider data (e.g. findUserByCard)
+		let department: string | null = providedData.department ?? null;
+
 		if (!options?.skipProviderFetch) {
 			try {
 				const userInfo = await fetchUserInfo(username);
 				name = userInfo.name ?? name;
 				email = userInfo.email ?? email;
+				department = userInfo.department ?? department;
 			} catch (error) {
 				// If fetch fails, proceed with defaults
 				logger.warn("User data fetch failed, using defaults", {
@@ -86,6 +90,7 @@ export async function createUser(
 			email,
 			slackUsername,
 			isSystemUser,
+			...(department !== null ? { department } : {}),
 			...(roleIds && roleIds.length > 0
 				? {
 						roles: {

--- a/packages/features/src/users/fetch-user-info.ts
+++ b/packages/features/src/users/fetch-user-info.ts
@@ -10,5 +10,6 @@ export async function fetchUserInfo(username: string) {
 		username: profile?.username ?? username,
 		email: profile?.email || fallbackEmail,
 		cardNumbers: profile?.cardNumbers,
+		department: profile?.department,
 	};
 }

--- a/packages/features/src/users/find-user-by-card.ts
+++ b/packages/features/src/users/find-user-by-card.ts
@@ -92,6 +92,7 @@ export async function findUserByCard(cardNumber: string) {
 						username: profile.username,
 						name: profile.name,
 						email: profile.email,
+						department: profile.department ?? null,
 					},
 					{ tx, skipProviderFetch: true },
 				);
@@ -122,6 +123,12 @@ export async function findUserByCard(cardNumber: string) {
 			}
 			if (profile.email && profile.email !== user.email) {
 				updateData.email = profile.email;
+			}
+			if (
+				profile.department !== undefined &&
+				profile.department !== user.department
+			) {
+				updateData.department = profile.department;
 			}
 
 			if (Object.keys(updateData).length > 0) {

--- a/packages/prisma/migrations/20260520141238_add_user_department/migration.sql
+++ b/packages/prisma/migrations/20260520141238_add_user_department/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "department" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   createdAt               DateTime               @default(now())
   updatedAt               DateTime               @default(now()) @updatedAt
   slackUsername           String?                @unique
+  department              String?
   apiTokens               ApiToken[]
   impersonatedAuditLogs   AuditLog[]             @relation("AuditLogImpersonators")
   auditLogs               AuditLog[]

--- a/packages/trpc/server/routers/globalReports/usersReport.route.ts
+++ b/packages/trpc/server/routers/globalReports/usersReport.route.ts
@@ -41,6 +41,7 @@ export async function usersReportHandler(options: TUsersReportOptions) {
 			isSystemUser: true,
 			createdAt: true,
 			updatedAt: true,
+			department: true,
 			roles: {
 				select: {
 					id: true,
@@ -65,6 +66,7 @@ export async function usersReportHandler(options: TUsersReportOptions) {
 		slackUsername: user.slackUsername,
 		isSystemUser: user.isSystemUser,
 		createdAt: user.createdAt,
+		department: user.department,
 		roles: user.roles.map((r) => r.name).join(", "),
 		roleCount: user.roles.length,
 		totalSessions: user._count.sessions,

--- a/packages/user-data/src/providers/buzzapi.ts
+++ b/packages/user-data/src/providers/buzzapi.ts
@@ -24,6 +24,7 @@ type BuzzApiPerson = {
 	gtPersonDirectoryId?: string;
 	gtPrimaryEmailAddress?: string;
 	gtPrimaryGTAccountUsername?: string;
+	gtCurriculum?: string[];
 };
 
 const REQUESTED_ATTRIBUTES = [
@@ -34,7 +35,19 @@ const REQUESTED_ATTRIBUTES = [
 	"sn",
 	"gtAccessCardNumber",
 	"gtBuzzcardNumber",
+	"gtCurriculum",
 ].join(",");
+
+/**
+ * Extracts the department code from the gtCurriculum array.
+ * The department value is a short, uppercase-only path such as "E/ECE/CMPE".
+ * Longer student enrollment paths (e.g. "student/major/...") are ignored.
+ */
+function extractDepartment(gtCurriculum?: string[]): string | undefined {
+	if (!gtCurriculum || gtCurriculum.length === 0) return undefined;
+	const DEPT_PATTERN = /^[A-Z0-9]{1,10}(\/[A-Z0-9]{1,10}){1,4}$/;
+	return gtCurriculum.find((entry) => DEPT_PATTERN.test(entry.trim()));
+}
 
 export class BuzzApiUserDataProvider implements UserDataProvider {
 	constructor(private readonly config: BuzzApiProviderConfig) {}
@@ -118,11 +131,14 @@ export class BuzzApiUserDataProvider implements UserDataProvider {
 			.map((c) => normalizeCardNumber(c))
 			.filter((c): c is string => c !== undefined);
 
+		const department = extractDepartment(result.gtCurriculum);
+
 		return {
 			username,
 			name,
 			email,
 			...(cardNumbers.length > 0 ? { cardNumbers } : {}),
+			...(department !== undefined ? { department } : {}),
 		};
 	}
 

--- a/packages/user-data/src/types.ts
+++ b/packages/user-data/src/types.ts
@@ -5,6 +5,8 @@ export interface UserProfile {
 	name: string;
 	email: string;
 	cardNumbers?: string[];
+	/** College/department/major code extracted from BuzzAPI gtCurriculum (e.g. "E/ECE/CMPE"). Only present when the data source provides it. */
+	department?: string;
 }
 
 export interface UserDataProvider {


### PR DESCRIPTION
This pull request adds support for tracking which department a user belongs to. Departments will follow a slash-separated string, such as `E/ECE/CMPE` for `Engineering -> Electrical and Computer Engineering -> Computer Engineering`.

This field is sourced from BuzzAPI. From what I can tell, this will only exist for people who are (or were) students, but that should be good enough for general analytics about space usage.