### PR TITLE
Add support for affiliation restrictions

### DIFF
--- a/apps/client/src/components/users/columns.tsx
+++ b/apps/client/src/components/users/columns.tsx
@@ -18,6 +18,7 @@ type User = {
 	createdAt: Date;
 	updatedAt: Date;
 	department: string | null;
+	affiliation: string | null;
 	roles: {
 		id: number;
 		name: string;
@@ -49,6 +50,14 @@ export function generateColumns(user: AuthUser | null): ColumnDef<User>[] {
 			header: "Department",
 			cell: ({ row }) =>
 				row.original.department ?? (
+					<span className="text-muted-foreground">—</span>
+				),
+		},
+		{
+			accessorKey: "affiliation",
+			header: "Affiliation",
+			cell: ({ row }) =>
+				row.original.affiliation ?? (
 					<span className="text-muted-foreground">—</span>
 				),
 		},

--- a/apps/kiosk/src/App.tsx
+++ b/apps/kiosk/src/App.tsx
@@ -133,6 +133,7 @@ function AppContent() {
 							pendingAgreement={tapWorkflow.pendingAgreement}
 							tapNotification={tapWorkflow.tapNotification}
 							suspension={tapWorkflow.suspension}
+							accessDenied={tapWorkflow.accessDenied}
 							onSessionTypeSelect={tapWorkflow.handleSessionTypeSelect}
 							onSessionTypeCancel={tapWorkflow.handleSessionTypeCancel}
 							onTapOutActionSelect={tapWorkflow.handleTapOutActionSelect}

--- a/apps/kiosk/src/components/access-denied-dialog.tsx
+++ b/apps/kiosk/src/components/access-denied-dialog.tsx
@@ -1,0 +1,84 @@
+import { ShieldXIcon } from "lucide-react";
+import { motion } from "motion/react";
+
+interface AccessDeniedDialogProps {
+	userName: string;
+	message: string;
+	isExiting: boolean;
+}
+
+export function AccessDeniedDialog({
+	userName,
+	message,
+	isExiting,
+}: AccessDeniedDialogProps) {
+	return (
+		<motion.div
+			className="absolute inset-0 z-50 p-8 flex items-center justify-center bg-black/95 backdrop-blur-md"
+			initial={{ opacity: 0 }}
+			animate={{ opacity: isExiting ? 0 : 1 }}
+			transition={{ duration: 0.3 }}
+		>
+			<motion.div
+				className="p-4 max-w-3xl mx-auto"
+				initial={{ opacity: 0, scale: 0.95, y: 16 }}
+				animate={{
+					opacity: isExiting ? 0 : 1,
+					scale: isExiting ? 0.95 : 1,
+					y: isExiting ? 16 : 0,
+				}}
+				transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+			>
+				<div className="border-destructive border-4 shadow-2xl transition-colors duration-300 p-8 bg-background rounded-lg">
+					<div className="flex flex-col items-center gap-8">
+						<div className="relative flex items-center justify-center">
+							<motion.div
+								initial={{ scale: 0.85, opacity: 0 }}
+								animate={{
+									scale: isExiting ? 0.85 : 1,
+									opacity: isExiting ? 0 : 1,
+								}}
+								transition={{ duration: 0.6, ease: "easeOut" }}
+							>
+								<ShieldXIcon className="w-32 h-32 text-destructive" />
+							</motion.div>
+							<motion.div
+								className="absolute inset-0"
+								initial={{ scale: 0.9, opacity: 0.4 }}
+								animate={
+									isExiting
+										? { scale: 0.9, opacity: 0 }
+										: { scale: [0.9, 1.4], opacity: [0.4, 0] }
+								}
+								transition={
+									isExiting
+										? { duration: 0.3, ease: "easeInOut" }
+										: { duration: 1.2, repeat: Infinity, ease: "easeOut" }
+								}
+							>
+								<ShieldXIcon className="w-32 h-32 text-destructive opacity-40" />
+							</motion.div>
+						</div>
+
+						<motion.div
+							className="text-center gap-4 flex flex-col"
+							initial={{ opacity: 0, y: 12 }}
+							animate={{ opacity: isExiting ? 0 : 1, y: isExiting ? 12 : 0 }}
+							transition={{ duration: 0.5, delay: 0.2 }}
+						>
+							<h2 className="text-5xl font-bold text-destructive">
+								ACCESS DENIED
+							</h2>
+							<p className="text-3xl font-semibold">
+								Sorry, {userName}. You are not permitted to enter.
+							</p>
+							<div className="bg-destructive/10 border border-destructive/30 rounded-lg p-4 mt-2">
+								<p className="text-xl text-muted-foreground">{message}</p>
+							</div>
+						</motion.div>
+					</div>
+				</div>
+			</motion.div>
+		</motion.div>
+	);
+}

--- a/apps/kiosk/src/components/flow-overlays.tsx
+++ b/apps/kiosk/src/components/flow-overlays.tsx
@@ -1,5 +1,6 @@
 import { Clock, LogOut, RefreshCw, Users } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
+import { AccessDeniedDialog } from "@/components/access-denied-dialog";
 import { AgreementFlow } from "@/components/agreement-flow";
 import { EarlyLeaveConfirmation } from "@/components/early-leave-confirmation";
 import { ErrorDialog } from "@/components/error-dialog";
@@ -9,6 +10,7 @@ import { ShiftEarlyLeaveConfirmation } from "@/components/shift-early-leave-conf
 import { SuspensionDialog } from "@/components/suspension-dialog";
 import { TapNotification } from "@/components/tap-notification";
 import type {
+	AccessDeniedState,
 	EarlyLeaveConfirmationState,
 	ErrorDialogState,
 	PendingAgreementState,
@@ -29,6 +31,7 @@ interface FlowOverlaysProps {
 	pendingAgreement: PendingAgreementState | null;
 	tapNotification: TapNotificationState;
 	suspension: SuspensionState | null;
+	accessDenied: AccessDeniedState | null;
 	onSessionTypeSelect: (type: "regular" | "staffing") => void;
 	onSessionTypeCancel: () => void;
 	onTapOutActionSelect: (
@@ -54,6 +57,7 @@ export function FlowOverlays({
 	pendingAgreement,
 	tapNotification,
 	suspension,
+	accessDenied,
 	onSessionTypeSelect,
 	onSessionTypeCancel,
 	onTapOutActionSelect,
@@ -75,7 +79,8 @@ export function FlowOverlays({
 			!!tapOutActionSelection ||
 			!!earlyLeaveConfirmation ||
 			!!shiftEarlyLeaveConfirmation ||
-			!!suspension,
+			!!suspension ||
+			!!accessDenied,
 		[
 			errorDialog.message,
 			pendingAgreement,
@@ -215,6 +220,14 @@ export function FlowOverlays({
 					endDate={suspension.endDate}
 					externalNotes={suspension.externalNotes}
 					isExiting={suspension.isExiting}
+				/>
+			)}
+
+			{accessDenied && (
+				<AccessDeniedDialog
+					userName={accessDenied.userName}
+					message={accessDenied.message}
+					isExiting={accessDenied.isExiting}
 				/>
 			)}
 

--- a/apps/kiosk/src/hooks/use-tap-workflow.ts
+++ b/apps/kiosk/src/hooks/use-tap-workflow.ts
@@ -69,6 +69,12 @@ export type SuspensionState = {
 	isExiting: boolean;
 };
 
+export type AccessDeniedState = {
+	userName: string;
+	message: string;
+	isExiting: boolean;
+};
+
 type TapWorkflowState = {
 	isProcessing: boolean;
 	pendingAgreement: PendingAgreementState | null;
@@ -80,6 +86,7 @@ type TapWorkflowState = {
 	errorDialog: ErrorDialogState;
 	oneTimeLogin: OneTimeLoginState | null;
 	suspension: SuspensionState | null;
+	accessDenied: AccessDeniedState | null;
 };
 
 type TapWorkflowAction =
@@ -111,7 +118,10 @@ type TapWorkflowAction =
 	| { type: "one_time_login_clear" }
 	| { type: "suspension_set"; payload: Omit<SuspensionState, "isExiting"> }
 	| { type: "suspension_clear" }
-	| { type: "suspension_exit_start" };
+	| { type: "suspension_exit_start" }
+	| { type: "access_denied_set"; payload: Omit<AccessDeniedState, "isExiting"> }
+	| { type: "access_denied_clear" }
+	| { type: "access_denied_exit_start" };
 
 const INITIAL_STATE: TapWorkflowState = {
 	isProcessing: false,
@@ -130,6 +140,7 @@ const INITIAL_STATE: TapWorkflowState = {
 	},
 	oneTimeLogin: null,
 	suspension: null,
+	accessDenied: null,
 };
 
 const tapWorkflowReducer = (
@@ -230,6 +241,23 @@ const tapWorkflowReducer = (
 			};
 		case "suspension_clear":
 			return { ...state, suspension: null };
+		case "access_denied_set":
+			return {
+				...state,
+				accessDenied: {
+					...action.payload,
+					isExiting: false,
+				},
+			};
+		case "access_denied_exit_start":
+			return {
+				...state,
+				accessDenied: state.accessDenied
+					? { ...state.accessDenied, isExiting: true }
+					: null,
+			};
+		case "access_denied_clear":
+			return { ...state, accessDenied: null };
 		default:
 			return state;
 	}
@@ -256,6 +284,7 @@ export function useTapWorkflow() {
 		errorDialog,
 		oneTimeLogin,
 		suspension,
+		accessDenied,
 	} = state;
 
 	const currentTapEventRef = useRef<TapEvent | null>(null);
@@ -283,6 +312,8 @@ export function useTapWorkflow() {
 	const agreementFlowTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const suspensionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const suspensionExitTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+	const accessDeniedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+	const accessDeniedExitTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
 	const dismissTapNotification = useCallback(() => {
 		clearTimer(tapEventTimeoutRef);
@@ -479,6 +510,27 @@ export function useTapWorkflow() {
 						dispatch({ type: "suspension_exit_start" });
 						suspensionExitTimeoutRef.current = setTimeout(() => {
 							dispatch({ type: "suspension_clear" });
+						}, FADE_OUT_DURATION_MS);
+					}, 5000);
+					return;
+				}
+
+				if (result.status === "access_denied") {
+					dispatch({ type: "processing_end" });
+					clearTimer(accessDeniedTimeoutRef);
+					clearTimer(accessDeniedExitTimeoutRef);
+					dispatch({
+						type: "access_denied_set",
+						payload: {
+							userName: result.user.name,
+							message: result.message,
+						},
+					});
+					// Show access denied dialog for 5 seconds then fade out
+					accessDeniedTimeoutRef.current = setTimeout(() => {
+						dispatch({ type: "access_denied_exit_start" });
+						accessDeniedExitTimeoutRef.current = setTimeout(() => {
+							dispatch({ type: "access_denied_clear" });
 						}, FADE_OUT_DURATION_MS);
 					}, 5000);
 					return;
@@ -702,6 +754,8 @@ export function useTapWorkflow() {
 			clearTimer(agreementFlowTimeoutRef);
 			clearTimer(suspensionTimeoutRef);
 			clearTimer(suspensionExitTimeoutRef);
+			clearTimer(accessDeniedTimeoutRef);
+			clearTimer(accessDeniedExitTimeoutRef);
 		};
 	}, []);
 
@@ -716,6 +770,7 @@ export function useTapWorkflow() {
 		errorDialog,
 		oneTimeLogin,
 		suspension,
+		accessDenied,
 		handleTap: handleTapInOut,
 		handleAgreementComplete,
 		handleAgreementCancel,

--- a/apps/kiosk/src/types/index.ts
+++ b/apps/kiosk/src/types/index.ts
@@ -125,6 +125,16 @@ export type TapResponse =
 				endDate: Date;
 				externalNotes: string | null;
 			};
+	  }
+	| {
+			status: "access_denied";
+			user: {
+				id: number;
+				name: string;
+				email: string;
+				username: string;
+			};
+			message: string;
 	  };
 
 export type TapEvent = Extract<

--- a/packages/features/src/affiliation/index.ts
+++ b/packages/features/src/affiliation/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Institutional affiliation policy for HUMS access control.
+ *
+ * The allow-list is intentionally defined as a static constant. This provides
+ * predictable, auditable behaviour and makes it easy to expand in the future
+ * (e.g. by loading overrides from the database or environment configuration).
+ */
+
+/**
+ * Affiliations that are permitted to access HUMS.
+ *
+ * These values are matched case-insensitively against the
+ * `eduPersonPrimaryAffiliation` attribute from the identity provider.
+ */
+export const ALLOWED_AFFILIATIONS = ["student", "faculty", "staff"] as const;
+
+export type AllowedAffiliation = (typeof ALLOWED_AFFILIATIONS)[number];
+
+/**
+ * Returns `true` when the provided affiliation string is in the allow-list.
+ *
+ * Matching is case-insensitive and leading/trailing whitespace is ignored.
+ * A `null` or `undefined` affiliation is never permitted, which means users
+ * whose affiliation has not yet been synced from the identity provider will
+ * be denied access until a sync occurs.
+ */
+export function isAffiliationAllowed(
+	affiliation: string | null | undefined,
+): boolean {
+	if (!affiliation) return false;
+	return (ALLOWED_AFFILIATIONS as readonly string[]).includes(
+		affiliation.toLowerCase().trim(),
+	);
+}
+
+/**
+ * Human-readable description of the allowed affiliations, suitable for
+ * use in error messages shown to end users.
+ */
+export const ALLOWED_AFFILIATIONS_LABEL =
+	"current Students, Faculty, and Staff";

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -1,4 +1,5 @@
 export { clearEmailLogoCache, getEmailLogosAsync } from "@ecehive/email";
+export * from "./affiliation";
 export * from "./api-tokens";
 export * from "./assignments/generators";
 export * from "./attendance";

--- a/packages/features/src/users/create-user.ts
+++ b/packages/features/src/users/create-user.ts
@@ -19,6 +19,8 @@ export type CreateUserData = {
 	isSystemUser?: boolean;
 	roleIds?: number[];
 	department?: string | null;
+	/** Institutional affiliation (e.g. "student", "faculty", "staff"). */
+	affiliation?: string | null;
 };
 
 export type CreateUserOptions = {
@@ -32,6 +34,12 @@ export type CreateUserOptions = {
 	 * could be exceeded by the network round-trip.
 	 */
 	skipProviderFetch?: boolean;
+	/**
+	 * When true, sets `profileSyncedAt` to the current time on the created user.
+	 * Use this when the caller has already fetched fresh provider data and is
+	 * passing it in via `skipProviderFetch: true`.
+	 */
+	markProfileSynced?: boolean;
 };
 
 /**
@@ -63,10 +71,12 @@ export async function createUser(
 			providedData.slackUsername || undefined;
 		const isSystemUser = providedData.isSystemUser ?? false;
 
-		// Attempt to fetch user information from the configured provider
-		// This enriches the user data with info from external systems (LDAP, BuzzAPI, etc.)
-		// Skipped when the caller already supplied provider data (e.g. findUserByCard)
+		// Attempt to fetch user information from the configured provider.
+		// This enriches the user data with info from external systems (LDAP, BuzzAPI, etc.).
+		// Skipped when the caller already supplied provider data (e.g. findUserByCard).
 		let department: string | null = providedData.department ?? null;
+		let affiliation: string | null = providedData.affiliation ?? null;
+		let profileSyncedAt: Date | null = null;
 
 		if (!options?.skipProviderFetch) {
 			try {
@@ -74,6 +84,8 @@ export async function createUser(
 				name = userInfo.name ?? name;
 				email = userInfo.email ?? email;
 				department = userInfo.department ?? department;
+				affiliation = userInfo.affiliation ?? affiliation;
+				profileSyncedAt = new Date();
 			} catch (error) {
 				// If fetch fails, proceed with defaults
 				logger.warn("User data fetch failed, using defaults", {
@@ -81,6 +93,9 @@ export async function createUser(
 					error: error instanceof Error ? error.message : String(error),
 				});
 			}
+		} else if (options?.markProfileSynced) {
+			// Caller provided fresh provider data; record the sync timestamp.
+			profileSyncedAt = new Date();
 		}
 
 		// Build the Prisma create data
@@ -91,6 +106,8 @@ export async function createUser(
 			slackUsername,
 			isSystemUser,
 			...(department !== null ? { department } : {}),
+			...(affiliation !== null ? { affiliation } : {}),
+			...(profileSyncedAt !== null ? { profileSyncedAt } : {}),
 			...(roleIds && roleIds.length > 0
 				? {
 						roles: {

--- a/packages/features/src/users/fetch-user-info.ts
+++ b/packages/features/src/users/fetch-user-info.ts
@@ -11,5 +11,6 @@ export async function fetchUserInfo(username: string) {
 		email: profile?.email || fallbackEmail,
 		cardNumbers: profile?.cardNumbers,
 		department: profile?.department,
+		affiliation: profile?.affiliation,
 	};
 }

--- a/packages/features/src/users/find-or-create-user.ts
+++ b/packages/features/src/users/find-or-create-user.ts
@@ -4,6 +4,7 @@ import {
 	createUser,
 } from "./create-user";
 import { findUser } from "./find-user";
+import { refreshUserProfileIfStale } from "./refresh-user-profile";
 
 export async function findOrCreateUser(
 	username: string,
@@ -13,7 +14,10 @@ export async function findOrCreateUser(
 	// Find or create the user
 	const existingUser = await findUser(username);
 	if (existingUser) {
-		return existingUser;
+		// Refresh the profile if it is older than the cache TTL so that changes
+		// to affiliation, card numbers, and other identity attributes are picked
+		// up in a timely fashion.
+		return refreshUserProfileIfStale(existingUser);
 	}
 
 	// Create the user if not found

--- a/packages/features/src/users/find-user-by-card.ts
+++ b/packages/features/src/users/find-user-by-card.ts
@@ -4,6 +4,7 @@ import { getUserDataProvider, normalizeCardNumber } from "@ecehive/user-data";
 import { TRPCError } from "@trpc/server";
 import { credentialPreview, hashCredential } from "../credentials/hash";
 import { createUser } from "./create-user";
+import { refreshUserProfileIfStale } from "./refresh-user-profile";
 
 const logger = getLogger("features:find-user-by-card");
 
@@ -15,6 +16,8 @@ const UNIQUE_CONSTRAINT_ERROR_CODE = "P2002";
  *
  * Lookup order:
  *  1. Credential table  – value already associated with a user.
+ *     If found, the profile is refreshed from the identity provider when
+ *     it is older than the cache TTL (7 days).
  *  2. External data provider – fetch by card number, create/update user,
  *     then persist a Credential row for future lookups.
  *
@@ -44,7 +47,9 @@ export async function findUserByCard(cardNumber: string) {
 			credentialId: credential.id,
 			userId: credential.user.id,
 		});
-		return credential.user;
+		// Refresh profile data from the identity provider when the cache is stale.
+		// This keeps affiliation, card numbers, and other attributes current.
+		return refreshUserProfileIfStale(credential.user);
 	}
 
 	// ── Step 2: External provider lookup (outside transaction) ───────────
@@ -93,8 +98,9 @@ export async function findUserByCard(cardNumber: string) {
 						name: profile.name,
 						email: profile.email,
 						department: profile.department ?? null,
+						affiliation: profile.affiliation ?? null,
 					},
-					{ tx, skipProviderFetch: true },
+					{ tx, skipProviderFetch: true, markProfileSynced: true },
 				);
 			} catch (error) {
 				if (
@@ -116,8 +122,10 @@ export async function findUserByCard(cardNumber: string) {
 				}
 			}
 		} else {
-			// Update existing user profile if needed
-			const updateData: Prisma.UserUpdateInput = {};
+			// Update existing user profile with fresh provider data.
+			const updateData: Prisma.UserUpdateInput = {
+				profileSyncedAt: new Date(),
+			};
 			if (profile.name && profile.name !== user.name) {
 				updateData.name = profile.name;
 			}
@@ -130,13 +138,13 @@ export async function findUserByCard(cardNumber: string) {
 			) {
 				updateData.department = profile.department;
 			}
+			// Always write affiliation so revoked access is reflected promptly.
+			updateData.affiliation = profile.affiliation ?? null;
 
-			if (Object.keys(updateData).length > 0) {
-				user = await tx.user.update({
-					where: { id: user.id },
-					data: updateData,
-				});
-			}
+			user = await tx.user.update({
+				where: { id: user.id },
+				data: updateData,
+			});
 		}
 
 		// Persist credentials for all cards belonging to this user

--- a/packages/features/src/users/index.ts
+++ b/packages/features/src/users/index.ts
@@ -3,4 +3,5 @@ export * from "./fetch-user-info";
 export * from "./find-or-create-user";
 export * from "./find-user";
 export * from "./find-user-by-card";
+export * from "./refresh-user-profile";
 export * from "./update-system-users";

--- a/packages/features/src/users/refresh-user-profile.ts
+++ b/packages/features/src/users/refresh-user-profile.ts
@@ -1,0 +1,159 @@
+import { getLogger } from "@ecehive/logger";
+import { prisma, type User } from "@ecehive/prisma";
+import { getUserDataProvider, normalizeCardNumber } from "@ecehive/user-data";
+import { credentialPreview, hashCredential } from "../credentials/hash";
+
+const logger = getLogger("features:refresh-user-profile");
+
+/**
+ * How long a cached user profile is considered fresh.
+ *
+ * After this TTL has elapsed since `profileSyncedAt`, the next access will
+ * trigger a re-fetch from the external identity provider. This keeps
+ * affiliation, access card numbers, and other identity attributes up-to-date
+ * while avoiding unnecessary provider calls on every request.
+ */
+export const PROFILE_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * Returns `true` when the user's profile data should be refreshed from the
+ * external identity provider.
+ *
+ * A profile is stale when:
+ * - `profileSyncedAt` is `null` (never synced), or
+ * - The time since the last sync exceeds `PROFILE_CACHE_TTL_MS`, or
+ * - `providerDeleted` is `true` — these users are always re-checked so that
+ *   a re-appearing account is reinstated as quickly as possible.
+ */
+export function isProfileStale(
+	user: Pick<User, "profileSyncedAt" | "providerDeleted">,
+): boolean {
+	if (user.providerDeleted) return true;
+	if (!user.profileSyncedAt) return true;
+	return Date.now() - user.profileSyncedAt.getTime() > PROFILE_CACHE_TTL_MS;
+}
+
+/**
+ * Refreshes a user's profile data from the external identity provider if the
+ * cached data is stale (older than `PROFILE_CACHE_TTL_MS`).
+ *
+ * When a refresh occurs:
+ * - Name, email, department, and affiliation are updated.
+ * - Any new access card numbers are persisted as `Credential` rows.
+ * - `profileSyncedAt` is set to the current time.
+ *
+ * If the provider call fails or returns no data the existing user record is
+ * returned unchanged so that a transient network error does not lock users out.
+ *
+ * The provider HTTP call is deliberately made **outside** any Prisma
+ * transaction to avoid exceeding the transaction timeout.
+ *
+ * @returns The updated user record, or the original record when no refresh
+ *          was needed or the refresh failed.
+ */
+export async function refreshUserProfileIfStale(user: User): Promise<User> {
+	if (!isProfileStale(user)) {
+		return user;
+	}
+
+	logger.info("User profile is stale, refreshing from external provider", {
+		userId: user.id,
+		username: user.username,
+		profileSyncedAt: user.profileSyncedAt,
+	});
+
+	const provider = getUserDataProvider();
+
+	let profile: Awaited<ReturnType<typeof provider.fetchByUsername>>;
+	try {
+		profile = await provider.fetchByUsername(user.username);
+	} catch (error) {
+		logger.warn(
+			"Profile refresh failed — keeping existing data to avoid lockout",
+			{
+				userId: user.id,
+				username: user.username,
+				error: error instanceof Error ? error.message : String(error),
+			},
+		);
+		return user;
+	}
+
+	if (!profile) {
+		logger.warn(
+			"External provider returned no data for user during refresh — marking as provider-deleted",
+			{
+				userId: user.id,
+				username: user.username,
+			},
+		);
+		// Mark the user as deleted by the provider so access is denied until
+		// they reappear. We also record the attempt time so we have an audit
+		// trail, but isProfileStale will still return true while providerDeleted
+		// is set, ensuring every subsequent login re-checks the provider.
+		const deletedUser = await prisma.user.update({
+			where: { id: user.id },
+			data: { providerDeleted: true, profileSyncedAt: new Date() },
+		});
+		return deletedUser;
+	}
+
+	const updateData: {
+		profileSyncedAt: Date;
+		providerDeleted: boolean;
+		name?: string;
+		email?: string;
+		department?: string | null;
+		affiliation?: string | null;
+	} = {
+		profileSyncedAt: new Date(),
+		// Clear the deleted flag in case the user has reappeared in the provider.
+		providerDeleted: false,
+	};
+
+	if (profile.name) updateData.name = profile.name;
+	if (profile.email) updateData.email = profile.email;
+	if (profile.department !== undefined)
+		updateData.department = profile.department ?? null;
+	// Always sync affiliation so revoked access is reflected promptly.
+	updateData.affiliation = profile.affiliation ?? null;
+
+	const updatedUser = await prisma.user.update({
+		where: { id: user.id },
+		data: updateData,
+	});
+
+	// Persist any new card credentials that may have been assigned since last sync.
+	if (profile.cardNumbers && profile.cardNumbers.length > 0) {
+		for (const card of profile.cardNumbers) {
+			const normalized = normalizeCardNumber(card);
+			if (!normalized) continue;
+			const hash = hashCredential(normalized);
+			const preview = credentialPreview(normalized);
+			await prisma.credential.upsert({
+				where: { hash },
+				update: { userId: user.id },
+				create: { hash, preview, userId: user.id },
+			});
+		}
+	}
+
+	if (user.providerDeleted) {
+		logger.info(
+			"Provider-deleted user has reappeared \u2014 access reinstated",
+			{
+				userId: user.id,
+				username: user.username,
+				affiliation: updatedUser.affiliation,
+			},
+		);
+	} else {
+		logger.info("User profile refreshed successfully", {
+			userId: user.id,
+			username: user.username,
+			affiliation: updatedUser.affiliation,
+		});
+	}
+
+	return updatedUser;
+}

--- a/packages/prisma/migrations/20260526144720_add_user_affiliation_and_profile_synced_at/migration.sql
+++ b/packages/prisma/migrations/20260526144720_add_user_affiliation_and_profile_synced_at/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "affiliation" TEXT,
+ADD COLUMN     "profileSyncedAt" TIMESTAMP(3);

--- a/packages/prisma/migrations/20260526151144_add_user_provider_deleted/migration.sql
+++ b/packages/prisma/migrations/20260526151144_add_user_provider_deleted/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "providerDeleted" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -18,6 +18,17 @@ model User {
   updatedAt               DateTime               @default(now()) @updatedAt
   slackUsername           String?                @unique
   department              String?
+  /// Institutional affiliation sourced from the external identity provider
+  /// (e.g. "student", "faculty", "staff"). Null when not yet synced or unavailable.
+  affiliation             String?
+  /// Timestamp of the most recent successful profile sync from the external
+  /// identity provider. Used to enforce the profile cache TTL.
+  profileSyncedAt         DateTime?
+  /// Set to true when the external identity provider returns no record for this
+  /// user during a profile refresh. While true the user is denied access and
+  /// every subsequent login triggers a re-fetch so that a re-appearing account
+  /// is reinstated automatically. Reset to false when the provider returns data.
+  providerDeleted         Boolean                @default(false)
   apiTokens               ApiToken[]
   impersonatedAuditLogs   AuditLog[]             @relation("AuditLogImpersonators")
   auditLogs               AuditLog[]

--- a/packages/trpc/server/routers/auth/login.route.ts
+++ b/packages/trpc/server/routers/auth/login.route.ts
@@ -1,5 +1,9 @@
 import { generateToken, validateTicket } from "@ecehive/auth";
-import { findOrCreateUser } from "@ecehive/features";
+import {
+	ALLOWED_AFFILIATIONS_LABEL,
+	findOrCreateUser,
+	isAffiliationAllowed,
+} from "@ecehive/features";
 import { TRPCError } from "@trpc/server";
 import z from "zod";
 
@@ -45,6 +49,17 @@ export async function loginHandler(options: TLoginOptions) {
 		name: derivedName.length ? derivedName : undefined,
 		email: validationResult.attributes.email,
 	});
+
+	// System users (administrators) bypass affiliation and provider-deletion restrictions.
+	if (
+		!user.isSystemUser &&
+		(user.providerDeleted || !isAffiliationAllowed(user.affiliation))
+	) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: `HUMS is only available to ${ALLOWED_AFFILIATIONS_LABEL}. If you believe this is an error, please contact support.`,
+		});
+	}
 
 	const token = await generateToken(user.id);
 

--- a/packages/trpc/server/routers/controlKiosk/tapInOut.route.ts
+++ b/packages/trpc/server/routers/controlKiosk/tapInOut.route.ts
@@ -11,6 +11,7 @@
  */
 
 import {
+	ALLOWED_AFFILIATIONS_LABEL,
 	ConfigService,
 	checkMissingAgreements,
 	checkStaffingPermission,
@@ -18,6 +19,7 @@ import {
 	findUserByCard,
 	getActiveSuspension,
 	getCurrentSession,
+	isAffiliationAllowed,
 	startSession,
 	switchSessionType,
 	validateCanEndSession,
@@ -45,6 +47,23 @@ export async function controlTapInOutHandler(options: TControlTapInOutOptions) {
 	const { cardNumber, sessionType, tapAction } = options.input;
 
 	const user = await findUserByCard(cardNumber);
+
+	// System users (administrators) bypass affiliation and provider-deletion restrictions.
+	if (
+		!user.isSystemUser &&
+		(user.providerDeleted || !isAffiliationAllowed(user.affiliation))
+	) {
+		return {
+			status: "access_denied" as const,
+			user: {
+				id: user.id,
+				name: user.name,
+				email: user.email,
+				username: user.username,
+			},
+			message: `Access Denied. HUMS is only available to ${ALLOWED_AFFILIATIONS_LABEL}.`,
+		};
+	}
 
 	// Get kiosk session type configuration
 	const [regularSessionsEnabled, staffingSessionsEnabled] = await Promise.all([

--- a/packages/user-data/src/providers/buzzapi.ts
+++ b/packages/user-data/src/providers/buzzapi.ts
@@ -25,6 +25,7 @@ type BuzzApiPerson = {
 	gtPrimaryEmailAddress?: string;
 	gtPrimaryGTAccountUsername?: string;
 	gtCurriculum?: string[];
+	eduPersonPrimaryAffiliation?: string;
 };
 
 const REQUESTED_ATTRIBUTES = [
@@ -36,6 +37,7 @@ const REQUESTED_ATTRIBUTES = [
 	"gtAccessCardNumber",
 	"gtBuzzcardNumber",
 	"gtCurriculum",
+	"eduPersonPrimaryAffiliation",
 ].join(",");
 
 /**
@@ -132,6 +134,7 @@ export class BuzzApiUserDataProvider implements UserDataProvider {
 			.filter((c): c is string => c !== undefined);
 
 		const department = extractDepartment(result.gtCurriculum);
+		const affiliation = result.eduPersonPrimaryAffiliation?.trim() || undefined;
 
 		return {
 			username,
@@ -139,6 +142,7 @@ export class BuzzApiUserDataProvider implements UserDataProvider {
 			email,
 			...(cardNumbers.length > 0 ? { cardNumbers } : {}),
 			...(department !== undefined ? { department } : {}),
+			...(affiliation !== undefined ? { affiliation } : {}),
 		};
 	}
 

--- a/packages/user-data/src/types.ts
+++ b/packages/user-data/src/types.ts
@@ -7,6 +7,8 @@ export interface UserProfile {
 	cardNumbers?: string[];
 	/** College/department/major code extracted from BuzzAPI gtCurriculum (e.g. "E/ECE/CMPE"). Only present when the data source provides it. */
 	department?: string;
+	/** Institutional affiliation from the identity provider (e.g. "student", "faculty", "staff"). Only present when the data source provides it. */
+	affiliation?: string;
 }
 
 export interface UserDataProvider {


### PR DESCRIPTION
This pull request adds support for restricting user access based on affiliation. The affiliation is pulled from `eduPersonPrimaryAffiliation`. Only affiliations of `student`, `faculty`, and `staff` are allowed access (both tapping in and web login).

I also made it so users that are no longer found in BuzzAPI (e.g. they got removed) are flagged as "lost" on our end. This makes them loose access. This should never happen, since either SSO or buzzcard resolution was successful, but we have it just incase.

This will likely need refactoring in the future - like having dynamic affiliation restrictions, or tying affiliations to roles - but for now this works to keep unauthorized access at bay. 